### PR TITLE
Include bimap

### DIFF
--- a/inst/include/boost/bimap/container_adaptor/detail/key_extractor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/detail/key_extractor.hpp
@@ -1,0 +1,45 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/detail/key_extractor.hpp
+/// \brief Key extractor for a pair<Key,Data>.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_DETAIL_KEY_EXTRACTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_DETAIL_KEY_EXTRACTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <functional>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+namespace detail {
+
+/// \brief Key Extractor
+
+template < class T >
+struct key_from_pair_extractor 
+    : std::unary_function< T, BOOST_DEDUCED_TYPENAME T::first_type >
+{
+    bool operator()( const T & p ) { return p.first; }
+};
+
+} // namespace detail
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_DETAIL_KEY_EXTRACTOR_HPP
+
+

--- a/inst/include/boost/bimap/container_adaptor/detail/non_unique_container_helper.hpp
+++ b/inst/include/boost/bimap/container_adaptor/detail/non_unique_container_helper.hpp
@@ -1,0 +1,62 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/detail/non_unique_container_helper.hpp
+/// \brief Details for non unique containers
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_DETAIL_NON_UNIQUE_CONTAINER_HELPER_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_DETAIL_NON_UNIQUE_CONTAINER_HELPER_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+/*****************************************************************************/
+#define BOOST_BIMAP_NON_UNIQUE_CONTAINER_ADAPTOR_INSERT_FUNCTIONS             \
+                                                                              \
+template <class InputIterator>                                                \
+void insert(InputIterator iterBegin, InputIterator iterEnd)                   \
+{                                                                             \
+    for( ; iterBegin != iterEnd ; ++iterBegin )                               \
+    {                                                                         \
+        this->base().insert(                                                  \
+            this->template functor<                                           \
+                BOOST_DEDUCED_TYPENAME base_::value_to_base>()(               \
+                    BOOST_DEDUCED_TYPENAME base_::value_type(*iterBegin)) );  \
+    }                                                                         \
+}                                                                             \
+                                                                              \
+BOOST_DEDUCED_TYPENAME base_::iterator insert(                                \
+    BOOST_DEDUCED_TYPENAME ::boost::call_traits<                              \
+        BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x)             \
+{                                                                             \
+    return this->base().insert( this->template functor<                       \
+                                   BOOST_DEDUCED_TYPENAME base_::             \
+                                        value_to_base>()(x) );                \
+}                                                                             \
+                                                                              \
+BOOST_DEDUCED_TYPENAME base_::iterator                                        \
+    insert(BOOST_DEDUCED_TYPENAME base_::iterator pos,                        \
+               BOOST_DEDUCED_TYPENAME ::boost::call_traits<                   \
+                    BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x) \
+{                                                                             \
+    return this->template functor<                                            \
+        BOOST_DEDUCED_TYPENAME base_::iterator_from_base>()(                  \
+            this->base().insert(this->template functor<                       \
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(pos),       \
+            this->template functor<                                           \
+                BOOST_DEDUCED_TYPENAME base_::value_to_base>()(x))            \
+    );                                                                        \
+}
+/*****************************************************************************/
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_DETAIL_NON_UNIQUE_CONTAINER_HELPER_HPP
+
+

--- a/inst/include/boost/bimap/container_adaptor/list_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/list_adaptor.hpp
@@ -1,0 +1,249 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/list_adaptor.hpp
+/// \brief Container adaptor to easily build a std::list signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_LIST_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_LIST_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/sequence_container_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/comparison_adaptor.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/call_traits.hpp>
+#include <functional>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::list signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class ReverseIterator,
+    class ConstReverseIterator,
+
+    class IteratorToBaseConverter          = ::boost::mpl::na,
+    class IteratorFromBaseConverter        = ::boost::mpl::na,
+    class ReverseIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter             = ::boost::mpl::na,
+    class ValueFromBaseConverter           = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class list_adaptor :
+
+    public ::boost::bimaps::container_adaptor::sequence_container_adaptor
+    <
+        Base, Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+    typedef ::boost::bimaps::container_adaptor::sequence_container_adaptor
+    <
+        Base, Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit list_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef list_adaptor list_adaptor_;
+
+    // Interface -------------------------------------------------------------
+
+    public:
+
+    void splice(Iterator position, list_adaptor & x)
+    {
+        this->base().splice(
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()
+                (position),
+            x.base()
+        );
+    }
+
+    void splice(Iterator position, list_adaptor & x, Iterator i)
+    {
+        this->base().splice(
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()
+                (position),
+            x.base(),
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(i)
+        );
+    }
+
+    void splice(Iterator position, list_adaptor & x, 
+                Iterator first, Iterator last)
+    {
+        this->base().splice(
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()
+                (position),
+            x.base(),
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(first),
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(last)
+        );
+    }
+
+    void remove(
+        BOOST_DEDUCED_TYPENAME ::boost::call_traits<
+            BOOST_DEDUCED_TYPENAME base_::value_type
+        >::param_type value
+    )
+    {
+        this->base().remove(
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::value_to_base>()(value)
+        );
+    }
+
+    template< class Predicate >
+    void remove_if(Predicate pred)
+    {
+        this->base().remove_if(
+            ::boost::bimaps::container_adaptor::detail::unary_check_adaptor
+            <
+                Predicate,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( pred, this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+        );
+    }
+
+    void unique()
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::equal_to<BOOST_DEDUCED_TYPENAME base_::value_type>,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >(
+                std::equal_to<BOOST_DEDUCED_TYPENAME base_::value_type>(),
+                this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+            )
+        );
+    }
+
+    template< class BinaryPredicate >
+    void unique(BinaryPredicate binary_pred)
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                BinaryPredicate,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( binary_pred,
+               this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+        );
+    }
+
+    void merge(list_adaptor & x)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >(
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>(),
+                this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+            )
+        );
+    }
+
+    template< class Compare >
+    void merge(list_adaptor & x, Compare comp)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( comp, this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+        );
+    }
+
+    void sort()
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >(
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>(),
+                this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+            )
+        );
+    }
+
+    template< class Compare >
+    void sort(Compare comp)
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( comp, this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+        );
+    }
+
+    void reverse()
+    {
+        this->base().reverse();
+    }
+
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_SET_ADAPTOR_HPP
+
+

--- a/inst/include/boost/bimap/container_adaptor/list_map_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/list_map_adaptor.hpp
@@ -1,0 +1,283 @@
+ // Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/list_map_adaptor.hpp
+/// \brief Container adaptor.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_LIST_MAP_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_LIST_MAP_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/mpl/list.hpp>
+#include <boost/mpl/push_front.hpp>
+
+#include <boost/bimap/container_adaptor/list_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/identity_converters.hpp>
+#include <boost/bimap/container_adaptor/detail/key_extractor.hpp>
+#include <boost/bimap/container_adaptor/detail/comparison_adaptor.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+template
+<
+    class Base, class Iterator, class ConstIterator,
+    class ReverseIterator, class ConstReverseIterator,
+    class IteratorToBaseConverter, class IteratorFromBaseConverter,
+    class ReverseIteratorFromBaseConverter,
+    class ValueToBaseConverter, class ValueFromBaseConverter,
+    class KeyFromBaseValueConverter,
+    class FunctorsFromDerivedClasses
+>
+struct list_map_adaptor_base
+{
+    typedef list_adaptor
+    <
+        Base,
+
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+
+        ReverseIteratorFromBaseConverter,
+
+        ValueToBaseConverter, ValueFromBaseConverter,
+
+        BOOST_DEDUCED_TYPENAME mpl::push_front<
+
+            FunctorsFromDerivedClasses,
+
+            BOOST_DEDUCED_TYPENAME mpl::if_< ::boost::mpl::is_na<KeyFromBaseValueConverter>,
+            // {
+                    detail::key_from_pair_extractor
+                    <
+                        BOOST_DEDUCED_TYPENAME Iterator::value_type 
+                    >,
+            // }
+            // else
+            // {
+                    KeyFromBaseValueConverter
+            // }
+
+            >::type
+
+        >::type
+
+    > type;
+};
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+/// \brief Container adaptor to easily build a list map container
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class ReverseIterator,
+    class ConstReverseIterator,
+
+    class IteratorToBaseConverter          = ::boost::mpl::na,
+    class IteratorFromBaseConverter        = ::boost::mpl::na,
+    class ReverseIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter             = ::boost::mpl::na,
+    class ValueFromBaseConverter           = ::boost::mpl::na,
+    class KeyFromBaseValueConverter        = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class list_map_adaptor :
+
+    public list_map_adaptor_base
+    <
+        Base, Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyFromBaseValueConverter,
+        FunctorsFromDerivedClasses
+
+    >::type
+{
+    typedef BOOST_DEDUCED_TYPENAME list_map_adaptor_base
+    <
+        Base, Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyFromBaseValueConverter,
+        FunctorsFromDerivedClasses
+
+    >::type base_;
+
+    // MetaData -------------------------------------------------------------
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type  key_type;
+    typedef BOOST_DEDUCED_TYPENAME Iterator::value_type::second_type data_type;
+    typedef data_type mapped_type;
+
+    protected:
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_< ::boost::mpl::is_na<KeyFromBaseValueConverter>,
+    // {
+            detail::key_from_pair_extractor< BOOST_DEDUCED_TYPENAME Iterator::value_type >,
+    // }
+    // else
+    // {
+            KeyFromBaseValueConverter
+    // }
+
+    >::type key_from_base_value;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit list_map_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef list_map_adaptor list_map_adaptor_;
+
+    // Functions -------------------------------------------------------------
+
+    public:
+
+    // The following functions are overwritten in order to work 
+    // with key_type instead of value_type
+
+    template< class Predicate >
+    void remove_if(Predicate pred)
+    {
+        this->base().remove_if(
+            ::boost::bimaps::container_adaptor::detail::unary_check_adaptor
+            <
+                Predicate,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                key_from_base_value
+
+            >( pred, this->template functor<key_from_base_value>() )
+        );
+    }
+
+    void unique()
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::equal_to<key_type>,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                key_from_base_value
+
+            >(
+                std::equal_to<key_type>(),
+                this->template functor<key_from_base_value>()
+            )
+        );
+    }
+
+    template< class BinaryPredicate >
+    void unique(BinaryPredicate binary_pred)
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                BinaryPredicate,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                key_from_base_value
+
+            >( binary_pred, this->template functor<key_from_base_value>() )
+        );
+    }
+
+    void merge(list_map_adaptor & x)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<key_type>,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                key_from_base_value
+
+            >(
+                std::less<key_type>(),
+                this->template functor<key_from_base_value>()
+            )
+        );
+    }
+
+    template< class Compare >
+    void merge(list_map_adaptor & x, Compare comp)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                key_from_base_value
+
+            >( comp, this->template functor<key_from_base_value>() )
+        );
+    }
+
+    void sort()
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<key_type>,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                key_from_base_value
+
+            >(
+                std::less<key_type>(),
+                this->template functor<key_from_base_value>()
+            )
+        );
+    }
+
+    template< class Compare >
+    void sort(Compare comp)
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME Base::value_type,
+                key_from_base_value
+
+            >( comp, this->template functor<key_from_base_value>() )
+        );
+    }
+
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_LIST_MAP_ADAPTOR_HPP
+

--- a/inst/include/boost/bimap/container_adaptor/multimap_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/multimap_adaptor.hpp
@@ -1,0 +1,110 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/multimap_adaptor.hpp
+/// \brief Container adaptor to easily build a std::multimap signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_MULTIMAP_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_MULTIMAP_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/ordered_associative_container_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/non_unique_container_helper.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::multimap signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class ReverseIterator,
+    class ConstReverseIterator,
+
+    class IteratorToBaseConverter          = ::boost::mpl::na,
+    class IteratorFromBaseConverter        = ::boost::mpl::na,
+    class ReverseIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter             = ::boost::mpl::na,
+    class ValueFromBaseConverter           = ::boost::mpl::na,
+    class KeyToBaseConverter               = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class multimap_adaptor :
+
+    public ::boost::bimaps::container_adaptor::
+                ordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+    typedef ::boost::bimaps::container_adaptor::
+                ordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // MetaData -------------------------------------------------------------
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME Iterator::value_type::second_type data_type;
+    typedef data_type mapped_type;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit multimap_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef multimap_adaptor multimap_adaptor_;
+
+    public:
+
+    BOOST_BIMAP_NON_UNIQUE_CONTAINER_ADAPTOR_INSERT_FUNCTIONS
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_MULTIMAP_ADAPTOR_HPP
+
+

--- a/inst/include/boost/bimap/container_adaptor/multiset_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/multiset_adaptor.hpp
@@ -1,0 +1,103 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/multiset_adaptor.hpp
+/// \brief Container adaptor to easily build a std::multiset signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_MULTISET_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_MULTISET_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/ordered_associative_container_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/non_unique_container_helper.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::multiset signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class ReverseIterator,
+    class ConstReverseIterator,
+
+    class IteratorToBaseConverter          = ::boost::mpl::na,
+    class IteratorFromBaseConverter        = ::boost::mpl::na,
+    class ReverseIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter             = ::boost::mpl::na,
+    class ValueFromBaseConverter           = ::boost::mpl::na,
+    class KeyToBaseConverter               = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class multiset_adaptor :
+
+    public ::boost::bimaps::container_adaptor::
+                ordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+
+    typedef ::boost::bimaps::container_adaptor::
+                ordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit multiset_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef multiset_adaptor multiset_adaptor_;
+
+    public:
+
+    BOOST_BIMAP_NON_UNIQUE_CONTAINER_ADAPTOR_INSERT_FUNCTIONS
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_MULTISET_ADAPTOR_HPP
+

--- a/inst/include/boost/bimap/container_adaptor/sequence_container_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/sequence_container_adaptor.hpp
@@ -1,0 +1,356 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/sequence_container_adaptor.hpp
+/// \brief Container adaptor to build a type that is compliant to the concept of a weak associative container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_SEQUENCE_CONTAINER_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_SEQUENCE_CONTAINER_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <utility>
+
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/bimap/container_adaptor/detail/identity_converters.hpp>
+#include <boost/bimap/container_adaptor/container_adaptor.hpp>
+#include <boost/call_traits.hpp>
+#include <boost/operators.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+template
+<
+    class Base, class Iterator, class ConstIterator,
+    class ReverseIterator, class ConstReverseIterator,
+    class IteratorToBaseConverter, class IteratorFromBaseConverter,
+    class ReverseIteratorFromBaseConverter,
+    class ValueToBaseConverter, class ValueFromBaseConverter,
+    class FunctorsFromDerivedClasses
+>
+struct sequence_container_adaptor_base
+{
+    typedef container_adaptor
+    <
+        Base, Iterator, ConstIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+
+        BOOST_DEDUCED_TYPENAME mpl::push_front<
+
+            FunctorsFromDerivedClasses,
+
+            BOOST_DEDUCED_TYPENAME mpl::if_<
+                ::boost::mpl::is_na<ReverseIteratorFromBaseConverter>,
+            // {
+                    detail::iterator_from_base_identity
+                    <
+                        BOOST_DEDUCED_TYPENAME Base::reverse_iterator, 
+                        ReverseIterator,
+                        BOOST_DEDUCED_TYPENAME Base::const_reverse_iterator,
+                        ConstReverseIterator
+                    >,
+            // }
+            // else
+            // {
+                    ReverseIteratorFromBaseConverter
+            // }
+
+            >::type
+
+        >::type
+
+    > type;
+};
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+/// \brief Container adaptor to build a type that is compliant to the concept of a sequence container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+
+    class ReverseIterator,
+    class ConstReverseIterator,
+
+    class IteratorToBaseConverter           = ::boost::mpl::na,
+    class IteratorFromBaseConverter         = ::boost::mpl::na,
+    class ReverseIteratorFromBaseConverter  = ::boost::mpl::na,
+    class ValueToBaseConverter              = ::boost::mpl::na,
+    class ValueFromBaseConverter            = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class sequence_container_adaptor :
+
+    public sequence_container_adaptor_base
+    <
+        Base, Iterator, ConstIterator,
+        ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+
+    >::type,
+
+    ::boost::totally_ordered
+    <
+        sequence_container_adaptor
+        <
+            Base, Iterator, ConstIterator,
+            ReverseIterator, ConstReverseIterator,
+            IteratorToBaseConverter, IteratorFromBaseConverter,
+            ReverseIteratorFromBaseConverter,
+            ValueToBaseConverter, ValueFromBaseConverter,
+            FunctorsFromDerivedClasses
+        >
+    >
+{
+    typedef BOOST_DEDUCED_TYPENAME sequence_container_adaptor_base
+    <
+        Base, Iterator, ConstIterator,
+        ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+
+    >::type base_;
+
+    // MetaData -------------------------------------------------------------
+
+    public:
+
+    typedef ReverseIterator      reverse_iterator;
+    typedef ConstReverseIterator const_reverse_iterator;
+
+    protected:
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+        ::boost::mpl::is_na<ReverseIteratorFromBaseConverter>,
+        // {
+                detail::iterator_from_base_identity
+                <
+                    BOOST_DEDUCED_TYPENAME Base::reverse_iterator,
+                    reverse_iterator,
+                    BOOST_DEDUCED_TYPENAME Base::const_reverse_iterator,
+                    const_reverse_iterator
+                >,
+        // }
+        // else
+        // {
+                ReverseIteratorFromBaseConverter
+        // }
+
+        >::type reverse_iterator_from_base;
+
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit sequence_container_adaptor(Base & c)
+        : base_(c) {}
+
+    protected:
+
+
+    typedef sequence_container_adaptor sequence_container_adaptor_;
+
+    // Interface --------------------------------------------------------------
+
+    public:
+
+    reverse_iterator rbegin()
+    {
+        return this->template functor<
+            reverse_iterator_from_base
+        >()                            ( this->base().rbegin() );
+
+    }
+
+    reverse_iterator rend()
+    {
+        return this->template functor<
+            reverse_iterator_from_base
+        >()                            ( this->base().rend() );
+    }
+
+    const_reverse_iterator rbegin() const
+    {
+        return this->template functor<
+            reverse_iterator_from_base
+        >()                            ( this->base().rbegin() );
+    }
+
+    const_reverse_iterator rend() const
+    {
+        return this->template functor<
+            reverse_iterator_from_base
+        >()                            ( this->base().rend() );
+    }
+
+    void resize(BOOST_DEDUCED_TYPENAME base_::size_type n,
+                BOOST_DEDUCED_TYPENAME ::boost::call_traits<
+                    BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x =
+                        BOOST_DEDUCED_TYPENAME base_::value_type())
+    {
+        this->base().resize(n,
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::value_to_base>()(x)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference front()
+    {
+        return this->template functor<
+            BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+        (
+            this->base().front()
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference back()
+    {
+        return this->template functor<
+            BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+        (
+            this->base().back()
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_reference front() const
+    {
+        return this->template functor<
+            BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+        (
+            this->base().front()
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_reference back() const
+    {
+        return this->template functor<
+            BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+        (
+            this->base().back()
+        );
+    }
+
+    void push_front(
+        BOOST_DEDUCED_TYPENAME ::boost::call_traits<
+            BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x)
+    {
+        this->base().push_front(
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::value_to_base>()(x));
+    }
+
+    void pop_front()
+    {
+        this->base().pop_front();
+    }
+
+    void push_back(
+        BOOST_DEDUCED_TYPENAME ::boost::call_traits< 
+            BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x)
+    {
+        this->base().push_back(
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::value_to_base>()(x));
+    }
+
+    void pop_back()
+    {
+        this->base().pop_back();
+    }
+
+    std::pair<BOOST_DEDUCED_TYPENAME base_::iterator,bool>
+    insert(BOOST_DEDUCED_TYPENAME base_::iterator position,
+           BOOST_DEDUCED_TYPENAME ::boost::call_traits< 
+                BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x)
+    {
+        std::pair< BOOST_DEDUCED_TYPENAME Base::iterator, bool > r(
+            this->base().insert(
+                this->template functor<
+                    BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+                this->template functor<
+                    BOOST_DEDUCED_TYPENAME base_::value_to_base   >()(x)
+            )
+        );
+
+        return std::pair<BOOST_DEDUCED_TYPENAME base_::iterator, bool>(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_from_base>()(r.first),
+            r.second
+        );
+    }
+
+    void insert(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                BOOST_DEDUCED_TYPENAME base_::size_type m,
+                BOOST_DEDUCED_TYPENAME ::boost::call_traits<
+                    BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x)
+    {
+        this->base().insert(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            m,
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::value_to_base   >()(x)
+        );
+    }
+
+    template< class InputIterator >
+    void insert(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                InputIterator first, InputIterator last)
+    {
+        // This is the same problem found in the insert function 
+        // of container_adaptor
+        // For now, do the simple thing. This can be optimized
+
+        for( ; first != last ; ++first )
+        {
+            this->base().insert(
+                this->template functor<
+                    BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()( position ),
+                this->template functor<
+                    BOOST_DEDUCED_TYPENAME base_::value_to_base   >()( *first )
+            );
+        }
+    }
+
+    // Totally ordered implementation
+
+    bool operator==(const sequence_container_adaptor & c) const
+    {
+        return ( this->base() == c.base() );
+    }
+
+    bool operator<(const sequence_container_adaptor & c) const
+    {
+        return ( this->base() < c.base() );
+    }
+};
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_SEQUENCE_CONTAINER_ADAPTOR_HPP

--- a/inst/include/boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp
@@ -1,0 +1,293 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/unordered_associative_container_adaptor.hpp
+/// \brief Container adaptor to build a type that is compliant to the concept of an unordered associative container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_ASSOCIATIVE_CONTAINER_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_ASSOCIATIVE_CONTAINER_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/associative_container_adaptor.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/mpl/push_front.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/call_traits.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+template
+<
+    class Base, class Iterator, class ConstIterator,
+    class LocalIterator, class ConstLocalIterator,
+    class KeyType,
+    class IteratorToBaseConverter, class IteratorFromBaseConverter,
+    class LocalIteratorFromBaseConverter,
+    class ValueToBaseConverter, class ValueFromBaseConverter,
+    class KeyToBaseConverter,
+    class FunctorsFromDerivedClasses
+>
+struct unordered_associative_container_adaptor_base
+{
+
+    typedef associative_container_adaptor
+    <
+        Base, Iterator, ConstIterator, KeyType,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ValueToBaseConverter   , ValueFromBaseConverter,
+        KeyToBaseConverter,
+
+        BOOST_DEDUCED_TYPENAME mpl::push_front<
+
+            FunctorsFromDerivedClasses,
+
+            BOOST_DEDUCED_TYPENAME mpl::if_<
+                ::boost::mpl::is_na<LocalIteratorFromBaseConverter>,
+            // {
+                    detail::iterator_from_base_identity
+                    <
+                        BOOST_DEDUCED_TYPENAME Base::local_iterator,
+                        LocalIterator,
+                        BOOST_DEDUCED_TYPENAME Base::const_local_iterator,
+                        ConstLocalIterator
+                    >,
+            // }
+            // else
+            // {
+                    LocalIteratorFromBaseConverter
+            // }
+
+            >::type
+
+        >::type
+
+    > type;
+};
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+
+/// \brief Container adaptor to build a type that is compliant to the concept of an unordered associative container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+
+    class LocalIterator,
+    class ConstLocalIterator,
+
+    class KeyType,
+
+    class IteratorToBaseConverter        = ::boost::mpl::na,
+    class IteratorFromBaseConverter      = ::boost::mpl::na,
+    class LocalIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter           = ::boost::mpl::na,
+    class ValueFromBaseConverter         = ::boost::mpl::na,
+    class KeyToBaseConverter             = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses     = mpl::vector<>
+
+>
+class unordered_associative_container_adaptor :
+
+    public unordered_associative_container_adaptor_base
+    <
+        Base, Iterator, ConstIterator,
+        LocalIterator, ConstLocalIterator,
+        KeyType,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    >::type
+{
+    typedef BOOST_DEDUCED_TYPENAME unordered_associative_container_adaptor_base
+    <
+        Base, Iterator, ConstIterator,
+        LocalIterator, ConstLocalIterator,
+        KeyType,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    >::type base_;
+
+    // Metadata ---------------------------------------------------------------
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME Base::key_equal key_equal;
+    typedef BOOST_DEDUCED_TYPENAME Base::hasher hasher;
+
+    typedef LocalIterator      local_iterator;
+    typedef ConstLocalIterator const_local_iterator;
+
+    protected:
+
+    typedef BOOST_DEDUCED_TYPENAME mpl::if_<
+        ::boost::mpl::is_na<LocalIteratorFromBaseConverter>,
+        // {
+                detail::iterator_from_base_identity
+                <
+                    BOOST_DEDUCED_TYPENAME Base::local_iterator,
+                    local_iterator,
+                    BOOST_DEDUCED_TYPENAME Base::const_local_iterator,
+                    const_local_iterator
+                >,
+        // }
+        // else
+        // {
+                LocalIteratorFromBaseConverter
+        // }
+
+        >::type local_iterator_from_base;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit unordered_associative_container_adaptor(Base & c)
+        : base_(c) {}
+
+    protected:
+
+
+    typedef unordered_associative_container_adaptor
+                unordered_associative_container_adaptor_;
+
+    // Interface --------------------------------------------------------------
+
+    public:
+
+    // bucket interface:
+
+    BOOST_DEDUCED_TYPENAME base_::size_type bucket_count() const
+    {
+        return this->base().bucket_count();
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::size_type max_bucket_count() const
+    {
+        return this->base().max_bucket_count();
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::size_type bucket_size(
+        BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->base().bucket_size(n);
+    }
+
+    template< class CompatibleKey >
+    BOOST_DEDUCED_TYPENAME base_::size_type bucket(
+        const CompatibleKey & k) const
+    {
+        typedef BOOST_DEDUCED_TYPENAME base_::key_to_base key_to_base;
+        return this->base().bucket(
+            this->template functor<key_to_base>()(k)
+        );
+    }
+
+    local_iterator       begin(BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<
+            local_iterator_from_base
+        >()                          ( this->base().begin(n) );
+    }
+
+    const_local_iterator begin(BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<
+            local_iterator_from_base
+        >()                          ( this->base().begin(n) );
+    }
+
+    local_iterator       end(BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<
+            local_iterator_from_base
+        >()                          ( this->base().end(n) );
+    }
+
+    const_local_iterator end(BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<
+            local_iterator_from_base
+        >()                          ( this->base().end(n) );
+    }
+
+    // hash policy
+
+    float load_factor() const
+    {
+        return this->base().load_factor();
+    }
+
+    float max_load_factor() const
+    {
+        return this->base().max_load_factor();
+    }
+
+    void max_load_factor(float z)
+    {
+        return this->base().max_load_factor(z);
+    }
+
+    void rehash(BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->base().rehash(n);
+    }
+
+    // We have redefined end and begin so we have to manually route the old ones
+
+    BOOST_DEDUCED_TYPENAME base_::iterator begin()
+    {
+        return base_::container_adaptor_::begin();
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::iterator end()
+    {
+        return base_::container_adaptor_::end();
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_iterator begin() const
+    {
+        return base_::container_adaptor_::begin();
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_iterator end() const
+    {
+        return base_::container_adaptor_::end();
+    }
+
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_ASSOCIATIVE_CONTAINER_ADAPTOR_HPP

--- a/inst/include/boost/bimap/container_adaptor/unordered_map_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/unordered_map_adaptor.hpp
@@ -1,0 +1,133 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/unordered_map_adaptor.hpp
+/// \brief Container adaptor to easily build a std::unordered_map signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MAP_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MAP_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+#include <boost/call_traits.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::unordered_map signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class LocalIterator,
+    class ConstLocalIterator,
+
+    class IteratorToBaseConverter        = ::boost::mpl::na,
+    class IteratorFromBaseConverter      = ::boost::mpl::na,
+    class LocalIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter           = ::boost::mpl::na,
+    class ValueFromBaseConverter         = ::boost::mpl::na,
+    class KeyToBaseConverter             = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class unordered_map_adaptor :
+
+    public ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+
+    typedef ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // MetaData -------------------------------------------------------------
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME Iterator::value_type::second_type data_type;
+    typedef data_type mapped_type;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit unordered_map_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef unordered_map_adaptor unordered_map_adaptor_;
+
+    // Interface --------------------------------------------------------------
+
+    public:
+
+    template< class CompatibleKey >
+    data_type& operator[](const CompatibleKey & k)
+    {
+        return this->base()
+            [this->template functor<BOOST_DEDUCED_TYPENAME base_::key_to_base>()(k)];
+    }
+
+    template< class CompatibleKey >
+    data_type& at(const CompatibleKey & k)
+    {
+        return this->base().
+            at(this->template functor<BOOST_DEDUCED_TYPENAME base_::key_to_base>()(k));
+    }
+
+    template< class CompatibleKey >
+    const data_type& at(const CompatibleKey & k) const
+    {
+        return this->base().
+            at(this->template functor<BOOST_DEDUCED_TYPENAME base_::key_to_base>()(k));
+    }
+
+};
+
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MAP_ADAPTOR_HPP
+

--- a/inst/include/boost/bimap/container_adaptor/unordered_multimap_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/unordered_multimap_adaptor.hpp
@@ -1,0 +1,111 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/unordered_multimap_adaptor.hpp
+/// \brief Container adaptor to easily build a std::unordered_multimap signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MULTIMAP_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MULTIMAP_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/non_unique_container_helper.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::unordered_multimap signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class LocalIterator,
+    class ConstLocalIterator,
+
+    class IteratorToBaseConverter        = ::boost::mpl::na,
+    class IteratorFromBaseConverter      = ::boost::mpl::na,
+    class LocalIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter           = ::boost::mpl::na,
+    class ValueFromBaseConverter         = ::boost::mpl::na,
+    class KeyToBaseConverter             = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class unordered_multimap_adaptor :
+
+    public ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+    typedef ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // MetaData -------------------------------------------------------------
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME Iterator::value_type::second_type data_type;
+    typedef data_type mapped_type;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit unordered_multimap_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef unordered_multimap_adaptor unordered_multimap_adaptor_;
+
+    public:
+
+    BOOST_BIMAP_NON_UNIQUE_CONTAINER_ADAPTOR_INSERT_FUNCTIONS
+};
+
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MULTIMAP_ADAPTOR_HPP
+
+

--- a/inst/include/boost/bimap/container_adaptor/unordered_multiset_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/unordered_multiset_adaptor.hpp
@@ -1,0 +1,102 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/unordered_multiset_adaptor.hpp
+/// \brief Container adaptor to easily build a std::unordered_multiset signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MULTISET_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MULTISET_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/non_unique_container_helper.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::unordered_multiset signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class LocalIterator,
+    class ConstLocalIterator,
+
+    class IteratorToBaseConverter        = ::boost::mpl::na,
+    class IteratorFromBaseConverter      = ::boost::mpl::na,
+    class LocalIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter           = ::boost::mpl::na,
+    class ValueFromBaseConverter         = ::boost::mpl::na,
+    class KeyToBaseConverter             = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class unordered_multiset_adaptor :
+
+    public ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+    typedef ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit unordered_multiset_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef unordered_multiset_adaptor unordered_multiset_adaptor_;
+
+    public:
+
+    BOOST_BIMAP_NON_UNIQUE_CONTAINER_ADAPTOR_INSERT_FUNCTIONS
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_MULTISET_ADAPTOR_HPP
+

--- a/inst/include/boost/bimap/container_adaptor/unordered_set_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/unordered_set_adaptor.hpp
@@ -1,0 +1,98 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/unordered_set_adaptor.hpp
+/// \brief Container adaptor to easily build a std::unordered_set signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_SET_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_SET_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/unordered_associative_container_adaptor.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::unordered_set signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class LocalIterator,
+    class ConstLocalIterator,
+
+    class IteratorToBaseConverter        = ::boost::mpl::na,
+    class IteratorFromBaseConverter      = ::boost::mpl::na,
+    class LocalIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter           = ::boost::mpl::na,
+    class ValueFromBaseConverter         = ::boost::mpl::na,
+    class KeyToBaseConverter             = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class unordered_set_adaptor :
+
+    public ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+    typedef ::boost::bimaps::container_adaptor::
+                unordered_associative_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, LocalIterator, ConstLocalIterator,
+        BOOST_DEDUCED_TYPENAME Iterator::value_type,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        LocalIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        KeyToBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    explicit unordered_set_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef unordered_set_adaptor unordered_set_adaptor_;
+
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_UNORDERED_SET_ADAPTOR_HPP
+

--- a/inst/include/boost/bimap/container_adaptor/vector_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/vector_adaptor.hpp
@@ -1,0 +1,150 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/vector_adaptor.hpp
+/// \brief Container adaptor to easily build a std::vector signature compatible container.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_VECTOR_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_VECTOR_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/sequence_container_adaptor.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/mpl/vector.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor to easily build a std::vector signature compatible container.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class ReverseIterator,
+    class ConstReverseIterator,
+
+    class IteratorToBaseConverter          = ::boost::mpl::na,
+    class IteratorFromBaseConverter        = ::boost::mpl::na,
+    class ReverseIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter             = ::boost::mpl::na,
+    class ValueFromBaseConverter           = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class vector_adaptor :
+
+    public ::boost::bimaps::container_adaptor::sequence_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+
+    typedef ::boost::bimaps::container_adaptor::sequence_container_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    vector_adaptor() {}
+
+    explicit vector_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef vector_adaptor vector_adaptor_;
+
+    // Interface --------------------------------------------------------------
+
+    public:
+
+    BOOST_DEDUCED_TYPENAME base_::size_type capacity() const
+    {
+        return this->base().capacity();
+    }
+
+    void reserve(BOOST_DEDUCED_TYPENAME base_::size_type m)
+    {
+        this->base().resize(m);
+    }
+
+    void resize(BOOST_DEDUCED_TYPENAME base_::size_type n,
+                BOOST_DEDUCED_TYPENAME ::boost::call_traits<
+                    BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x =
+                        BOOST_DEDUCED_TYPENAME base_::value_type())
+    {
+        this->base().resize(n,
+            this->template functor<BOOST_DEDUCED_TYPENAME base_::value_to_base>()(x)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_reference
+        operator[](BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().operator[](n)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_reference
+        at(BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().at(n)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference
+        operator[](BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().operator[](n)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference
+        at(BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().at(n)
+        );
+    }
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_VECTOR_ADAPTOR_HPP
+
+

--- a/inst/include/boost/bimap/container_adaptor/vector_map_adaptor.hpp
+++ b/inst/include/boost/bimap/container_adaptor/vector_map_adaptor.hpp
@@ -1,0 +1,104 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file container_adaptor/vector_map_adaptor.hpp
+/// \brief Container adaptor.
+
+#ifndef BOOST_BIMAP_CONTAINER_ADAPTOR_VECTOR_MAP_ADAPTOR_HPP
+#define BOOST_BIMAP_CONTAINER_ADAPTOR_VECTOR_MAP_ADAPTOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/mpl/list.hpp>
+#include <boost/mpl/push_front.hpp>
+#include <boost/mpl/aux_/na.hpp>
+#include <boost/bimap/container_adaptor/vector_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/identity_converters.hpp>
+#include <boost/mpl/vector.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace container_adaptor {
+
+/// \brief Container adaptor.
+
+template
+<
+    class Base,
+
+    class Iterator,
+    class ConstIterator,
+    class ReverseIterator,
+    class ConstReverseIterator,
+
+    class IteratorToBaseConverter          = ::boost::mpl::na,
+    class IteratorFromBaseConverter        = ::boost::mpl::na,
+    class ReverseIteratorFromBaseConverter = ::boost::mpl::na,
+    class ValueToBaseConverter             = ::boost::mpl::na,
+    class ValueFromBaseConverter           = ::boost::mpl::na,
+
+    class FunctorsFromDerivedClasses = mpl::vector<>
+>
+class vector_map_adaptor :
+
+    public vector_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+    >
+{
+    typedef vector_adaptor
+    <
+        Base,
+        Iterator, ConstIterator, ReverseIterator, ConstReverseIterator,
+        IteratorToBaseConverter, IteratorFromBaseConverter,
+        ReverseIteratorFromBaseConverter,
+        ValueToBaseConverter, ValueFromBaseConverter,
+        FunctorsFromDerivedClasses
+
+    > base_;
+
+    // MetaData -------------------------------------------------------------
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME Iterator::value_type::first_type  key_type;
+    typedef BOOST_DEDUCED_TYPENAME Iterator::value_type::second_type data_type;
+    typedef data_type mapped_type;
+
+    // Access -----------------------------------------------------------------
+
+    public:
+
+    vector_map_adaptor() {}
+
+    explicit vector_map_adaptor(Base & c) :
+        base_(c) {}
+
+    protected:
+
+    typedef vector_map_adaptor vector_map_adaptor_;
+
+};
+
+
+} // namespace container_adaptor
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_CONTAINER_ADAPTOR_VECTOR_MAP_ADAPTOR_HPP
+

--- a/inst/include/boost/bimap/detail/non_unique_views_helper.hpp
+++ b/inst/include/boost/bimap/detail/non_unique_views_helper.hpp
@@ -1,0 +1,71 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file detail/non_unique_views_helper.hpp
+/// \brief Details for non unique views
+
+#ifndef BOOST_BIMAP_DETAIL_NON_UNIQUE_VIEWS_HELPER_HPP
+#define BOOST_BIMAP_DETAIL_NON_UNIQUE_VIEWS_HELPER_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+/*===========================================================================*/
+#define BOOST_BIMAP_NON_UNIQUE_VIEW_INSERT_FUNCTIONS                         \
+                                                                             \
+template <class InputIterator>                                               \
+void insert(InputIterator iterBegin, InputIterator iterEnd)                  \
+{                                                                            \
+    for( ; iterBegin != iterEnd ; ++iterBegin )                              \
+    {                                                                        \
+        this->base().insert(                                                 \
+            this->template functor<                                          \
+                BOOST_DEDUCED_TYPENAME base_::value_to_base>()(              \
+                    BOOST_DEDUCED_TYPENAME base_::value_type(*iterBegin)) ); \
+    }                                                                        \
+}                                                                            \
+                                                                             \
+std::pair<BOOST_DEDUCED_TYPENAME base_::iterator, bool> insert(              \
+    BOOST_DEDUCED_TYPENAME ::boost::call_traits<                             \
+        BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x)            \
+{                                                                            \
+    typedef BOOST_DEDUCED_TYPENAME base_::base_type::iterator base_iterator; \
+                                                                             \
+    std::pair< base_iterator, bool > r(                                      \
+        this->base().insert(                                                 \
+            this->template functor<                                          \
+                BOOST_DEDUCED_TYPENAME base_::value_to_base>()(x) )          \
+    );                                                                       \
+                                                                             \
+    return std::pair<typename base_::iterator, bool>(                        \
+        this->template functor<                                              \
+            BOOST_DEDUCED_TYPENAME base_::iterator_from_base>()(r.first),    \
+            r.second                                                         \
+    );                                                                       \
+}                                                                            \
+                                                                             \
+BOOST_DEDUCED_TYPENAME base_::iterator insert(                               \
+    BOOST_DEDUCED_TYPENAME base_::iterator pos,                              \
+        BOOST_DEDUCED_TYPENAME ::boost::call_traits<                         \
+            BOOST_DEDUCED_TYPENAME base_::value_type >::param_type x)        \
+{                                                                            \
+    return this->template functor<                                           \
+        BOOST_DEDUCED_TYPENAME base_::iterator_from_base>()(                 \
+            this->base().insert(                                             \
+                this->template functor<                                      \
+                    BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(pos),  \
+            this->template functor<                                          \
+                BOOST_DEDUCED_TYPENAME base_::value_to_base>()(x))           \
+    );                                                                       \
+}
+/*===========================================================================*/
+
+#endif // BOOST_BIMAP_DETAIL_NON_UNIQUE_VIEWS_HELPER_HPP

--- a/inst/include/boost/bimap/detail/test/check_metadata.hpp
+++ b/inst/include/boost/bimap/detail/test/check_metadata.hpp
@@ -1,0 +1,113 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_BIMAP_DETAIL_CHECK_METADATA_HPP
+#define BOOST_BIMAP_DETAIL_CHECK_METADATA_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/mpl/assert.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/preprocessor/cat.hpp>
+
+
+// Easier way to call BOOST_MPL_ASSERT_MSG in class scope
+/*===========================================================================*/
+#define BOOST_BIMAP_MPL_ASSERT_MSG_ACS(p1,p2,p3)                              \
+                                                                              \
+    struct p2 {};                                                             \
+    BOOST_MPL_ASSERT_MSG(p1,p2,p3);                                           \
+/*===========================================================================*/
+
+
+// Build a descriptive name.
+/*===========================================================================*/
+#define BOOST_BIMAP_WRONG_METADATA_MESSAGE(                                   \
+                                                                              \
+        P_CLASS,                                                              \
+        P_NAME,                                                               \
+        P_CORRECT_TYPE                                                        \
+                                                                              \
+    )                                                                         \
+                                                                              \
+    BOOST_PP_CAT                                                              \
+    (                                                                         \
+        WRONG_METADATA__,                                                     \
+        BOOST_PP_CAT                                                          \
+        (                                                                     \
+            P_CLASS,                                                          \
+            BOOST_PP_CAT                                                      \
+            (                                                                 \
+                __AT__,                                                       \
+                BOOST_PP_CAT                                                  \
+                (                                                             \
+                    P_NAME,                                                   \
+                    BOOST_PP_CAT                                              \
+                    (                                                         \
+                        __IS_DIFERENT_TO__,                                   \
+                        P_CORRECT_TYPE                                        \
+                    )                                                         \
+                )                                                             \
+            )                                                                 \
+        )                                                                     \
+    )
+/*===========================================================================*/
+
+
+// Check if the metadata have the correct type, and if not inform
+// it with a useful compile time message.
+/*===========================================================================*/
+#define BOOST_BIMAP_CHECK_METADATA(                                           \
+                                                                              \
+        P_CLASS,                                                              \
+        P_NAME,                                                               \
+        P_CORRECT_TYPE                                                        \
+                                                                              \
+    )                                                                         \
+                                                                              \
+    BOOST_BIMAP_MPL_ASSERT_MSG_ACS                                            \
+    (                                                                         \
+        (                                                                     \
+            ::boost::is_same                                                  \
+            <                                                                 \
+                P_CLASS::P_NAME,                                              \
+                P_CORRECT_TYPE                                                \
+                                                                              \
+            >::value                                                          \
+        ),                                                                    \
+        BOOST_BIMAP_WRONG_METADATA_MESSAGE                                    \
+        (                                                                     \
+            P_CLASS,                                                          \
+            P_NAME,                                                           \
+            P_CORRECT_TYPE                                                    \
+        ),                                                                    \
+        (P_CLASS::P_NAME,P_CORRECT_TYPE)                                      \
+    )
+/*===========================================================================*/
+
+
+// Just for autodocumment the test code
+/*===========================================================================*/
+#define BOOST_BIMAP_TEST_STATIC_FUNCTION(NAME)                                \
+    namespace NAME
+/*===========================================================================*/
+
+
+// Just for autodocument the test code
+/*===========================================================================*/
+#define BOOST_BIMAP_CALL_TEST_STATIC_FUNCTION(NAME)
+/*===========================================================================*/
+
+
+
+#endif // BOOST_BIMAP_DETAIL_CHECK_METADATA_HPP
+

--- a/inst/include/boost/bimap/list_of.hpp
+++ b/inst/include/boost/bimap/list_of.hpp
@@ -1,0 +1,181 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file list_of.hpp
+/// \brief Include support for list constrains for the bimap container
+
+#ifndef BOOST_BIMAP_LIST_OF_HPP
+#define BOOST_BIMAP_LIST_OF_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/detail/user_interface_config.hpp>
+
+#include <boost/mpl/bool.hpp>
+
+#include <boost/concept_check.hpp>
+
+#include <boost/bimap/detail/concept_tags.hpp>
+
+#include <boost/bimap/tags/support/value_type_of.hpp>
+
+#include <boost/bimap/detail/generate_index_binder.hpp>
+#include <boost/bimap/detail/generate_view_binder.hpp>
+#include <boost/bimap/detail/generate_relation_binder.hpp>
+
+#include <boost/multi_index/sequenced_index.hpp>
+
+#include <boost/bimap/views/list_map_view.hpp>
+#include <boost/bimap/views/list_set_view.hpp>
+
+namespace boost {
+namespace bimaps {
+
+
+/// \brief Set Type Specification
+/**
+This struct is used to specify a set specification.
+It is not a container, it is just a metaprogramming facility to
+express the type of a set. Generally, this specification will
+be used in other place to create a container.
+It has the same syntax that an std::list instantiation, except
+that the allocator cannot be specified. The rationale behind
+this difference is that the allocator is not part of the set
+type specification, rather it is a container configuration
+parameter.
+
+\code
+using namespace support;
+
+BOOST_STATIC_ASSERT( is_set_type_of< list_of<Type> >::value )
+
+BOOST_STATIC_ASSERT
+(
+     is_same
+     <
+        list_of<Type>::index_bind
+        <
+            KeyExtractor,
+            Tag
+
+        >::type,
+
+        sequenced< tag<Tag>, KeyExtractor >
+
+    >::value
+)
+
+typedef bimap
+<
+    list_of<Type>, RightKeyType
+
+> bimap_with_left_type_as_list;
+
+BOOST_STATIC_ASSERT
+(
+    is_same
+    <
+        list_of<Type>::map_view_bind
+        <
+            member_at::left,
+            bimap_with_left_type_as_list
+
+        >::type,
+        list_map_view< member_at::left, bimap_with_left_type_as_list >
+
+    >::value
+)
+
+\endcode
+
+See also list_of_relation.
+                                                                        **/
+
+template< class Type >
+struct list_of : public ::boost::bimaps::detail::set_type_of_tag
+{
+    /// User type, can be tagged
+    typedef Type user_type;
+
+    /// Type of the object that will be stored in the list
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::
+        value_type_of<user_type>::type value_type;
+
+
+    struct lazy_concept_checked
+    {
+        BOOST_CLASS_REQUIRE ( value_type,
+                              boost, AssignableConcept );
+
+        typedef list_of type;
+    };
+
+    BOOST_BIMAP_GENERATE_INDEX_BINDER_0CP_NO_EXTRACTOR(
+
+        // binds to
+        multi_index::sequenced
+    )
+
+    BOOST_BIMAP_GENERATE_MAP_VIEW_BINDER(
+
+        // binds to
+        views::list_map_view
+    )
+
+    BOOST_BIMAP_GENERATE_SET_VIEW_BINDER(
+
+        // binds to
+        views::list_set_view
+    )
+
+    typedef mpl::bool_<true> mutable_key;
+};
+
+
+/// \brief List Of Relation Specification
+/**
+This struct is similar to list_of but it is bind logically to a
+relation. It is used in the bimap instantiation to specify the
+desired type of the main view. This struct implements internally
+a metafunction named bind_to that manages the quite complicated
+task of finding the right type of the set for the relation.
+
+\code
+template<class Relation>
+struct bind_to
+{
+    typedef -unspecified- type;
+};
+\endcode
+
+See also list_of, is_set_type_of_relation.
+                                                                **/
+
+struct list_of_relation : public ::boost::bimaps::detail::set_type_of_relation_tag
+{
+    BOOST_BIMAP_GENERATE_RELATION_BINDER_0CP(
+
+        // binds to
+        list_of
+    )
+
+    typedef mpl::bool_<true>  left_mutable_key;
+    typedef mpl::bool_<true> right_mutable_key;
+};
+
+
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_LIST_OF_HPP
+

--- a/inst/include/boost/bimap/multiset_of.hpp
+++ b/inst/include/boost/bimap/multiset_of.hpp
@@ -1,0 +1,205 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file multiset_of.hpp
+/// \brief Include support for multiset constrains for the bimap container
+
+#ifndef BOOST_BIMAP_MULTISET_OF_HPP
+#define BOOST_BIMAP_MULTISET_OF_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/detail/user_interface_config.hpp>
+
+#include <functional>
+#include <boost/mpl/bool.hpp>
+
+#include <boost/concept_check.hpp>
+
+#include <boost/bimap/detail/concept_tags.hpp>
+
+#include <boost/bimap/tags/support/value_type_of.hpp>
+
+#include <boost/bimap/detail/generate_index_binder.hpp>
+#include <boost/bimap/detail/generate_view_binder.hpp>
+#include <boost/bimap/detail/generate_relation_binder.hpp>
+
+#include <boost/multi_index/ordered_index.hpp>
+
+#include <boost/bimap/views/multimap_view.hpp>
+#include <boost/bimap/views/multiset_view.hpp>
+
+namespace boost {
+namespace bimaps {
+
+/// \brief Set Type Specification
+/**
+This struct is used to specify a multiset specification.
+It is not a container, it is just a metaprogramming facility to
+express the type of a set. Generally, this specification will
+be used in other place to create a container.
+It has the same syntax that an std::set instantiation, except
+that the allocator cannot be specified. The rationale behind
+this difference is that the allocator is not part of the set
+type specification, rather it is a container configuration
+parameter.
+The first parameter is the type of the objects in the multiset,
+and the second one is a Functor that compares them.
+Bimap binding metafunctions can be used with this class in
+the following way:
+
+\code
+using namespace support;
+
+BOOST_STATIC_ASSERT( is_set_type_of< multiset_of<Type> >::value )
+
+BOOST_STATIC_ASSERT
+(
+     is_same
+     <
+        compute_index_type
+        <
+            multiset_of<Type,KeyCompare>,
+            KeyExtractor,
+            Tag
+
+        >::type
+        ,
+        ordered_nonunique< tag<Tag>, KeyExtractor, KeyCompare >
+
+    >::value
+)
+
+typedef bimap
+<
+    multiset_of<Type>, RightKeyType
+
+> bimap_with_left_type_as_multiset;
+
+BOOST_STATIC_ASSERT
+(
+    is_same
+    <
+        compute_map_view_type
+        <
+            member_at::left,
+            bimap_with_left_type_as_multiset
+
+        >::type,
+        multimap_view< member_at::left, bimap_with_left_type_as_multiset >
+
+    >::value
+)
+
+\endcode
+
+See also multiset_of_relation.
+                                                                        **/
+
+template
+<
+    class KeyType,
+    class KeyCompare = std::less< BOOST_DEDUCED_TYPENAME
+        ::boost::bimaps::tags::support::value_type_of<KeyType>::type >
+>
+struct multiset_of : public ::boost::bimaps::detail::set_type_of_tag
+{
+    /// User type, can be tagged
+    typedef KeyType user_type;
+
+    /// Type of the object that will be stored in the multiset
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::
+        value_type_of<user_type>::type value_type;
+
+    /// Functor that compare two keys
+    typedef KeyCompare key_compare;
+
+    struct lazy_concept_checked
+    {
+        BOOST_CLASS_REQUIRE ( value_type,
+                              boost, AssignableConcept );
+
+        BOOST_CLASS_REQUIRE4( key_compare, bool, value_type, value_type,
+                              boost, BinaryFunctionConcept );
+
+        typedef multiset_of type;
+    };
+
+    BOOST_BIMAP_GENERATE_INDEX_BINDER_1CP(
+
+        // binds to
+        multi_index::ordered_non_unique,
+
+        // with
+        key_compare
+    )
+
+    BOOST_BIMAP_GENERATE_MAP_VIEW_BINDER(
+
+        // binds to
+        views::multimap_view
+    )
+
+    BOOST_BIMAP_GENERATE_SET_VIEW_BINDER(
+
+        // binds to
+        views::multiset_view
+    )
+
+    typedef mpl::bool_<false> mutable_key;
+};
+
+
+/// \brief Set Of Relation Specification
+/**
+This struct is similar to multiset_of but it is bind logically to a
+relation. It is used in the bimap instantiation to specify the
+desired type of the main view. This struct implements internally
+a metafunction named bind_to that manages the quite complicated
+task of finding the right type of the set for the relation.
+
+\code
+template<class Relation>
+struct bind_to
+{
+    typedef -unspecified- type;
+};
+\endcode
+
+See also multiset_of, is_set_type_of_relation.
+                                                                **/
+
+template< class KeyCompare = std::less< _relation > >
+struct multiset_of_relation : public ::boost::bimaps::detail::set_type_of_relation_tag
+{
+    /// Functor that compare two keys
+    typedef KeyCompare key_compare;
+
+
+    BOOST_BIMAP_GENERATE_RELATION_BINDER_1CP(
+
+        // binds to
+        multiset_of,
+
+        // with
+        key_compare
+    )
+
+    typedef mpl::bool_<false>  left_mutable_key;
+    typedef mpl::bool_<false> right_mutable_key;
+};
+
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_MULTISET_OF_HPP

--- a/inst/include/boost/bimap/property_map/set_support.hpp
+++ b/inst/include/boost/bimap/property_map/set_support.hpp
@@ -1,0 +1,55 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file property_map/set_support.hpp
+/// \brief Support for the property map concept.
+
+#ifndef BOOST_BIMAP_PROPERTY_MAP_SET_SUPPORT_HPP
+#define BOOST_BIMAP_PROPERTY_MAP_SET_SUPPORT_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/property_map/property_map.hpp>
+#include <boost/bimap/set_of.hpp>
+#include <boost/bimap/support/data_type_by.hpp>
+#include <boost/bimap/support/key_type_by.hpp>
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+namespace boost {
+
+template< class Tag, class Bimap >
+struct property_traits< ::boost::bimaps::views::map_view<Tag,Bimap> >
+{
+    typedef BOOST_DEDUCED_TYPENAME
+        ::boost::bimaps::support::data_type_by<Tag,Bimap>::type value_type;
+    typedef BOOST_DEDUCED_TYPENAME
+        ::boost::bimaps::support:: key_type_by<Tag,Bimap>::type   key_type;
+
+    typedef readable_property_map_tag category;
+};
+
+
+template< class Tag, class Bimap >
+const BOOST_DEDUCED_TYPENAME ::boost::bimaps::support::data_type_by<Tag,Bimap>::type &
+    get(const ::boost::bimaps::views::map_view<Tag,Bimap> & m,
+        const BOOST_DEDUCED_TYPENAME
+            ::boost::bimaps::support::key_type_by<Tag,Bimap>::type & key)
+{
+    return m.at(key);
+}
+
+} // namespace boost
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+#endif // BOOST_BIMAP_PROPERTY_MAP_SET_SUPPORT_HPP

--- a/inst/include/boost/bimap/property_map/unordered_set_support.hpp
+++ b/inst/include/boost/bimap/property_map/unordered_set_support.hpp
@@ -1,0 +1,55 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file property_map/unordered_set_support.hpp
+/// \brief Support for the property map concept.
+
+#ifndef BOOST_BIMAP_PROPERTY_MAP_UNORDERED_SET_SUPPORT_HPP
+#define BOOST_BIMAP_PROPERTY_MAP_UNORDERED_SET_SUPPORT_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/property_map/property_map.hpp>
+#include <boost/bimap/unordered_set_of.hpp>
+#include <boost/bimap/support/data_type_by.hpp>
+#include <boost/bimap/support/key_type_by.hpp>
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+namespace boost {
+
+template< class Tag, class Bimap >
+struct property_traits< ::boost::bimaps::views::unordered_map_view<Tag,Bimap> >
+{
+    typedef BOOST_DEDUCED_TYPENAME
+        ::boost::bimaps::support::data_type_by<Tag,Bimap>::type value_type;
+    typedef BOOST_DEDUCED_TYPENAME
+        ::boost::bimaps::support:: key_type_by<Tag,Bimap>::type   key_type;
+
+    typedef readable_property_map_tag category;
+};
+
+
+template< class Tag, class Bimap >
+const BOOST_DEDUCED_TYPENAME ::boost::bimaps::support::data_type_by<Tag,Bimap>::type &
+    get(const ::boost::bimaps::views::unordered_map_view<Tag,Bimap> & m,
+        const BOOST_DEDUCED_TYPENAME
+            ::boost::bimaps::support::key_type_by<Tag,Bimap>::type & key)
+{
+    return m.at(key);
+}
+
+} // namespace boost
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+#endif // BOOST_BIMAP_PROPERTY_MAP_UNORDERED_SET_SUPPORT_HPP

--- a/inst/include/boost/bimap/support/lambda.hpp
+++ b/inst/include/boost/bimap/support/lambda.hpp
@@ -1,0 +1,46 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file support/lambda.hpp
+/// \brief Placeholders definition to help in bimap modify function
+
+#ifndef BOOST_BIMAP_SUPPORT_LAMBDA_HPP
+#define BOOST_BIMAP_SUPPORT_LAMBDA_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/lambda/lambda.hpp>
+
+namespace boost {
+namespace bimaps {
+
+namespace {
+
+/*
+boost::lambda::placeholder1_type & _first  = boost::lambda::_1;
+boost::lambda::placeholder2_type & _second = boost::lambda::_2;
+
+boost::lambda::placeholder1_type & _left   = boost::lambda::_1;
+boost::lambda::placeholder2_type & _right  = boost::lambda::_2;
+*/
+
+boost::lambda::placeholder1_type & _key  = boost::lambda::_1;
+boost::lambda::placeholder1_type & _data = boost::lambda::_1;
+
+}
+
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_SUPPORT_LAMBDA_HPP
+

--- a/inst/include/boost/bimap/tags/support/apply_to_value_type.hpp
+++ b/inst/include/boost/bimap/tags/support/apply_to_value_type.hpp
@@ -1,0 +1,70 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file tags/support/apply_to_value_type.hpp
+/// \brief Similar to mpl::apply but for tagged types.
+
+#ifndef BOOST_BIMAP_TAGS_SUPPORT_APPLY_TO_VALUE_TYPE_HPP
+#define BOOST_BIMAP_TAGS_SUPPORT_APPLY_TO_VALUE_TYPE_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/tags/tagged.hpp>
+#include <boost/mpl/apply.hpp>
+
+/** \struct boost::bimaps::tags::support::apply_to_value_type
+\brief Higger order metafunction similar to mpl::apply but for tagged types.
+
+\code
+template< class Metafunction, class TaggedType >
+struct apply_to_value_type
+{
+    typedef tagged
+    <
+        Metafuntion< value_type_of< TaggedType >::type >::type,
+        tag_of< TaggedType >::type
+
+    > type;
+};
+\endcode
+
+This higher order metafunctions is very useful, and it can be used with lambda
+expresions.
+
+See also tagged.
+                                                                                **/
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+namespace boost {
+namespace bimaps {
+namespace tags {
+namespace support {
+
+template < class F, class TaggedType >
+struct apply_to_value_type;
+
+template < class F, class ValueType, class Tag >
+struct apply_to_value_type<F, tagged<ValueType,Tag> >
+{
+    typedef BOOST_DEDUCED_TYPENAME mpl::apply< F, ValueType >::type new_value_type;
+    typedef tagged< new_value_type, Tag > type;
+};
+
+} // namespace support
+} // namespace tags
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+#endif // BOOST_BIMAP_TAGS_SUPPORT_APPLY_TO_VALUE_TYPE_HPP

--- a/inst/include/boost/bimap/tags/support/is_tagged.hpp
+++ b/inst/include/boost/bimap/tags/support/is_tagged.hpp
@@ -1,0 +1,64 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file tags/support/is_tagged.hpp
+/// \brief type_traits extension
+
+#ifndef BOOST_BIMAP_TAGS_SUPPORT_IS_TAGGED_HPP
+#define BOOST_BIMAP_TAGS_SUPPORT_IS_TAGGED_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/mpl/bool.hpp>
+#include <boost/bimap/tags/tagged.hpp>
+
+/** \struct boost::bimaps::tags::support::is_tagged
+\brief Type trait to check if a type is tagged.
+
+\code
+template< class Type >
+struct is_tagged
+{
+    typedef {mpl::true_/mpl::false_} type;
+};
+\endcode
+
+See also tagged.
+                                                                                **/
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+namespace boost {
+namespace bimaps {
+namespace tags {
+namespace support {
+
+
+// is_tagged metafunction
+
+template< class Type >
+struct is_tagged :
+    ::boost::mpl::false_ {};
+
+template< class Type, class Tag >
+struct is_tagged< tagged< Type, Tag > > :
+    ::boost::mpl::true_ {};
+
+} // namespace support
+} // namespace tags
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+#endif // BOOST_BIMAP_TAGS_SUPPORT_IS_TAGGED_HPP
+

--- a/inst/include/boost/bimap/tags/support/overwrite_tagged.hpp
+++ b/inst/include/boost/bimap/tags/support/overwrite_tagged.hpp
@@ -1,0 +1,73 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file tags/support/overwrite_tagged.hpp
+/// \brief Hard tagging
+
+#ifndef BOOST_BIMAP_TAGS_SUPPORT_OVERWRITE_TAGGED_HPP
+#define BOOST_BIMAP_TAGS_SUPPORT_OVERWRITE_TAGGED_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/tags/tagged.hpp>
+
+/** \struct boost::bimaps::tags::support::overwrite_tagged
+\brief Hard tagging metafunction
+
+\code
+template< class Type, class Tag >
+struct overwrite_tagged
+{
+    typedef {TaggedType} type;
+};
+\endcode
+
+If the type is not tagged, this metafunction returns a tagged type with the
+passed tag. If it is tagged it returns a new tagged type with the tag replaced
+by the one passed as a parameter.
+
+See also tagged, default_tagged.
+                                                                                **/
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+namespace boost {
+namespace bimaps {
+namespace tags {
+namespace support {
+
+
+// Change the tag
+
+template< class Type, class NewTag >
+struct overwrite_tagged
+{
+    typedef tagged<Type,NewTag> type;
+};
+
+template< class Type, class OldTag, class NewTag >
+struct overwrite_tagged< tagged< Type, OldTag >, NewTag >
+{
+    typedef tagged<Type,NewTag> type;
+};
+
+
+} // namespace support
+} // namespace tags
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+#endif // BOOST_BIMAP_TAGS_SUPPORT_OVERWRITE_TAGGED_HPP
+
+

--- a/inst/include/boost/bimap/unordered_multiset_of.hpp
+++ b/inst/include/boost/bimap/unordered_multiset_of.hpp
@@ -1,0 +1,233 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file unordered_multiset_of.hpp
+/// \brief Include support for unordered_multiset constrains for the bimap container
+
+#ifndef BOOST_BIMAP_UNORDERED_MULTISET_OF_HPP
+#define BOOST_BIMAP_UNORDERED_MULTISET_OF_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/detail/user_interface_config.hpp>
+
+#include <cstdlib>
+#include <functional>
+#include <boost/functional/hash.hpp>
+#include <boost/mpl/bool.hpp>
+
+#include <boost/concept_check.hpp>
+
+#include <boost/bimap/detail/concept_tags.hpp>
+
+#include <boost/bimap/tags/support/value_type_of.hpp>
+
+#include <boost/bimap/detail/generate_index_binder.hpp>
+#include <boost/bimap/detail/generate_view_binder.hpp>
+#include <boost/bimap/detail/generate_relation_binder.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+
+#include <boost/bimap/views/unordered_multimap_view.hpp>
+#include <boost/bimap/views/unordered_multiset_view.hpp>
+
+namespace boost {
+namespace bimaps {
+
+
+/// \brief Set Type Specification
+/**
+This struct is used to specify an unordered_multiset specification.
+It is not a container, it is just a metaprogramming facility to
+express the type of a set. Generally, this specification will
+be used in other place to create a container.
+It has the same syntax that an tr1::unordered_multiset instantiation,
+except that the allocator cannot be specified. The rationale behind
+this difference is that the allocator is not part of the
+unordered_multiset type specification, rather it is a container
+configuration parameter.
+The first parameter is the type of the objects in the set, the
+second one is a Hash Functor that takes objects of this type, and
+the third one is a Functor that compares them for equality.
+Bimap binding metafunctions can be used with this class in
+the following way:
+
+\code
+using namespace support;
+
+BOOST_STATIC_ASSERT( is_set_type_of< unordered_multiset_of<Type> >::value )
+
+BOOST_STATIC_ASSERT
+(
+     is_same
+     <
+        compute_index_type
+        <
+            unordered_multiset_of<Type,HashFunctor,EqualKey>,
+            KeyExtractor,
+            Tag
+
+        >::type
+        ,
+        hashed_nonunique< tag<Tag>, KeyExtractor, HashFunctor, EqualKey >
+
+    >::value
+)
+
+typedef bimap
+<
+    unordered_multiset_of<Type>, RightKeyType
+
+> bimap_with_left_type_as_unordered_multiset;
+
+BOOST_STATIC_ASSERT
+(
+    is_same
+    <
+        compute_map_view_type
+        <
+            member_at::left,
+            bimap_with_left_type_as_unordered_multiset
+
+        >::type,
+
+        unordered_multimap_view
+        <
+            member_at::left,
+            bimap_with_left_type_as_unordered_multiset
+        >
+
+    >::value
+)
+
+\endcode
+
+See also unordered_multiset_of_relation.
+                                                                        **/
+
+template
+<
+    class KeyType,
+    class HashFunctor   = hash< BOOST_DEDUCED_TYPENAME 
+        ::boost::bimaps::tags::support::value_type_of<KeyType>::type >,
+    class EqualKey      = std::equal_to< BOOST_DEDUCED_TYPENAME 
+        ::boost::bimaps::tags::support::value_type_of<KeyType>::type >
+>
+struct unordered_multiset_of : public ::boost::bimaps::detail::set_type_of_tag
+{
+    /// User type, can be tagged
+    typedef KeyType user_type;
+
+    /// Type of the object that will be stored in the container
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::
+        value_type_of<user_type>::type value_type;
+
+    /// Hash Functor that takes value_type objects
+    typedef HashFunctor     hasher;
+
+    /// Functor that compare two value_type objects for equality
+    typedef EqualKey        key_equal;
+
+    struct lazy_concept_checked
+    {
+        BOOST_CLASS_REQUIRE ( value_type,
+                              boost, AssignableConcept );
+
+        BOOST_CLASS_REQUIRE3( hasher, std::size_t, value_type,
+                              boost, UnaryFunctionConcept );
+
+        BOOST_CLASS_REQUIRE4( key_equal, bool, value_type, value_type,
+                              boost, BinaryFunctionConcept );
+
+        typedef unordered_multiset_of type;
+    };
+
+    BOOST_BIMAP_GENERATE_INDEX_BINDER_2CP(
+
+        // binds to
+        multi_index::hashed_non_unique,
+
+        // with
+        hasher,
+        key_equal
+    )
+
+    BOOST_BIMAP_GENERATE_MAP_VIEW_BINDER(
+
+        // binds to
+        views::unordered_multimap_view
+    )
+
+    BOOST_BIMAP_GENERATE_SET_VIEW_BINDER(
+
+        // binds to
+        views::unordered_multiset_view
+    )
+
+    typedef mpl::bool_<false> mutable_key;
+};
+
+
+/// \brief Set Of Relation Specification
+/**
+This struct is similar to unordered_multiset_of but it is bind logically
+to a relation. It is used in the bimap instantiation to specify the
+desired type of the main view. This struct implements internally
+a metafunction named bind_to that manages the quite complicated
+task of finding the right type of the set for the relation.
+
+\code
+template<class Relation>
+struct bind_to
+{
+    typedef -unspecified- type;
+};
+\endcode
+
+See also unordered_multiset_of, is_set_type_of_relation.
+                                                                **/
+
+template
+<
+    class HashFunctor   = hash< _relation >,
+    class EqualKey      = std::equal_to< _relation >
+>
+struct unordered_multiset_of_relation : public ::boost::bimaps::detail::set_type_of_relation_tag
+{
+    /// Hash Functor that takes value_type objects
+    typedef HashFunctor     hasher;
+
+    /// Functor that compare two value_type objects for equality
+    typedef EqualKey        key_equal;
+
+
+    BOOST_BIMAP_GENERATE_RELATION_BINDER_2CP(
+
+        // binds to
+        unordered_multiset_of,
+
+        // with
+        hasher,
+        key_equal
+    )
+
+    typedef mpl::bool_<false>  left_mutable_key;
+    typedef mpl::bool_<false> right_mutable_key;
+};
+
+
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_UNORDERED_MULTISET_OF_HPP
+

--- a/inst/include/boost/bimap/unordered_set_of.hpp
+++ b/inst/include/boost/bimap/unordered_set_of.hpp
@@ -1,0 +1,230 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file unordered_set_of.hpp
+/// \brief Include support for unordered_set constrains for the bimap container
+
+#ifndef BOOST_BIMAP_UNORDERED_SET_OF_HPP
+#define BOOST_BIMAP_UNORDERED_SET_OF_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/detail/user_interface_config.hpp>
+
+#include <functional>
+#include <boost/functional/hash.hpp>
+#include <boost/mpl/bool.hpp>
+
+#include <boost/concept_check.hpp>
+
+#include <boost/bimap/detail/concept_tags.hpp>
+
+#include <boost/bimap/tags/support/value_type_of.hpp>
+
+#include <boost/bimap/detail/generate_index_binder.hpp>
+#include <boost/bimap/detail/generate_view_binder.hpp>
+#include <boost/bimap/detail/generate_relation_binder.hpp>
+
+#include <boost/multi_index/hashed_index.hpp>
+
+#include <boost/bimap/views/unordered_map_view.hpp>
+#include <boost/bimap/views/unordered_set_view.hpp>
+
+namespace boost {
+namespace bimaps {
+
+/// \brief Set Type Specification
+/**
+This struct is used to specify an unordered_set specification.
+It is not a container, it is just a metaprogramming facility to
+express the type of a set. Generally, this specification will
+be used in other place to create a container.
+It has the same syntax that an tr1::unordered_set instantiation,
+except that the allocator cannot be specified. The rationale behind
+this difference is that the allocator is not part of the
+unordered_set type specification, rather it is a container
+configuration parameter.
+The first parameter is the type of the objects in the set, the
+second one is a Hash Functor that takes objects of this type, and
+the third one is a Functor that compares them for equality.
+Bimap binding metafunctions can be used with this class in
+the following way:
+
+\code
+using namespace support;
+
+BOOST_STATIC_ASSERT( is_set_type_of< unordered_set_of<Type> >::value )
+
+BOOST_STATIC_ASSERT
+(
+     is_same
+     <
+        unordered_set_of<Type,HashFunctor,EqualKey>::index_bind
+        <
+            KeyExtractor,
+            Tag
+
+        >::type,
+
+        hashed_unique< tag<Tag>, KeyExtractor, HashFunctor, EqualKey >
+
+    >::value
+)
+
+typedef bimap
+<
+    unordered_set_of<Type>, RightKeyType
+
+> bimap_with_left_type_as_unordered_set;
+
+BOOST_STATIC_ASSERT
+(
+    is_same
+    <
+        unordered_set_of<Type>::map_view_bind
+        <
+            member_at::left,
+            bimap_with_left_type_as_unordered_set
+
+        >::type,
+
+        unordered_map_view
+        <
+            member_at::left,
+            bimap_with_left_type_as_unordered_set
+        >
+
+    >::value
+)
+
+\endcode
+
+See also unordered_set_of_relation.
+                                                                        **/
+
+template
+<
+    class KeyType,
+    class HashFunctor   = hash< BOOST_DEDUCED_TYPENAME 
+        ::boost::bimaps::tags::support::value_type_of<KeyType>::type >,
+    class EqualKey      = std::equal_to< BOOST_DEDUCED_TYPENAME 
+        ::boost::bimaps::tags::support::value_type_of<KeyType>::type >
+>
+struct unordered_set_of : public ::boost::bimaps::detail::set_type_of_tag
+{
+    /// User type, can be tagged
+    typedef KeyType user_type;
+
+    /// Type of the object that will be stored in the container
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::
+        value_type_of<user_type>::type value_type;
+
+    /// Hash Functor that takes value_type objects
+    typedef HashFunctor     hasher;
+
+    /// Functor that compare two value_type objects for equality
+    typedef EqualKey        key_equal;
+
+    struct lazy_concept_checked
+    {
+        BOOST_CLASS_REQUIRE ( value_type,
+                              boost, AssignableConcept );
+
+        BOOST_CLASS_REQUIRE3( hasher, std::size_t, value_type,
+                              boost, UnaryFunctionConcept );
+
+        BOOST_CLASS_REQUIRE4( key_equal, bool, value_type, value_type,
+                              boost, BinaryFunctionConcept );
+
+        typedef unordered_set_of type; 
+    };
+
+    BOOST_BIMAP_GENERATE_INDEX_BINDER_2CP(
+
+        // binds to
+        multi_index::hashed_unique,
+
+        // with
+        hasher,
+        key_equal
+    )
+
+    BOOST_BIMAP_GENERATE_MAP_VIEW_BINDER(
+
+        // binds to
+        views::unordered_map_view
+    )
+
+    BOOST_BIMAP_GENERATE_SET_VIEW_BINDER(
+
+        // binds to
+        views::unordered_set_view
+    )
+
+    typedef mpl::bool_<false> mutable_key;
+};
+
+
+/// \brief Set Of Relation Specification
+/**
+This struct is similar to unordered_set_of but it is bind logically to
+a relation. It is used in the bimap instantiation to specify the
+desired type of the main view. This struct implements internally
+a metafunction named bind_to that manages the quite complicated
+task of finding the right type of the set for the relation.
+
+\code
+template<class Relation>
+struct bind_to
+{
+    typedef -unspecified- type;
+};
+\endcode
+
+See also unordered_set_of, is_set_type_of_relation.
+                                                                **/
+
+template
+<
+    class HashFunctor   = hash< _relation >,
+    class EqualKey      = std::equal_to< _relation >
+>
+struct unordered_set_of_relation : public ::boost::bimaps::detail::set_type_of_relation_tag
+{
+    /// Hash Functor that takes value_type objects
+    typedef HashFunctor     hasher;
+
+    /// Functor that compare two value_type objects for equality
+    typedef EqualKey        key_equal;
+
+
+    BOOST_BIMAP_GENERATE_RELATION_BINDER_2CP(
+
+        // binds to
+        unordered_set_of,
+
+        // with
+        hasher,
+        key_equal
+    )
+
+    typedef mpl::bool_<false>  left_mutable_key;
+    typedef mpl::bool_<false> right_mutable_key;
+};
+
+
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_UNORDERED_SET_OF_HPP
+

--- a/inst/include/boost/bimap/vector_of.hpp
+++ b/inst/include/boost/bimap/vector_of.hpp
@@ -1,0 +1,186 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file vector_of.hpp
+/// \brief Include support for vector constrains for the bimap container
+
+#ifndef BOOST_BIMAP_VECTOR_OF_HPP
+#define BOOST_BIMAP_VECTOR_OF_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/detail/user_interface_config.hpp>
+
+#include <boost/mpl/bool.hpp>
+
+#include <boost/concept_check.hpp>
+
+#include <boost/bimap/detail/concept_tags.hpp>
+
+#include <boost/bimap/tags/support/value_type_of.hpp>
+
+#include <boost/bimap/detail/generate_index_binder.hpp>
+#include <boost/bimap/detail/generate_view_binder.hpp>
+#include <boost/bimap/detail/generate_relation_binder.hpp>
+
+#include <boost/multi_index/random_access_index.hpp>
+
+#include <boost/bimap/views/vector_map_view.hpp>
+#include <boost/bimap/views/vector_set_view.hpp>
+
+namespace boost {
+namespace bimaps {
+
+
+/// \brief Set Type Specification
+/**
+This struct is used to specify a set specification.
+It is not a container, it is just a metaprogramming facility to
+express the type of a set. Generally, this specification will
+be used in other place to create a container.
+It has the same syntax that an std::vector instantiation, except
+that the allocator cannot be specified. The rationale behind
+this difference is that the allocator is not part of the set
+type specification, rather it is a container configuration
+parameter.
+The first parameter is the type of the objects in the set, and
+the second one is a Functor that compares them.
+Bimap binding metafunctions can be used with this class in
+the following way:
+
+\code
+using namespace support;
+
+BOOST_STATIC_ASSERT( is_set_type_of< vector_of<Type> >::value )
+
+BOOST_STATIC_ASSERT
+(
+     is_same
+     <
+        vector_of<Type>::index_bind
+        <
+            KeyExtractor,
+            Tag
+
+        >::type,
+
+        random_access< tag<Tag>, KeyExtractor >
+
+    >::value
+)
+
+typedef bimap
+<
+    vector_of<Type>, RightKeyType
+
+> bimap_with_left_type_as_vector;
+
+BOOST_STATIC_ASSERT
+(
+    is_same
+    <
+        vector_of<Type>::map_view_bind
+        <
+            member_at::left,
+            bimap_with_left_type_as_vector
+
+        >::type,
+
+        vector_map_view< member_at::left, bimap_with_left_type_as_vector >
+
+    >::value
+)
+
+\endcode
+
+See also vector_of_relation.
+                                                                        **/
+
+template< class Type >
+struct vector_of : public ::boost::bimaps::detail::set_type_of_tag
+{
+    /// User type, can be tagged
+    typedef Type user_type;
+
+    /// Type of the object that will be stored in the vector
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::tags::support::
+        value_type_of<user_type>::type value_type;
+
+
+    struct lazy_concept_checked
+    {
+        BOOST_CLASS_REQUIRE ( value_type,
+                              boost, AssignableConcept );
+
+        typedef vector_of type;
+    };
+
+    BOOST_BIMAP_GENERATE_INDEX_BINDER_0CP_NO_EXTRACTOR(
+
+        // binds to
+        multi_index::random_access
+    )
+
+    BOOST_BIMAP_GENERATE_MAP_VIEW_BINDER(
+
+        // binds to
+        views::vector_map_view
+    )
+
+    BOOST_BIMAP_GENERATE_SET_VIEW_BINDER(
+
+        // binds to
+        views::vector_set_view
+    )
+
+    typedef mpl::bool_<true> mutable_key;
+};
+
+
+/// \brief Set Of Relation Specification
+/**
+This struct is similar to vector_of but it is bind logically to a
+relation. It is used in the bimap instantiation to specify the
+desired type of the main view. This struct implements internally
+a metafunction named bind_to that manages the quite complicated
+task of finding the right type of the set for the relation.
+
+\code
+template<class Relation>
+struct bind_to
+{
+    typedef -unspecified- type;
+};
+\endcode
+
+See also vector_of, is_set_type_of_relation.
+                                                                **/
+
+struct vector_of_relation : public ::boost::bimaps::detail::set_type_of_relation_tag
+{
+    BOOST_BIMAP_GENERATE_RELATION_BINDER_0CP(
+
+        // binds to
+        vector_of
+    )
+
+    typedef mpl::bool_<true>  left_mutable_key;
+    typedef mpl::bool_<true> right_mutable_key;
+};
+
+
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_VECTOR_OF_HPP
+

--- a/inst/include/boost/bimap/views/list_map_view.hpp
+++ b/inst/include/boost/bimap/views/list_map_view.hpp
@@ -1,0 +1,177 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/list_map_view.hpp
+/// \brief View of a side of a bimap.
+
+#ifndef BOOST_BIMAP_VIEWS_LIST_MAP_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_LIST_MAP_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/list_map_adaptor.hpp>
+#include <boost/bimap/relation/support/pair_by.hpp>
+#include <boost/bimap/support/iterator_type_by.hpp>
+#include <boost/bimap/detail/map_view_base.hpp>
+#include <boost/bimap/relation/support/data_extractor.hpp>
+#include <boost/bimap/relation/detail/to_mutable_relation_functor.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+#ifndef BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+template< class Tag, class BimapType >
+struct list_map_view_base
+{
+    typedef ::boost::bimaps::container_adaptor::list_map_adaptor
+    <
+        BOOST_DEDUCED_TYPENAME BimapType::core_type::
+            BOOST_NESTED_TEMPLATE index<Tag>::type,
+        ::boost::bimaps::detail::              map_view_iterator<Tag,BimapType>,
+        ::boost::bimaps::detail::        const_map_view_iterator<Tag,BimapType>,
+        ::boost::bimaps::detail::      reverse_map_view_iterator<Tag,BimapType>,
+        ::boost::bimaps::detail::const_reverse_map_view_iterator<Tag,BimapType>,
+        ::boost::bimaps::container_adaptor::support::iterator_facade_to_base
+        <
+            ::boost::bimaps::detail::      map_view_iterator<Tag,BimapType>,
+            ::boost::bimaps::detail::const_map_view_iterator<Tag,BimapType>
+            
+        >,
+        ::boost::mpl::na,
+        ::boost::mpl::na,
+        ::boost::bimaps::relation::detail::
+            pair_to_relation_functor<Tag, BOOST_DEDUCED_TYPENAME BimapType::relation >,
+        ::boost::bimaps::relation::support::
+            get_pair_functor<Tag, BOOST_DEDUCED_TYPENAME BimapType::relation >,
+
+        BOOST_DEDUCED_TYPENAME ::boost::bimaps::relation::support::data_extractor
+        <
+            Tag,
+            BOOST_DEDUCED_TYPENAME BimapType::relation
+            
+        >::type
+
+    > type;
+};
+
+#endif // BOOST_BIMAP_DOXYGEN_WILL_NOT_PROCESS_THE_FOLLOWING_LINES
+
+/// \brief View of a side of a bimap.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core.
+
+See also const_list_map_view.
+                                                                                    **/
+template< class Tag, class BimapType >
+class list_map_view
+:
+    public list_map_view_base<Tag,BimapType>::type,
+    public ::boost::bimaps::detail::
+            map_view_base< list_map_view<Tag,BimapType>,Tag,BimapType >
+
+{
+    typedef BOOST_DEDUCED_TYPENAME list_map_view_base<Tag,BimapType>::type base_;
+
+    BOOST_BIMAP_MAP_VIEW_BASE_FRIEND(list_map_view,Tag,BimapType)
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME base_::value_type::info_type info_type;
+
+    list_map_view(BOOST_DEDUCED_TYPENAME base_::base_type & c) :
+        base_(c) {}
+
+    list_map_view & operator=(const list_map_view & v)
+    {
+        this->base() = v.base(); 
+        return *this;
+    }
+
+    BOOST_BIMAP_VIEW_ASSIGN_IMPLEMENTATION(base_)
+
+    BOOST_BIMAP_VIEW_FRONT_BACK_IMPLEMENTATION(base_)
+
+    // Rearrange Operations
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                  BOOST_DEDUCED_TYPENAME base_::iterator i)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(i)
+        );
+    }
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                  BOOST_DEDUCED_TYPENAME base_::iterator first,
+                  BOOST_DEDUCED_TYPENAME base_::iterator last)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(first),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(last)
+        );
+    }
+};
+
+
+} // namespace views
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,TYPENAME)            \
+typedef BOOST_DEDUCED_TYPENAME MAP_VIEW::TYPENAME                             \
+    BOOST_PP_CAT(SIDE,BOOST_PP_CAT(_,TYPENAME));
+/*===========================================================================*/
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(MAP_VIEW,SIDE)               \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,reverse_iterator)        \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_reverse_iterator)  \
+/*===========================================================================*/
+
+namespace detail {
+
+template< class Tag, class BimapType >
+struct left_map_view_extra_typedefs< ::boost::bimaps::views::list_map_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::list_map_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,left)
+};
+
+template< class Tag, class BimapType >
+struct right_map_view_extra_typedefs< ::boost::bimaps::views::list_map_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::list_map_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,right)
+};
+
+} // namespace detail
+
+/*===========================================================================*/
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY
+/*===========================================================================*/
+
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_LIST_MAP_VIEW_HPP
+

--- a/inst/include/boost/bimap/views/list_set_view.hpp
+++ b/inst/include/boost/bimap/views/list_set_view.hpp
@@ -1,0 +1,109 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/list_set_view.hpp
+/// \brief View of a side of a bimap that is signature compatible with std::list.
+
+#ifndef BOOST_BIMAP_VIEWS_LIST_SET_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_LIST_SET_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/list_adaptor.hpp>
+#include <boost/bimap/detail/set_view_base.hpp>
+#include <boost/bimap/detail/map_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a bimap that is signature compatible with std::list.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a std::list.
+
+See also const_list_set_view.
+                                                                                    **/
+
+template< class CoreIndex >
+class list_set_view
+:
+    public BOOST_BIMAP_SEQUENCED_SET_VIEW_CONTAINER_ADAPTOR(
+        list_adaptor,
+        CoreIndex,
+        reverse_iterator, const_reverse_iterator
+    ),
+
+    public ::boost::bimaps::detail::
+        set_view_base< list_set_view< CoreIndex >, CoreIndex >
+{
+    BOOST_BIMAP_SET_VIEW_BASE_FRIEND(list_set_view,CoreIndex)
+
+    typedef BOOST_BIMAP_SEQUENCED_SET_VIEW_CONTAINER_ADAPTOR(
+        list_adaptor,
+        CoreIndex,
+        reverse_iterator, const_reverse_iterator
+
+    ) base_;
+
+    public:
+
+    list_set_view(BOOST_DEDUCED_TYPENAME base_::base_type & c) :
+        base_(c) {}
+
+    list_set_view & operator=(const list_set_view & v) 
+    {
+        this->base() = v.base();
+        return *this;
+    }
+
+    BOOST_BIMAP_VIEW_ASSIGN_IMPLEMENTATION(base_)
+
+    BOOST_BIMAP_VIEW_FRONT_BACK_IMPLEMENTATION(base_)
+
+    // Rearrange Operations
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position, 
+                  BOOST_DEDUCED_TYPENAME base_::iterator i)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(i)
+        );
+    }
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                  BOOST_DEDUCED_TYPENAME base_::iterator first,
+                  BOOST_DEDUCED_TYPENAME base_::iterator last)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(first),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(last)
+        );
+    }
+};
+
+
+} // namespace views
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_VIEWS_LIST_SET_VIEW_HPP
+

--- a/inst/include/boost/bimap/views/multimap_view.hpp
+++ b/inst/include/boost/bimap/views/multimap_view.hpp
@@ -1,0 +1,123 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/multimap_view.hpp
+/// \brief View of a side of a bimap that is signature compatible with std::multimap.
+
+#ifndef BOOST_BIMAP_VIEWS_MULTIMAP_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_MULTIMAP_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/multimap_adaptor.hpp>
+#include <boost/bimap/detail/non_unique_views_helper.hpp>
+#include <boost/bimap/support/iterator_type_by.hpp>
+#include <boost/bimap/detail/map_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a side of a bimap that is signature compatible with std::multimap.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a std::multimap.
+
+See also const_multimap_view.
+                                                                                    **/
+
+template< class Tag, class BimapType >
+class multimap_view
+:
+    public BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        multimap_adaptor,
+        Tag,BimapType,
+        reverse_map_view_iterator,const_reverse_map_view_iterator
+    ),
+    public ::boost::bimaps::detail::
+                map_view_base< multimap_view<Tag,BimapType>,Tag,BimapType >
+
+{
+    typedef BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        multimap_adaptor,
+        Tag,BimapType,
+        reverse_map_view_iterator,const_reverse_map_view_iterator
+
+    ) base_;
+
+    BOOST_BIMAP_MAP_VIEW_BASE_FRIEND(multimap_view,Tag,BimapType)
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME base_::value_type::info_type info_type;
+
+    multimap_view(BOOST_DEDUCED_TYPENAME base_::base_type & c)
+        : base_(c) {}
+
+    BOOST_BIMAP_MAP_VIEW_RANGE_IMPLEMENTATION(base_)
+
+    multimap_view & operator=(const multimap_view & v) 
+    {
+        this->base() = v.base();
+        return *this;
+    }
+
+    BOOST_BIMAP_NON_UNIQUE_VIEW_INSERT_FUNCTIONS
+};
+
+
+} // namespace views
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,TYPENAME)            \
+typedef BOOST_DEDUCED_TYPENAME MAP_VIEW::TYPENAME                             \
+    BOOST_PP_CAT(SIDE,BOOST_PP_CAT(_,TYPENAME));
+/*===========================================================================*/
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(MAP_VIEW,SIDE)               \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,reverse_iterator)        \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_reverse_iterator)  \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,range_type)              \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_range_type)        \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,key_compare)
+/*===========================================================================*/
+
+namespace detail {
+
+template< class Tag, class BimapType >
+struct left_map_view_extra_typedefs< ::boost::bimaps::views::multimap_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::multimap_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,left)
+};
+
+template< class Tag, class BimapType >
+struct right_map_view_extra_typedefs< ::boost::bimaps::views::multimap_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::multimap_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,right)
+};
+
+} // namespace detail
+
+/*===========================================================================*/
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY
+/*===========================================================================*/
+
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_MAP_VIEW_HPP
+

--- a/inst/include/boost/bimap/views/multiset_view.hpp
+++ b/inst/include/boost/bimap/views/multiset_view.hpp
@@ -1,0 +1,110 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/multiset_view.hpp
+/// \brief View of a bimap that is signature compatible with std::multiset.
+
+#ifndef BOOST_BIMAP_VIEWS_MULTISET_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_MULTISET_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/multiset_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/comparison_adaptor.hpp>
+#include <boost/bimap/detail/non_unique_views_helper.hpp>
+#include <boost/bimap/detail/set_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a bimap that is signature compatible with std::multiset.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a std::multiset.
+
+See also const_multiset_view.
+                                                                                    **/
+
+template< class CoreIndex >
+class multiset_view
+:
+    public BOOST_BIMAP_SET_VIEW_CONTAINER_ADAPTOR(
+        multiset_adaptor,
+        CoreIndex,
+        reverse_iterator,
+        const_reverse_iterator
+    ),
+
+    public ::boost::bimaps::detail::
+                set_view_base< multiset_view< CoreIndex >, CoreIndex >
+{
+    BOOST_BIMAP_SET_VIEW_BASE_FRIEND(multiset_view, CoreIndex)
+
+    typedef BOOST_BIMAP_SET_VIEW_CONTAINER_ADAPTOR(
+        multiset_adaptor,
+        CoreIndex,
+        reverse_iterator,
+        const_reverse_iterator
+
+    ) base_;
+
+    public:
+
+    multiset_view(BOOST_DEDUCED_TYPENAME base_::base_type & c) : base_(c) {}
+
+    /*
+    template< class LowerBounder, class UpperBounder >
+    std::pair<BOOST_DEDUCED_TYPENAME base_::const_iterator,
+              BOOST_DEDUCED_TYPENAME base_::const_iterator>
+        range(LowerBounder lower,UpperBounder upper) const
+    {
+        return this->base().range(
+
+            ::boost::bimaps::container_adaptor::detail::unary_check_adaptor
+            <
+                LowerBounder,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( lower, this->template functor<
+                            BOOST_DEDUCED_TYPENAME base_::value_from_base>() ),
+
+            ::boost::bimaps::container_adaptor::detail::unary_check_adaptor
+            <
+                UpperBounder,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( upper, this->template functor<
+                            BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+
+        );
+    }
+    */
+
+    multiset_view & operator=(const multiset_view & v) 
+    {
+        this->base() = v.base(); return *this;
+    }
+
+    BOOST_BIMAP_NON_UNIQUE_VIEW_INSERT_FUNCTIONS
+};
+
+
+} // namespace views
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_MULTISET_VIEW_HPP
+

--- a/inst/include/boost/bimap/views/unordered_map_view.hpp
+++ b/inst/include/boost/bimap/views/unordered_map_view.hpp
@@ -1,0 +1,174 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/unordered_map_view.hpp
+/// \brief View of a side of a bimap that is signature compatible with tr1::unordered_map.
+
+#ifndef BOOST_BIMAP_VIEWS_UNOREDERED_MAP_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_UNOREDERED_MAP_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <utility>
+
+#include <boost/bimap/container_adaptor/unordered_map_adaptor.hpp>
+#include <boost/bimap/detail/map_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief Map View of a bimap, signature compatible with tr1::unordered_map.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a tr1::unordered_map.
+
+See also const_unordered_map_view.
+                                                                             **/
+
+
+template< class Tag, class BimapType >
+class unordered_map_view
+:
+    public BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        unordered_map_adaptor,
+        Tag,BimapType,
+        local_map_view_iterator,const_local_map_view_iterator
+    ),
+
+    public ::boost::bimaps::detail::map_view_base<
+                unordered_map_view<Tag,BimapType>,Tag,BimapType >,
+    public ::boost::bimaps::detail::
+                unique_map_view_access<
+                    unordered_map_view<Tag,BimapType>, Tag,  BimapType>::type
+
+{
+    typedef BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        unordered_map_adaptor,
+        Tag,BimapType,
+        local_map_view_iterator,const_local_map_view_iterator
+
+    ) base_;
+
+    BOOST_BIMAP_MAP_VIEW_BASE_FRIEND(unordered_map_view,Tag,BimapType)
+
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::detail::
+        unique_map_view_access<
+            unordered_map_view<Tag,BimapType>, Tag,  BimapType
+
+        >::type unique_map_view_access_;
+
+    public:
+
+    typedef std::pair<
+        BOOST_DEDUCED_TYPENAME base_::iterator,
+        BOOST_DEDUCED_TYPENAME base_::iterator
+    > range_type;
+
+    typedef std::pair<
+        BOOST_DEDUCED_TYPENAME base_::const_iterator,
+        BOOST_DEDUCED_TYPENAME base_::const_iterator
+    > const_range_type;
+
+    typedef BOOST_DEDUCED_TYPENAME base_::value_type::info_type info_type;
+
+    unordered_map_view(BOOST_DEDUCED_TYPENAME base_::base_type & c)
+        : base_(c) {}
+
+    using unique_map_view_access_::at;
+    using unique_map_view_access_::operator[];
+
+    unordered_map_view & operator=(const unordered_map_view & v) 
+    {
+        this->base() = v.base();
+        return *this;
+    }
+
+    // It can be used enable_if here but the error message when there 
+    // is no info is very clear like this
+
+    template< class CompatibleKey >
+    const info_type & info_at(const CompatibleKey& k) const
+    {
+        BOOST_DEDUCED_TYPENAME base_::const_iterator iter = this->find(k);
+        if( iter == this->end() )
+        {
+            ::boost::throw_exception(
+                std::out_of_range("bimap<>: invalid key")
+            );
+        }
+        return iter->info;
+    }
+
+    template< class CompatibleKey >
+    info_type & info_at(const CompatibleKey& k)
+    {
+        BOOST_DEDUCED_TYPENAME base_::iterator iter = this->find(k);
+        if( iter == this->end() )
+        {
+            ::boost::throw_exception(
+                std::out_of_range("bimap<>: invalid key")
+            );
+        }
+        return iter->info;
+    }
+};
+
+
+} // namespace views
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,TYPENAME)            \
+typedef BOOST_DEDUCED_TYPENAME MAP_VIEW::TYPENAME                             \
+    BOOST_PP_CAT(SIDE,BOOST_PP_CAT(_,TYPENAME));
+/*===========================================================================*/
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(MAP_VIEW,SIDE)               \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,local_iterator)          \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_local_iterator)    \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,range_type)              \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_range_type)        \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,hasher)                  \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,key_equal)
+/*===========================================================================*/
+
+namespace detail {
+
+template< class Tag, class BimapType >
+struct left_map_view_extra_typedefs< ::boost::bimaps::views::unordered_map_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::unordered_map_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,left)
+};
+
+template< class Tag, class BimapType >
+struct right_map_view_extra_typedefs< ::boost::bimaps::views::unordered_map_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::unordered_map_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,right)
+};
+
+} // namespace detail
+
+/*===========================================================================*/
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY
+/*===========================================================================*/
+
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_UNOREDERED_MAP_VIEW_HPP
+
+

--- a/inst/include/boost/bimap/views/unordered_multimap_view.hpp
+++ b/inst/include/boost/bimap/views/unordered_multimap_view.hpp
@@ -1,0 +1,136 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/unordered_multimap_view.hpp
+/// \brief View of a side of a bimap that is signature compatible with tr1::unordered_multimap.
+
+#ifndef BOOST_BIMAP_VIEWS_UNOREDERED_MULTIMAP_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_UNOREDERED_MULTIMAP_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <utility>
+
+#include <boost/bimap/container_adaptor/unordered_multimap_adaptor.hpp>
+#include <boost/bimap/detail/non_unique_views_helper.hpp>
+#include <boost/bimap/support/iterator_type_by.hpp>
+#include <boost/bimap/detail/map_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a side of a bimap that is signature compatible with tr1::unordered_multimap.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a tr1::unordered_multimap.
+
+See also const_unordered_multimap_view.
+                                                                             **/
+
+template< class Tag, class BimapType >
+class unordered_multimap_view
+:
+    public BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        unordered_multimap_adaptor,
+        Tag,BimapType,
+        local_map_view_iterator,const_local_map_view_iterator
+    ),
+
+    public ::boost::bimaps::detail::map_view_base<
+                unordered_multimap_view<Tag,BimapType>,Tag,BimapType >
+
+{
+    typedef BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        unordered_multimap_adaptor,
+        Tag,BimapType,
+        local_map_view_iterator,const_local_map_view_iterator
+
+    ) base_;
+
+    BOOST_BIMAP_MAP_VIEW_BASE_FRIEND(unordered_multimap_view,Tag,BimapType)
+
+    public:
+
+    typedef std::pair<
+        BOOST_DEDUCED_TYPENAME base_::iterator,
+        BOOST_DEDUCED_TYPENAME base_::iterator
+    > range_type;
+
+    typedef std::pair<
+        BOOST_DEDUCED_TYPENAME base_::const_iterator,
+        BOOST_DEDUCED_TYPENAME base_::const_iterator
+    > const_range_type;
+
+    typedef BOOST_DEDUCED_TYPENAME base_::value_type::info_type info_type;
+
+    unordered_multimap_view(BOOST_DEDUCED_TYPENAME base_::base_type & c)
+        : base_(c) {}
+
+    BOOST_BIMAP_NON_UNIQUE_VIEW_INSERT_FUNCTIONS
+
+    unordered_multimap_view & operator=(const unordered_multimap_view & v) 
+    {
+        this->base() = v.base();
+        return *this;
+    }
+};
+
+
+} // namespace views
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,TYPENAME)            \
+typedef BOOST_DEDUCED_TYPENAME MAP_VIEW::TYPENAME                             \
+    BOOST_PP_CAT(SIDE,BOOST_PP_CAT(_,TYPENAME));
+/*===========================================================================*/
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(MAP_VIEW,SIDE)               \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,local_iterator)          \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_local_iterator)    \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,range_type)              \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_range_type)        \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,hasher)                  \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,key_equal)
+/*===========================================================================*/
+
+namespace detail {
+
+template< class Tag, class BimapType >
+struct left_map_view_extra_typedefs< ::boost::bimaps::views::unordered_multimap_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::unordered_multimap_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,left)
+};
+
+template< class Tag, class BimapType >
+struct right_map_view_extra_typedefs< ::boost::bimaps::views::unordered_multimap_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::unordered_multimap_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,right)
+};
+
+} // namespace detail
+
+/*===========================================================================*/
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY
+/*===========================================================================*/
+
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_UNOREDERED_MULTIMAP_VIEW_HPP
+
+

--- a/inst/include/boost/bimap/views/unordered_multiset_view.hpp
+++ b/inst/include/boost/bimap/views/unordered_multiset_view.hpp
@@ -1,0 +1,83 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/unordered_multiset_view.hpp
+/// \brief View of a bimap that is signature compatible with tr1::unordered_multiset.
+
+#ifndef BOOST_BIMAP_VIEWS_UNORDERED_MULTISET_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_UNORDERED_MULTISET_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/unordered_multiset_adaptor.hpp>
+#include <boost/bimap/detail/non_unique_views_helper.hpp>
+#include <boost/bimap/detail/set_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a bimap that is signature compatible with std::unordered_multiset.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a std::unordered_multiset.
+
+See also const_unordered_multiset_view.
+                                                                                    **/
+
+template< class CoreIndex >
+class unordered_multiset_view
+:
+    public BOOST_BIMAP_SET_VIEW_CONTAINER_ADAPTOR(
+        unordered_multiset_adaptor,
+        CoreIndex,
+        local_iterator,
+        const_local_iterator
+
+    ),
+
+    public ::boost::bimaps::detail::
+                set_view_base< unordered_multiset_view< CoreIndex >, CoreIndex >
+{
+    BOOST_BIMAP_SET_VIEW_BASE_FRIEND(unordered_multiset_view,CoreIndex)
+
+    typedef BOOST_BIMAP_SET_VIEW_CONTAINER_ADAPTOR(
+        unordered_multiset_adaptor,
+        CoreIndex,
+        local_iterator,
+        const_local_iterator
+
+    ) base_;
+
+    public:
+
+    unordered_multiset_view(BOOST_DEDUCED_TYPENAME base_::base_type & c)
+        : base_(c) {}
+
+    BOOST_BIMAP_NON_UNIQUE_VIEW_INSERT_FUNCTIONS
+
+    unordered_multiset_view & operator=(const unordered_multiset_view & v)
+    {
+        this->base() = v.base();
+        return *this;
+    }
+};
+
+
+} // namespace views
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_UNORDERED_MULTISET_VIEW_HPP
+
+

--- a/inst/include/boost/bimap/views/unordered_set_view.hpp
+++ b/inst/include/boost/bimap/views/unordered_set_view.hpp
@@ -1,0 +1,78 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/unordered_set_view.hpp
+/// \brief View of a bimap that is signature compatible with tr1::unordered_set.
+
+#ifndef BOOST_BIMAP_VIEWS_UNORDERED_SET_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_UNORDERED_SET_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/unordered_set_adaptor.hpp>
+#include <boost/bimap/detail/set_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a bimap that is signature compatible with std::unordered_set.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a std::unordered_set.
+
+See also const_unordered_set_view.
+                                                                             **/
+
+template< class CoreIndex >
+class unordered_set_view
+:
+    public BOOST_BIMAP_SET_VIEW_CONTAINER_ADAPTOR(
+        unordered_set_adaptor,
+        CoreIndex,
+        local_iterator,
+        const_local_iterator
+    ),
+
+    public ::boost::bimaps::detail::
+        set_view_base< unordered_set_view< CoreIndex >, CoreIndex >
+{
+    BOOST_BIMAP_SET_VIEW_BASE_FRIEND(unordered_set_view,CoreIndex)
+
+    typedef BOOST_BIMAP_SET_VIEW_CONTAINER_ADAPTOR(
+        unordered_set_adaptor,
+        CoreIndex,
+        local_iterator,
+        const_local_iterator
+
+    ) base_;
+
+    public:
+
+    unordered_set_view(BOOST_DEDUCED_TYPENAME base_::base_type & c)
+        : base_(c) {}
+
+    unordered_set_view & operator=(const unordered_set_view & v) 
+    {
+        this->base() = v.base();
+        return *this;
+    }
+};
+
+
+} // namespace views
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_UNORDERED_SET_VIEW_HPP
+

--- a/inst/include/boost/bimap/views/vector_map_view.hpp
+++ b/inst/include/boost/bimap/views/vector_map_view.hpp
@@ -1,0 +1,340 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/vector_map_view.hpp
+/// \brief View of a side of a bimap.
+
+#ifndef BOOST_BIMAP_VIEWS_VECTOR_MAP_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_VECTOR_MAP_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/vector_map_adaptor.hpp>
+#include <boost/bimap/support/iterator_type_by.hpp>
+#include <boost/bimap/detail/map_view_base.hpp>
+#include <boost/bimap/container_adaptor/detail/comparison_adaptor.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a side of a bimap.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core.
+
+See also const_map_view.
+                                                                             **/
+template< class Tag, class BimapType >
+class vector_map_view
+:
+    public BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        vector_map_adaptor,
+        Tag,BimapType,
+        reverse_map_view_iterator, const_reverse_map_view_iterator
+    ),
+
+    public ::boost::bimaps::detail::
+                map_view_base< vector_map_view<Tag,BimapType>,Tag,BimapType >
+{
+    typedef BOOST_BIMAP_MAP_VIEW_CONTAINER_ADAPTOR(
+        vector_map_adaptor,
+        Tag,BimapType,
+        reverse_map_view_iterator, const_reverse_map_view_iterator
+
+    ) base_;
+
+    BOOST_BIMAP_MAP_VIEW_BASE_FRIEND(vector_map_view,Tag,BimapType)
+
+    typedef BOOST_DEDUCED_TYPENAME ::boost::bimaps::relation::support::data_extractor
+    <
+        Tag,
+        BOOST_DEDUCED_TYPENAME BimapType::relation
+
+    >::type key_from_base_value;
+
+    public:
+
+    typedef BOOST_DEDUCED_TYPENAME base_::value_type::info_type info_type;
+
+    vector_map_view(BOOST_DEDUCED_TYPENAME base_::base_type & c) :
+        base_(c) {}
+
+    vector_map_view & operator=(const vector_map_view & v)
+    {
+        this->base() = v.base();
+        return *this;
+    }
+    
+    BOOST_DEDUCED_TYPENAME base_::const_reference
+        operator[](BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().operator[](n)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_reference
+        at(BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().at(n)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference
+        operator[](BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            const_cast<BOOST_DEDUCED_TYPENAME base_::base_type::value_type &>(
+                this->base().operator[](n)
+        ));
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference
+        at(BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            const_cast<BOOST_DEDUCED_TYPENAME base_::base_type::value_type &>(
+                this->base().at(n)
+        ));
+    }
+    
+    BOOST_BIMAP_VIEW_ASSIGN_IMPLEMENTATION(base_)
+
+    BOOST_BIMAP_VIEW_FRONT_BACK_IMPLEMENTATION(base_)
+
+    // Lists operations
+
+    void splice(BOOST_DEDUCED_TYPENAME base_::iterator position, vector_map_view & x)
+    {
+        this->base().splice(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            x.base()
+        );
+    }
+
+    void splice(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                vector_map_view & x,
+                BOOST_DEDUCED_TYPENAME base_::iterator i)
+    {
+        this->base().splice(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            x.base(),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(i)
+        );
+    }
+
+    void splice(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                vector_map_view & x,
+                BOOST_DEDUCED_TYPENAME base_::iterator first,
+                BOOST_DEDUCED_TYPENAME base_::iterator last)
+    {
+        this->base().splice(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            x.base(),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(first),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(last)
+        );
+    }
+
+    void remove(BOOST_DEDUCED_TYPENAME ::boost::call_traits< 
+                    BOOST_DEDUCED_TYPENAME base_::value_type >::param_type value)
+    {
+        this->base().remove(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::value_to_base>()(value)
+        );
+    }
+
+    template< class Predicate >
+    void remove_if(Predicate pred)
+    {
+        this->base().remove_if(
+            ::boost::bimaps::container_adaptor::detail::unary_check_adaptor
+            <
+                Predicate,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                key_from_base_value
+
+            >( pred, key_from_base_value() )
+        );
+    }
+
+    void unique()
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::equal_to<BOOST_DEDUCED_TYPENAME base_::key_type>,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                key_from_base_value
+
+            >(std::equal_to<BOOST_DEDUCED_TYPENAME base_::key_type>(),
+                    key_from_base_value() )
+        );
+    }
+
+    template< class BinaryPredicate >
+    void unique(BinaryPredicate binary_pred)
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                BinaryPredicate,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                key_from_base_value
+
+            >( binary_pred, key_from_base_value() )
+        );
+    }
+
+    void merge(vector_map_view & x)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<BOOST_DEDUCED_TYPENAME base_::key_type>,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                key_from_base_value
+
+            >( std::less<BOOST_DEDUCED_TYPENAME base_::key_type>(), 
+                    key_from_base_value() )
+        );
+    }
+
+    template< class Compare >
+    void merge(vector_map_view & x, Compare comp)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                key_from_base_value
+
+            >( comp, key_from_base_value() )
+        );
+    }
+
+    void sort()
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<BOOST_DEDUCED_TYPENAME base_::key_type>,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                key_from_base_value
+
+            >( std::less<BOOST_DEDUCED_TYPENAME base_::key_type>(),
+                    key_from_base_value() )
+        );
+    }
+
+    template< class Compare >
+    void sort(Compare comp)
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                key_from_base_value
+
+            >( comp, key_from_base_value() )
+        );
+    }
+
+    void reverse()
+    {
+        this->base().reverse();
+    }
+
+    // Rearrange Operations
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position, 
+                  BOOST_DEDUCED_TYPENAME base_::iterator i)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(i)
+        );
+    }
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                  BOOST_DEDUCED_TYPENAME base_::iterator first, 
+                  BOOST_DEDUCED_TYPENAME base_::iterator last)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(first),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(last)
+        );
+    }
+
+};
+
+
+} // namespace views
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,TYPENAME)            \
+typedef BOOST_DEDUCED_TYPENAME MAP_VIEW::TYPENAME                             \
+    BOOST_PP_CAT(SIDE,BOOST_PP_CAT(_,TYPENAME));
+/*===========================================================================*/
+
+/*===========================================================================*/
+#define BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(MAP_VIEW,SIDE)               \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,reverse_iterator)        \
+    BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF(MAP_VIEW,SIDE,const_reverse_iterator)
+/*===========================================================================*/
+
+namespace detail {
+
+template< class Tag, class BimapType >
+struct left_map_view_extra_typedefs< ::boost::bimaps::views::vector_map_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::vector_map_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,left)
+};
+
+template< class Tag, class BimapType >
+struct right_map_view_extra_typedefs< ::boost::bimaps::views::vector_map_view<Tag,BimapType> >
+{
+    private: typedef ::boost::bimaps::views::vector_map_view<Tag,BimapType> map_view_;
+    public : BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY(map_view_,right)
+};
+
+} // namespace detail
+
+/*===========================================================================*/
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEF
+#undef BOOST_BIMAP_MAP_VIEW_EXTRA_TYPEDEFS_BODY
+/*===========================================================================*/
+
+} // namespace bimaps
+} // namespace boost
+
+#endif // BOOST_BIMAP_VIEWS_VECTOR_MAP_VIEW_HPP
+

--- a/inst/include/boost/bimap/views/vector_set_view.hpp
+++ b/inst/include/boost/bimap/views/vector_set_view.hpp
@@ -1,0 +1,313 @@
+// Boost.Bimap
+//
+// Copyright (c) 2006-2007 Matias Capeletto
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file views/vector_set_view.hpp
+/// \brief View of a side of a bimap that is signature compatible with std::vector.
+
+#ifndef BOOST_BIMAP_VIEWS_VECTOR_SET_VIEW_HPP
+#define BOOST_BIMAP_VIEWS_VECTOR_SET_VIEW_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp>
+
+#include <boost/bimap/container_adaptor/vector_adaptor.hpp>
+#include <boost/bimap/container_adaptor/detail/comparison_adaptor.hpp>
+#include <boost/bimap/detail/set_view_base.hpp>
+#include <boost/bimap/detail/map_view_base.hpp>
+
+namespace boost {
+namespace bimaps {
+namespace views {
+
+/// \brief View of a bimap that is signature compatible with std::vector.
+/**
+
+This class uses container_adaptor and iterator_adaptor to wrapped a index of the
+multi_index bimap core so it can be used as a std::vector.
+
+See also const_set_view.
+                                                                                    **/
+
+template< class CoreIndex >
+class vector_set_view
+:
+    public BOOST_BIMAP_SEQUENCED_SET_VIEW_CONTAINER_ADAPTOR(
+        vector_adaptor,
+        CoreIndex,
+        reverse_iterator, const_reverse_iterator
+    ),
+
+    public ::boost::bimaps::detail::
+                set_view_base< vector_set_view< CoreIndex >, CoreIndex >
+{
+    BOOST_BIMAP_SET_VIEW_BASE_FRIEND(vector_set_view,CoreIndex)
+
+    typedef BOOST_BIMAP_SEQUENCED_SET_VIEW_CONTAINER_ADAPTOR(
+        vector_adaptor,
+        CoreIndex,
+        reverse_iterator, const_reverse_iterator
+
+    ) base_;
+
+    public:
+
+    vector_set_view(BOOST_DEDUCED_TYPENAME base_::base_type & c) :
+        base_(c) {}
+
+    vector_set_view & operator=(const vector_set_view & v)
+    {
+        this->base() = v.base();
+        return *this;
+    }
+
+        BOOST_DEDUCED_TYPENAME base_::const_reference
+        operator[](BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().operator[](n)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::const_reference
+        at(BOOST_DEDUCED_TYPENAME base_::size_type n) const
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            this->base().at(n)
+        );
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference
+        operator[](BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            const_cast<BOOST_DEDUCED_TYPENAME base_::base_type::value_type &>(
+                this->base().operator[](n)
+        ));
+    }
+
+    BOOST_DEDUCED_TYPENAME base_::reference
+        at(BOOST_DEDUCED_TYPENAME base_::size_type n)
+    {
+        return this->template functor<BOOST_DEDUCED_TYPENAME base_::value_from_base>()(
+            const_cast<BOOST_DEDUCED_TYPENAME base_::base_type::value_type &>(
+                this->base().at(n)
+        ));
+    }
+    
+    BOOST_BIMAP_VIEW_ASSIGN_IMPLEMENTATION(base_)
+
+    BOOST_BIMAP_VIEW_FRONT_BACK_IMPLEMENTATION(base_)
+
+    // List operations
+
+    void splice(BOOST_DEDUCED_TYPENAME base_::iterator position, 
+                vector_set_view & x)
+    {
+        this->base().splice(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            x.base()
+        );
+    }
+
+    void splice(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                vector_set_view & x,
+                BOOST_DEDUCED_TYPENAME base_::iterator i)
+    {
+        this->base().splice(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            x.base(),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(i)
+        );
+    }
+
+    void splice(BOOST_DEDUCED_TYPENAME base_::iterator position, 
+                vector_set_view & x,
+                BOOST_DEDUCED_TYPENAME base_::iterator first, 
+                BOOST_DEDUCED_TYPENAME base_::iterator last)
+    {
+        this->base().splice(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            x.base(),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(first),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(last)
+        );
+    }
+
+    void remove(BOOST_DEDUCED_TYPENAME ::boost::call_traits<
+                    BOOST_DEDUCED_TYPENAME base_::value_type >::param_type value)
+    {
+        this->base().remove(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::value_to_base>()(value)
+        );
+    }
+
+    template<typename Predicate>
+    void remove_if(Predicate pred)
+    {
+        this->base().remove_if(
+            ::boost::bimaps::container_adaptor::detail::unary_check_adaptor
+            <
+                Predicate,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( pred, this->template functor<
+                            BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+        );
+    }
+
+    void unique()
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::equal_to<BOOST_DEDUCED_TYPENAME base_::value_type>,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >(
+                std::equal_to<BOOST_DEDUCED_TYPENAME base_::value_type>(),
+                this->template functor<
+                    BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+            )
+        );
+    }
+
+    template< class BinaryPredicate >
+    void unique(BinaryPredicate binary_pred)
+    {
+        this->base().unique(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                BinaryPredicate,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( binary_pred,
+               this->template functor<
+                    BOOST_DEDUCED_TYPENAME base_::value_from_base>() 
+            )
+        );
+    }
+
+    void merge(vector_set_view & x)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >(
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>(),
+                this->template functor<
+                        BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+            )
+        );
+    }
+
+    template< class Compare >
+    void merge(vector_set_view & x, Compare comp)
+    {
+        this->base().merge(x.base(),
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( comp, this->template functor<
+                        BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+        );
+    }
+
+    void sort()
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >(
+                std::less<BOOST_DEDUCED_TYPENAME base_::value_type>(),
+                this->template functor<
+                    BOOST_DEDUCED_TYPENAME base_::value_from_base>()
+            )
+        );
+    }
+
+    template< class Compare >
+    void sort(Compare comp)
+    {
+        this->base().sort(
+            ::boost::bimaps::container_adaptor::detail::comparison_adaptor
+            <
+                Compare,
+                BOOST_DEDUCED_TYPENAME base_::base_type::value_type,
+                BOOST_DEDUCED_TYPENAME base_::value_from_base
+
+            >( comp, this->template functor<
+                        BOOST_DEDUCED_TYPENAME base_::value_from_base>() )
+        );
+    }
+
+    void reverse()
+    {
+        this->base().reverse();
+    }
+
+    // Rearrange Operations
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position, 
+                  BOOST_DEDUCED_TYPENAME base_::iterator i)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(i)
+        );
+    }
+
+    void relocate(BOOST_DEDUCED_TYPENAME base_::iterator position,
+                  BOOST_DEDUCED_TYPENAME base_::iterator first, 
+                  BOOST_DEDUCED_TYPENAME base_::iterator last)
+    {
+        this->base().relocate(
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(position),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(first),
+            this->template functor<
+                BOOST_DEDUCED_TYPENAME base_::iterator_to_base>()(last)
+        );
+    }
+
+};
+
+
+} // namespace views
+} // namespace bimaps
+} // namespace boost
+
+
+#endif // BOOST_BIMAP_VIEWS_VECTOR_SET_VIEW_HPP
+

--- a/inst/include/boost/multi_index/composite_key.hpp
+++ b/inst/include/boost/multi_index/composite_key.hpp
@@ -1,0 +1,1513 @@
+/* Copyright 2003-2015 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_COMPOSITE_KEY_HPP
+#define BOOST_MULTI_INDEX_COMPOSITE_KEY_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/functional/hash_fwd.hpp>
+#include <boost/multi_index/detail/access_specifier.hpp>
+#include <boost/mpl/eval_if.hpp>
+#include <boost/mpl/identity.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/preprocessor/cat.hpp>
+#include <boost/preprocessor/control/expr_if.hpp>
+#include <boost/preprocessor/list/at.hpp>
+#include <boost/preprocessor/repetition/enum.hpp>
+#include <boost/preprocessor/repetition/enum_params.hpp> 
+#include <boost/static_assert.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <functional>
+
+#if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+#include <boost/ref.hpp>
+#endif
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/type_traits/is_convertible.hpp>
+#endif
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)&&\
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+#include <boost/multi_index/detail/cons_stdtuple.hpp>
+#endif
+
+/* A composite key stores n key extractors and "computes" the
+ * result on a given value as a packed reference to the value and
+ * the composite key itself. Actual invocations to the component
+ * key extractors are lazily performed when executing an operation
+ * on composite_key results (equality, comparison, hashing.)
+ * As the other key extractors in Boost.MultiIndex, composite_key<T,...>
+ * is  overloaded to work on chained pointers to T and reference_wrappers
+ * of T.
+ */
+
+/* This user_definable macro limits the number of elements of a composite
+ * key; useful for shortening resulting symbol names (MSVC++ 6.0, for
+ * instance has problems coping with very long symbol names.)
+ * NB: This cannot exceed the maximum number of arguments of
+ * boost::tuple. In Boost 1.32, the limit is 10.
+ */
+
+#if !defined(BOOST_MULTI_INDEX_LIMIT_COMPOSITE_KEY_SIZE)
+#define BOOST_MULTI_INDEX_LIMIT_COMPOSITE_KEY_SIZE 10
+#endif
+
+/* maximum number of key extractors in a composite key */
+
+#if BOOST_MULTI_INDEX_LIMIT_COMPOSITE_KEY_SIZE<10 /* max length of a tuple */
+#define BOOST_MULTI_INDEX_COMPOSITE_KEY_SIZE \
+  BOOST_MULTI_INDEX_LIMIT_COMPOSITE_KEY_SIZE
+#else
+#define BOOST_MULTI_INDEX_COMPOSITE_KEY_SIZE 10
+#endif
+
+/* BOOST_PP_ENUM of BOOST_MULTI_INDEX_COMPOSITE_KEY_SIZE elements */
+
+#define BOOST_MULTI_INDEX_CK_ENUM(macro,data)                                \
+  BOOST_PP_ENUM(BOOST_MULTI_INDEX_COMPOSITE_KEY_SIZE,macro,data)
+
+/* BOOST_PP_ENUM_PARAMS of BOOST_MULTI_INDEX_COMPOSITE_KEY_SIZE elements */
+
+#define BOOST_MULTI_INDEX_CK_ENUM_PARAMS(param)                              \
+  BOOST_PP_ENUM_PARAMS(BOOST_MULTI_INDEX_COMPOSITE_KEY_SIZE,param)
+
+/* if n==0 ->   text0
+ * otherwise -> textn=tuples::null_type
+ */
+
+#define BOOST_MULTI_INDEX_CK_TEMPLATE_PARM(z,n,text)                         \
+  typename BOOST_PP_CAT(text,n) BOOST_PP_EXPR_IF(n,=tuples::null_type)
+
+/* const textn& kn=textn() */
+
+#define BOOST_MULTI_INDEX_CK_CTOR_ARG(z,n,text)                              \
+  const BOOST_PP_CAT(text,n)& BOOST_PP_CAT(k,n) = BOOST_PP_CAT(text,n)()
+
+/* typename list(0)<list(1),n>::type */
+
+#define BOOST_MULTI_INDEX_CK_APPLY_METAFUNCTION_N(z,n,list)                  \
+  BOOST_DEDUCED_TYPENAME BOOST_PP_LIST_AT(list,0)<                           \
+    BOOST_PP_LIST_AT(list,1),n                                               \
+  >::type
+
+namespace boost{
+
+template<class T> class reference_wrapper; /* fwd decl. */
+
+namespace multi_index{
+
+namespace detail{
+
+/* n-th key extractor of a composite key */
+
+template<typename CompositeKey,int N>
+struct nth_key_from_value
+{
+  typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+  typedef typename mpl::eval_if_c<
+    N<tuples::length<key_extractor_tuple>::value,
+    tuples::element<N,key_extractor_tuple>,
+    mpl::identity<tuples::null_type>
+  >::type                                            type;
+};
+
+/* nth_composite_key_##name<CompositeKey,N>::type yields
+ * functor<nth_key_from_value<CompositeKey,N> >, or tuples::null_type
+ * if N exceeds the length of the composite key.
+ */
+
+#define BOOST_MULTI_INDEX_CK_NTH_COMPOSITE_KEY_FUNCTOR(name,functor)         \
+template<typename KeyFromValue>                                              \
+struct BOOST_PP_CAT(key_,name)                                               \
+{                                                                            \
+  typedef functor<typename KeyFromValue::result_type> type;                  \
+};                                                                           \
+                                                                             \
+template<>                                                                   \
+struct BOOST_PP_CAT(key_,name)<tuples::null_type>                            \
+{                                                                            \
+  typedef tuples::null_type type;                                            \
+};                                                                           \
+                                                                             \
+template<typename CompositeKey,int  N>                                       \
+struct BOOST_PP_CAT(nth_composite_key_,name)                                 \
+{                                                                            \
+  typedef typename nth_key_from_value<CompositeKey,N>::type key_from_value;  \
+  typedef typename BOOST_PP_CAT(key_,name)<key_from_value>::type type;       \
+};
+
+/* nth_composite_key_equal_to
+ * nth_composite_key_less
+ * nth_composite_key_greater
+ * nth_composite_key_hash
+ */
+
+BOOST_MULTI_INDEX_CK_NTH_COMPOSITE_KEY_FUNCTOR(equal_to,std::equal_to)
+BOOST_MULTI_INDEX_CK_NTH_COMPOSITE_KEY_FUNCTOR(less,std::less)
+BOOST_MULTI_INDEX_CK_NTH_COMPOSITE_KEY_FUNCTOR(greater,std::greater)
+BOOST_MULTI_INDEX_CK_NTH_COMPOSITE_KEY_FUNCTOR(hash,boost::hash)
+
+/* used for defining equality and comparison ops of composite_key_result */
+
+#define BOOST_MULTI_INDEX_CK_IDENTITY_ENUM_MACRO(z,n,text) text
+
+struct generic_operator_equal
+{
+  template<typename T,typename Q>
+  bool operator()(const T& x,const Q& y)const{return x==y;}
+};
+
+typedef tuple<
+  BOOST_MULTI_INDEX_CK_ENUM(
+    BOOST_MULTI_INDEX_CK_IDENTITY_ENUM_MACRO,
+    detail::generic_operator_equal)>          generic_operator_equal_tuple;
+
+struct generic_operator_less
+{
+  template<typename T,typename Q>
+  bool operator()(const T& x,const Q& y)const{return x<y;}
+};
+
+typedef tuple<
+  BOOST_MULTI_INDEX_CK_ENUM(
+    BOOST_MULTI_INDEX_CK_IDENTITY_ENUM_MACRO,
+    detail::generic_operator_less)>           generic_operator_less_tuple;
+
+/* Metaprogramming machinery for implementing equality, comparison and
+ * hashing operations of composite_key_result.
+ *
+ * equal_* checks for equality between composite_key_results and
+ * between those and tuples, accepting a tuple of basic equality functors.
+ * compare_* does lexicographical comparison.
+ * hash_* computes a combination of elementwise hash values.
+ */
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename EqualCons
+>
+struct equal_ckey_ckey; /* fwd decl. */
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename EqualCons
+>
+struct equal_ckey_ckey_terminal
+{
+  static bool compare(
+    const KeyCons1&,const Value1&,
+    const KeyCons2&,const Value2&,
+    const EqualCons&)
+  {
+    return true;
+  }
+};
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename EqualCons
+>
+struct equal_ckey_ckey_normal
+{
+  static bool compare(
+    const KeyCons1& c0,const Value1& v0,
+    const KeyCons2& c1,const Value2& v1,
+    const EqualCons& eq)
+  {
+    if(!eq.get_head()(c0.get_head()(v0),c1.get_head()(v1)))return false;
+    return equal_ckey_ckey<
+      BOOST_DEDUCED_TYPENAME KeyCons1::tail_type,Value1,
+      BOOST_DEDUCED_TYPENAME KeyCons2::tail_type,Value2,
+      BOOST_DEDUCED_TYPENAME EqualCons::tail_type
+    >::compare(c0.get_tail(),v0,c1.get_tail(),v1,eq.get_tail());
+  }
+};
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename EqualCons
+>
+struct equal_ckey_ckey:
+  mpl::if_<
+    mpl::or_<
+      is_same<KeyCons1,tuples::null_type>,
+      is_same<KeyCons2,tuples::null_type>
+    >,
+    equal_ckey_ckey_terminal<KeyCons1,Value1,KeyCons2,Value2,EqualCons>,
+    equal_ckey_ckey_normal<KeyCons1,Value1,KeyCons2,Value2,EqualCons>
+  >::type
+{
+};
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename EqualCons
+>
+struct equal_ckey_cval; /* fwd decl. */
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename EqualCons
+>
+struct equal_ckey_cval_terminal
+{
+  static bool compare(
+    const KeyCons&,const Value&,const ValCons&,const EqualCons&)
+  {
+    return true;
+  }
+
+  static bool compare(
+    const ValCons&,const KeyCons&,const Value&,const EqualCons&)
+  {
+    return true;
+  }
+};
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename EqualCons
+>
+struct equal_ckey_cval_normal
+{
+  static bool compare(
+    const KeyCons& c,const Value& v,const ValCons& vc,
+    const EqualCons& eq)
+  {
+    if(!eq.get_head()(c.get_head()(v),vc.get_head()))return false;
+    return equal_ckey_cval<
+      BOOST_DEDUCED_TYPENAME KeyCons::tail_type,Value,
+      BOOST_DEDUCED_TYPENAME ValCons::tail_type,
+      BOOST_DEDUCED_TYPENAME EqualCons::tail_type
+    >::compare(c.get_tail(),v,vc.get_tail(),eq.get_tail());
+  }
+
+  static bool compare(
+    const ValCons& vc,const KeyCons& c,const Value& v,
+    const EqualCons& eq)
+  {
+    if(!eq.get_head()(vc.get_head(),c.get_head()(v)))return false;
+    return equal_ckey_cval<
+      BOOST_DEDUCED_TYPENAME KeyCons::tail_type,Value,
+      BOOST_DEDUCED_TYPENAME ValCons::tail_type,
+      BOOST_DEDUCED_TYPENAME EqualCons::tail_type
+    >::compare(vc.get_tail(),c.get_tail(),v,eq.get_tail());
+  }
+};
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename EqualCons
+>
+struct equal_ckey_cval:
+  mpl::if_<
+    mpl::or_<
+      is_same<KeyCons,tuples::null_type>,
+      is_same<ValCons,tuples::null_type>
+    >,
+    equal_ckey_cval_terminal<KeyCons,Value,ValCons,EqualCons>,
+    equal_ckey_cval_normal<KeyCons,Value,ValCons,EqualCons>
+  >::type
+{
+};
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename CompareCons
+>
+struct compare_ckey_ckey; /* fwd decl. */
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename CompareCons
+>
+struct compare_ckey_ckey_terminal
+{
+  static bool compare(
+    const KeyCons1&,const Value1&,
+    const KeyCons2&,const Value2&,
+    const CompareCons&)
+  {
+    return false;
+  }
+};
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename CompareCons
+>
+struct compare_ckey_ckey_normal
+{
+  static bool compare(
+    const KeyCons1& c0,const Value1& v0,
+    const KeyCons2& c1,const Value2& v1,
+    const CompareCons& comp)
+  {
+    if(comp.get_head()(c0.get_head()(v0),c1.get_head()(v1)))return true;
+    if(comp.get_head()(c1.get_head()(v1),c0.get_head()(v0)))return false;
+    return compare_ckey_ckey<
+      BOOST_DEDUCED_TYPENAME KeyCons1::tail_type,Value1,
+      BOOST_DEDUCED_TYPENAME KeyCons2::tail_type,Value2,
+      BOOST_DEDUCED_TYPENAME CompareCons::tail_type
+    >::compare(c0.get_tail(),v0,c1.get_tail(),v1,comp.get_tail());
+  }
+};
+
+template
+<
+  typename KeyCons1,typename Value1,
+  typename KeyCons2, typename Value2,
+  typename CompareCons
+>
+struct compare_ckey_ckey:
+  mpl::if_<
+    mpl::or_<
+      is_same<KeyCons1,tuples::null_type>,
+      is_same<KeyCons2,tuples::null_type>
+    >,
+    compare_ckey_ckey_terminal<KeyCons1,Value1,KeyCons2,Value2,CompareCons>,
+    compare_ckey_ckey_normal<KeyCons1,Value1,KeyCons2,Value2,CompareCons>
+  >::type
+{
+};
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename CompareCons
+>
+struct compare_ckey_cval; /* fwd decl. */
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename CompareCons
+>
+struct compare_ckey_cval_terminal
+{
+  static bool compare(
+    const KeyCons&,const Value&,const ValCons&,const CompareCons&)
+  {
+    return false;
+  }
+
+  static bool compare(
+    const ValCons&,const KeyCons&,const Value&,const CompareCons&)
+  {
+    return false;
+  }
+};
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename CompareCons
+>
+struct compare_ckey_cval_normal
+{
+  static bool compare(
+    const KeyCons& c,const Value& v,const ValCons& vc,
+    const CompareCons& comp)
+  {
+    if(comp.get_head()(c.get_head()(v),vc.get_head()))return true;
+    if(comp.get_head()(vc.get_head(),c.get_head()(v)))return false;
+    return compare_ckey_cval<
+      BOOST_DEDUCED_TYPENAME KeyCons::tail_type,Value,
+      BOOST_DEDUCED_TYPENAME ValCons::tail_type,
+      BOOST_DEDUCED_TYPENAME CompareCons::tail_type
+    >::compare(c.get_tail(),v,vc.get_tail(),comp.get_tail());
+  }
+
+  static bool compare(
+    const ValCons& vc,const KeyCons& c,const Value& v,
+    const CompareCons& comp)
+  {
+    if(comp.get_head()(vc.get_head(),c.get_head()(v)))return true;
+    if(comp.get_head()(c.get_head()(v),vc.get_head()))return false;
+    return compare_ckey_cval<
+      BOOST_DEDUCED_TYPENAME KeyCons::tail_type,Value,
+      BOOST_DEDUCED_TYPENAME ValCons::tail_type,
+      BOOST_DEDUCED_TYPENAME CompareCons::tail_type
+    >::compare(vc.get_tail(),c.get_tail(),v,comp.get_tail());
+  }
+};
+
+template
+<
+  typename KeyCons,typename Value,
+  typename ValCons,typename CompareCons
+>
+struct compare_ckey_cval:
+  mpl::if_<
+    mpl::or_<
+      is_same<KeyCons,tuples::null_type>,
+      is_same<ValCons,tuples::null_type>
+    >,
+    compare_ckey_cval_terminal<KeyCons,Value,ValCons,CompareCons>,
+    compare_ckey_cval_normal<KeyCons,Value,ValCons,CompareCons>
+  >::type
+{
+};
+
+template<typename KeyCons,typename Value,typename HashCons>
+struct hash_ckey; /* fwd decl. */
+
+template<typename KeyCons,typename Value,typename HashCons>
+struct hash_ckey_terminal
+{
+  static std::size_t hash(
+    const KeyCons&,const Value&,const HashCons&,std::size_t carry)
+  {
+    return carry;
+  }
+};
+
+template<typename KeyCons,typename Value,typename HashCons>
+struct hash_ckey_normal
+{
+  static std::size_t hash(
+    const KeyCons& c,const Value& v,const HashCons& h,std::size_t carry=0)
+  {
+    /* same hashing formula as boost::hash_combine */
+
+    carry^=h.get_head()(c.get_head()(v))+0x9e3779b9+(carry<<6)+(carry>>2);
+    return hash_ckey<
+      BOOST_DEDUCED_TYPENAME KeyCons::tail_type,Value,
+      BOOST_DEDUCED_TYPENAME HashCons::tail_type
+    >::hash(c.get_tail(),v,h.get_tail(),carry);
+  }
+};
+
+template<typename KeyCons,typename Value,typename HashCons>
+struct hash_ckey:
+  mpl::if_<
+    is_same<KeyCons,tuples::null_type>,
+    hash_ckey_terminal<KeyCons,Value,HashCons>,
+    hash_ckey_normal<KeyCons,Value,HashCons>
+  >::type
+{
+};
+
+template<typename ValCons,typename HashCons>
+struct hash_cval; /* fwd decl. */
+
+template<typename ValCons,typename HashCons>
+struct hash_cval_terminal
+{
+  static std::size_t hash(const ValCons&,const HashCons&,std::size_t carry)
+  {
+    return carry;
+  }
+};
+
+template<typename ValCons,typename HashCons>
+struct hash_cval_normal
+{
+  static std::size_t hash(
+    const ValCons& vc,const HashCons& h,std::size_t carry=0)
+  {
+    carry^=h.get_head()(vc.get_head())+0x9e3779b9+(carry<<6)+(carry>>2);
+    return hash_cval<
+      BOOST_DEDUCED_TYPENAME ValCons::tail_type,
+      BOOST_DEDUCED_TYPENAME HashCons::tail_type
+    >::hash(vc.get_tail(),h.get_tail(),carry);
+  }
+};
+
+template<typename ValCons,typename HashCons>
+struct hash_cval:
+  mpl::if_<
+    is_same<ValCons,tuples::null_type>,
+    hash_cval_terminal<ValCons,HashCons>,
+    hash_cval_normal<ValCons,HashCons>
+  >::type
+{
+};
+
+} /* namespace multi_index::detail */
+
+/* composite_key_result */
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#pragma warning(disable:4512)
+#endif
+
+template<typename CompositeKey>
+struct composite_key_result
+{
+  typedef CompositeKey                            composite_key_type;
+  typedef typename composite_key_type::value_type value_type;
+
+  composite_key_result(
+    const composite_key_type& composite_key_,const value_type& value_):
+    composite_key(composite_key_),value(value_)
+  {}
+
+  const composite_key_type& composite_key;
+  const value_type&         value;
+};
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+/* composite_key */
+
+template<
+  typename Value,
+  BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_TEMPLATE_PARM,KeyFromValue)
+>
+struct composite_key:
+  private tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(KeyFromValue)>
+{
+private:
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(KeyFromValue)> super;
+
+public:
+  typedef super                               key_extractor_tuple;
+  typedef Value                               value_type;
+  typedef composite_key_result<composite_key> result_type;
+
+  composite_key(
+    BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_CTOR_ARG,KeyFromValue)):
+    super(BOOST_MULTI_INDEX_CK_ENUM_PARAMS(k))
+  {}
+
+  composite_key(const key_extractor_tuple& x):super(x){}
+
+  const key_extractor_tuple& key_extractors()const{return *this;}
+  key_extractor_tuple&       key_extractors(){return *this;}
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<const ChainedPtr&,const value_type&>,result_type>::type
+#else
+  result_type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  result_type operator()(const value_type& x)const
+  {
+    return result_type(*this,x);
+  }
+
+  result_type operator()(const reference_wrapper<const value_type>& x)const
+  {
+    return result_type(*this,x.get());
+  }
+
+  result_type operator()(const reference_wrapper<value_type>& x)const
+  {
+    return result_type(*this,x.get());
+  }
+};
+
+/* comparison operators */
+
+/* == */
+
+template<typename CompositeKey1,typename CompositeKey2>
+inline bool operator==(
+  const composite_key_result<CompositeKey1>& x,
+  const composite_key_result<CompositeKey2>& y)
+{
+  typedef typename CompositeKey1::key_extractor_tuple key_extractor_tuple1;
+  typedef typename CompositeKey1::value_type          value_type1;
+  typedef typename CompositeKey2::key_extractor_tuple key_extractor_tuple2;
+  typedef typename CompositeKey2::value_type          value_type2;
+
+  BOOST_STATIC_ASSERT(
+    tuples::length<key_extractor_tuple1>::value==
+    tuples::length<key_extractor_tuple2>::value);
+
+  return detail::equal_ckey_ckey<
+    key_extractor_tuple1,value_type1,
+    key_extractor_tuple2,value_type2,
+    detail::generic_operator_equal_tuple
+  >::compare(
+    x.composite_key.key_extractors(),x.value,
+    y.composite_key.key_extractors(),y.value,
+    detail::generic_operator_equal_tuple());
+}
+
+template<
+  typename CompositeKey,
+  BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value)
+>
+inline bool operator==(
+  const composite_key_result<CompositeKey>& x,
+  const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+  typedef typename CompositeKey::value_type              value_type;
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+  
+  BOOST_STATIC_ASSERT(
+    tuples::length<key_extractor_tuple>::value==
+    tuples::length<key_tuple>::value);
+
+  return detail::equal_ckey_cval<
+    key_extractor_tuple,value_type,
+    key_tuple,detail::generic_operator_equal_tuple
+  >::compare(
+    x.composite_key.key_extractors(),x.value,
+    y,detail::generic_operator_equal_tuple());
+}
+
+template
+<
+  BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value),
+  typename CompositeKey
+>
+inline bool operator==(
+  const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& x,
+  const composite_key_result<CompositeKey>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+  typedef typename CompositeKey::value_type              value_type;
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+  
+  BOOST_STATIC_ASSERT(
+    tuples::length<key_extractor_tuple>::value==
+    tuples::length<key_tuple>::value);
+
+  return detail::equal_ckey_cval<
+    key_extractor_tuple,value_type,
+    key_tuple,detail::generic_operator_equal_tuple
+  >::compare(
+    x,y.composite_key.key_extractors(),
+    y.value,detail::generic_operator_equal_tuple());
+}
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)&&\
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+template<typename CompositeKey,typename... Values>
+inline bool operator==(
+  const composite_key_result<CompositeKey>& x,
+  const std::tuple<Values...>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+  typedef typename CompositeKey::value_type          value_type;
+  typedef std::tuple<Values...>                      key_tuple;
+  typedef typename detail::cons_stdtuple_ctor<
+    key_tuple>::result_type                          cons_key_tuple;
+  
+  BOOST_STATIC_ASSERT(
+    static_cast<std::size_t>(tuples::length<key_extractor_tuple>::value)==
+    std::tuple_size<key_tuple>::value);
+
+  return detail::equal_ckey_cval<
+    key_extractor_tuple,value_type,
+    cons_key_tuple,detail::generic_operator_equal_tuple
+  >::compare(
+    x.composite_key.key_extractors(),x.value,
+    detail::make_cons_stdtuple(y),detail::generic_operator_equal_tuple());
+}
+
+template<typename CompositeKey,typename... Values>
+inline bool operator==(
+  const std::tuple<Values...>& x,
+  const composite_key_result<CompositeKey>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+  typedef typename CompositeKey::value_type          value_type;
+  typedef std::tuple<Values...>                      key_tuple;
+  typedef typename detail::cons_stdtuple_ctor<
+    key_tuple>::result_type                          cons_key_tuple;
+
+  BOOST_STATIC_ASSERT(
+    static_cast<std::size_t>(tuples::length<key_extractor_tuple>::value)==
+    std::tuple_size<key_tuple>::value);
+
+  return detail::equal_ckey_cval<
+    key_extractor_tuple,value_type,
+    cons_key_tuple,detail::generic_operator_equal_tuple
+  >::compare(
+    detail::make_cons_stdtuple(x),y.composite_key.key_extractors(),
+    y.value,detail::generic_operator_equal_tuple());
+}
+#endif
+
+/* < */
+
+template<typename CompositeKey1,typename CompositeKey2>
+inline bool operator<(
+  const composite_key_result<CompositeKey1>& x,
+  const composite_key_result<CompositeKey2>& y)
+{
+  typedef typename CompositeKey1::key_extractor_tuple key_extractor_tuple1;
+  typedef typename CompositeKey1::value_type          value_type1;
+  typedef typename CompositeKey2::key_extractor_tuple key_extractor_tuple2;
+  typedef typename CompositeKey2::value_type          value_type2;
+
+  return detail::compare_ckey_ckey<
+   key_extractor_tuple1,value_type1,
+   key_extractor_tuple2,value_type2,
+   detail::generic_operator_less_tuple
+  >::compare(
+    x.composite_key.key_extractors(),x.value,
+    y.composite_key.key_extractors(),y.value,
+    detail::generic_operator_less_tuple());
+}
+
+template
+<
+  typename CompositeKey,
+  BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value)
+>
+inline bool operator<(
+  const composite_key_result<CompositeKey>& x,
+  const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+  typedef typename CompositeKey::value_type              value_type;
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+  
+  return detail::compare_ckey_cval<
+    key_extractor_tuple,value_type,
+    key_tuple,detail::generic_operator_less_tuple
+  >::compare(
+    x.composite_key.key_extractors(),x.value,
+    y,detail::generic_operator_less_tuple());
+}
+
+template
+<
+  BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value),
+  typename CompositeKey
+>
+inline bool operator<(
+  const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& x,
+  const composite_key_result<CompositeKey>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+  typedef typename CompositeKey::value_type              value_type;
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+  
+  return detail::compare_ckey_cval<
+    key_extractor_tuple,value_type,
+    key_tuple,detail::generic_operator_less_tuple
+  >::compare(
+    x,y.composite_key.key_extractors(),
+    y.value,detail::generic_operator_less_tuple());
+}
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)&&\
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+template<typename CompositeKey,typename... Values>
+inline bool operator<(
+  const composite_key_result<CompositeKey>& x,
+  const std::tuple<Values...>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+  typedef typename CompositeKey::value_type          value_type;
+  typedef std::tuple<Values...>                      key_tuple;
+  typedef typename detail::cons_stdtuple_ctor<
+    key_tuple>::result_type                          cons_key_tuple;
+  
+  return detail::compare_ckey_cval<
+    key_extractor_tuple,value_type,
+    cons_key_tuple,detail::generic_operator_less_tuple
+  >::compare(
+    x.composite_key.key_extractors(),x.value,
+    detail::make_cons_stdtuple(y),detail::generic_operator_less_tuple());
+}
+
+template<typename CompositeKey,typename... Values>
+inline bool operator<(
+  const std::tuple<Values...>& x,
+  const composite_key_result<CompositeKey>& y)
+{
+  typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+  typedef typename CompositeKey::value_type          value_type;
+  typedef std::tuple<Values...>                      key_tuple;
+  typedef typename detail::cons_stdtuple_ctor<
+    key_tuple>::result_type                          cons_key_tuple;
+  
+  return detail::compare_ckey_cval<
+    key_extractor_tuple,value_type,
+    cons_key_tuple,detail::generic_operator_less_tuple
+  >::compare(
+    detail::make_cons_stdtuple(x),y.composite_key.key_extractors(),
+    y.value,detail::generic_operator_less_tuple());
+}
+#endif
+
+/* rest of comparison operators */
+
+#define BOOST_MULTI_INDEX_CK_COMPLETE_COMP_OPS(t1,t2,a1,a2)                  \
+template<t1,t2> inline bool operator!=(const a1& x,const a2& y)              \
+{                                                                            \
+  return !(x==y);                                                            \
+}                                                                            \
+                                                                             \
+template<t1,t2> inline bool operator>(const a1& x,const a2& y)               \
+{                                                                            \
+  return y<x;                                                                \
+}                                                                            \
+                                                                             \
+template<t1,t2> inline bool operator>=(const a1& x,const a2& y)              \
+{                                                                            \
+  return !(x<y);                                                             \
+}                                                                            \
+                                                                             \
+template<t1,t2> inline bool operator<=(const a1& x,const a2& y)              \
+{                                                                            \
+  return !(y<x);                                                             \
+}
+
+BOOST_MULTI_INDEX_CK_COMPLETE_COMP_OPS(
+  typename CompositeKey1,
+  typename CompositeKey2,
+  composite_key_result<CompositeKey1>,
+  composite_key_result<CompositeKey2>
+)
+
+BOOST_MULTI_INDEX_CK_COMPLETE_COMP_OPS(
+  typename CompositeKey,
+  BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value),
+  composite_key_result<CompositeKey>,
+  tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>
+)
+
+BOOST_MULTI_INDEX_CK_COMPLETE_COMP_OPS(
+  BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value),
+  typename CompositeKey,
+  tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>,
+  composite_key_result<CompositeKey>
+)
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)&&\
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+BOOST_MULTI_INDEX_CK_COMPLETE_COMP_OPS(
+  typename CompositeKey,
+  typename... Values,
+  composite_key_result<CompositeKey>,
+  std::tuple<Values...>
+)
+
+BOOST_MULTI_INDEX_CK_COMPLETE_COMP_OPS(
+  typename CompositeKey,
+  typename... Values,
+  std::tuple<Values...>,
+  composite_key_result<CompositeKey>
+)
+#endif
+
+/* composite_key_equal_to */
+
+template
+<
+  BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_TEMPLATE_PARM,Pred)
+>
+struct composite_key_equal_to:
+  private tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Pred)>
+{
+private:
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Pred)> super;
+
+public:
+  typedef super key_eq_tuple;
+
+  composite_key_equal_to(
+    BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_CTOR_ARG,Pred)):
+    super(BOOST_MULTI_INDEX_CK_ENUM_PARAMS(k))
+  {}
+
+  composite_key_equal_to(const key_eq_tuple& x):super(x){}
+
+  const key_eq_tuple& key_eqs()const{return *this;}
+  key_eq_tuple&       key_eqs(){return *this;}
+
+  template<typename CompositeKey1,typename CompositeKey2>
+  bool operator()(
+    const composite_key_result<CompositeKey1> & x,
+    const composite_key_result<CompositeKey2> & y)const
+  {
+    typedef typename CompositeKey1::key_extractor_tuple key_extractor_tuple1;
+    typedef typename CompositeKey1::value_type          value_type1;
+    typedef typename CompositeKey2::key_extractor_tuple key_extractor_tuple2;
+    typedef typename CompositeKey2::value_type          value_type2;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_extractor_tuple1>::value<=
+      tuples::length<key_eq_tuple>::value&&
+      tuples::length<key_extractor_tuple1>::value==
+      tuples::length<key_extractor_tuple2>::value);
+
+    return detail::equal_ckey_ckey<
+      key_extractor_tuple1,value_type1,
+      key_extractor_tuple2,value_type2,
+      key_eq_tuple
+    >::compare(
+      x.composite_key.key_extractors(),x.value,
+      y.composite_key.key_extractors(),y.value,
+      key_eqs());
+  }
+  
+  template
+  <
+    typename CompositeKey,
+    BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value)
+  >
+  bool operator()(
+    const composite_key_result<CompositeKey>& x,
+    const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+    typedef typename CompositeKey::value_type              value_type;
+    typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_extractor_tuple>::value<=
+      tuples::length<key_eq_tuple>::value&&
+      tuples::length<key_extractor_tuple>::value==
+      tuples::length<key_tuple>::value);
+
+    return detail::equal_ckey_cval<
+      key_extractor_tuple,value_type,
+      key_tuple,key_eq_tuple
+    >::compare(x.composite_key.key_extractors(),x.value,y,key_eqs());
+  }
+
+  template
+  <
+    BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value),
+    typename CompositeKey
+  >
+  bool operator()(
+    const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& x,
+    const composite_key_result<CompositeKey>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+    typedef typename CompositeKey::value_type              value_type;
+    typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_tuple>::value<=
+      tuples::length<key_eq_tuple>::value&&
+      tuples::length<key_tuple>::value==
+      tuples::length<key_extractor_tuple>::value);
+
+    return detail::equal_ckey_cval<
+      key_extractor_tuple,value_type,
+      key_tuple,key_eq_tuple
+    >::compare(x,y.composite_key.key_extractors(),y.value,key_eqs());
+  }
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)&&\
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+  template<typename CompositeKey,typename... Values>
+  bool operator()(
+    const composite_key_result<CompositeKey>& x,
+    const std::tuple<Values...>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+    typedef typename CompositeKey::value_type          value_type;
+    typedef std::tuple<Values...>                      key_tuple;
+    typedef typename detail::cons_stdtuple_ctor<
+      key_tuple>::result_type                          cons_key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_extractor_tuple>::value<=
+      tuples::length<key_eq_tuple>::value&&
+      static_cast<std::size_t>(tuples::length<key_extractor_tuple>::value)==
+      std::tuple_size<key_tuple>::value);
+
+    return detail::equal_ckey_cval<
+      key_extractor_tuple,value_type,
+      cons_key_tuple,key_eq_tuple
+    >::compare(
+      x.composite_key.key_extractors(),x.value,
+      detail::make_cons_stdtuple(y),key_eqs());
+  }
+
+  template<typename CompositeKey,typename... Values>
+  bool operator()(
+    const std::tuple<Values...>& x,
+    const composite_key_result<CompositeKey>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+    typedef typename CompositeKey::value_type          value_type;
+    typedef std::tuple<Values...>                      key_tuple;
+    typedef typename detail::cons_stdtuple_ctor<
+      key_tuple>::result_type                          cons_key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      std::tuple_size<key_tuple>::value<=
+      static_cast<std::size_t>(tuples::length<key_eq_tuple>::value)&&
+      std::tuple_size<key_tuple>::value==
+      static_cast<std::size_t>(tuples::length<key_extractor_tuple>::value));
+
+    return detail::equal_ckey_cval<
+      key_extractor_tuple,value_type,
+      cons_key_tuple,key_eq_tuple
+    >::compare(
+      detail::make_cons_stdtuple(x),y.composite_key.key_extractors(),
+      y.value,key_eqs());
+  }
+#endif
+};
+
+/* composite_key_compare */
+
+template
+<
+  BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_TEMPLATE_PARM,Compare)
+>
+struct composite_key_compare:
+  private tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Compare)>
+{
+private:
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Compare)> super;
+
+public:
+  typedef super key_comp_tuple;
+
+  composite_key_compare(
+    BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_CTOR_ARG,Compare)):
+    super(BOOST_MULTI_INDEX_CK_ENUM_PARAMS(k))
+  {}
+
+  composite_key_compare(const key_comp_tuple& x):super(x){}
+
+  const key_comp_tuple& key_comps()const{return *this;}
+  key_comp_tuple&       key_comps(){return *this;}
+
+  template<typename CompositeKey1,typename CompositeKey2>
+  bool operator()(
+    const composite_key_result<CompositeKey1> & x,
+    const composite_key_result<CompositeKey2> & y)const
+  {
+    typedef typename CompositeKey1::key_extractor_tuple key_extractor_tuple1;
+    typedef typename CompositeKey1::value_type          value_type1;
+    typedef typename CompositeKey2::key_extractor_tuple key_extractor_tuple2;
+    typedef typename CompositeKey2::value_type          value_type2;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_extractor_tuple1>::value<=
+      tuples::length<key_comp_tuple>::value||
+      tuples::length<key_extractor_tuple2>::value<=
+      tuples::length<key_comp_tuple>::value);
+
+    return detail::compare_ckey_ckey<
+      key_extractor_tuple1,value_type1,
+      key_extractor_tuple2,value_type2,
+      key_comp_tuple
+    >::compare(
+      x.composite_key.key_extractors(),x.value,
+      y.composite_key.key_extractors(),y.value,
+      key_comps());
+  }
+  
+#if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+  template<typename CompositeKey,typename Value>
+  bool operator()(
+    const composite_key_result<CompositeKey>& x,
+    const Value& y)const
+  {
+    return operator()(x,boost::make_tuple(boost::cref(y)));
+  }
+#endif
+
+  template
+  <
+    typename CompositeKey,
+    BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value)
+  >
+  bool operator()(
+    const composite_key_result<CompositeKey>& x,
+    const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+    typedef typename CompositeKey::value_type              value_type;
+    typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_extractor_tuple>::value<=
+      tuples::length<key_comp_tuple>::value||
+      tuples::length<key_tuple>::value<=
+      tuples::length<key_comp_tuple>::value);
+
+    return detail::compare_ckey_cval<
+      key_extractor_tuple,value_type,
+      key_tuple,key_comp_tuple
+    >::compare(x.composite_key.key_extractors(),x.value,y,key_comps());
+  }
+
+#if !defined(BOOST_NO_FUNCTION_TEMPLATE_ORDERING)
+  template<typename Value,typename CompositeKey>
+  bool operator()(
+    const Value& x,
+    const composite_key_result<CompositeKey>& y)const
+  {
+    return operator()(boost::make_tuple(boost::cref(x)),y);
+  }
+#endif
+
+  template
+  <
+    BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value),
+    typename CompositeKey
+  >
+  bool operator()(
+    const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& x,
+    const composite_key_result<CompositeKey>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple     key_extractor_tuple;
+    typedef typename CompositeKey::value_type              value_type;
+    typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_tuple>::value<=
+      tuples::length<key_comp_tuple>::value||
+      tuples::length<key_extractor_tuple>::value<=
+      tuples::length<key_comp_tuple>::value);
+
+    return detail::compare_ckey_cval<
+      key_extractor_tuple,value_type,
+      key_tuple,key_comp_tuple
+    >::compare(x,y.composite_key.key_extractors(),y.value,key_comps());
+  }
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)&&\
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+  template<typename CompositeKey,typename... Values>
+  bool operator()(
+    const composite_key_result<CompositeKey>& x,
+    const std::tuple<Values...>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+    typedef typename CompositeKey::value_type          value_type;
+    typedef std::tuple<Values...>                      key_tuple;
+    typedef typename detail::cons_stdtuple_ctor<
+      key_tuple>::result_type                          cons_key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_extractor_tuple>::value<=
+      tuples::length<key_comp_tuple>::value||
+      std::tuple_size<key_tuple>::value<=
+      static_cast<std::size_t>(tuples::length<key_comp_tuple>::value));
+
+    return detail::compare_ckey_cval<
+      key_extractor_tuple,value_type,
+      cons_key_tuple,key_comp_tuple
+    >::compare(
+      x.composite_key.key_extractors(),x.value,
+      detail::make_cons_stdtuple(y),key_comps());
+  }
+
+  template<typename CompositeKey,typename... Values>
+  bool operator()(
+    const std::tuple<Values...>& x,
+    const composite_key_result<CompositeKey>& y)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+    typedef typename CompositeKey::value_type          value_type;
+    typedef std::tuple<Values...>                      key_tuple;
+    typedef typename detail::cons_stdtuple_ctor<
+      key_tuple>::result_type                          cons_key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      std::tuple_size<key_tuple>::value<=
+      static_cast<std::size_t>(tuples::length<key_comp_tuple>::value)||
+      tuples::length<key_extractor_tuple>::value<=
+      tuples::length<key_comp_tuple>::value);
+
+    return detail::compare_ckey_cval<
+      key_extractor_tuple,value_type,
+      cons_key_tuple,key_comp_tuple
+    >::compare(
+      detail::make_cons_stdtuple(x),y.composite_key.key_extractors(),
+      y.value,key_comps());
+  }
+#endif
+};
+
+/* composite_key_hash */
+
+template
+<
+  BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_TEMPLATE_PARM,Hash)
+>
+struct composite_key_hash:
+  private tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Hash)>
+{
+private:
+  typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Hash)> super;
+
+public:
+  typedef super key_hasher_tuple;
+
+  composite_key_hash(
+    BOOST_MULTI_INDEX_CK_ENUM(BOOST_MULTI_INDEX_CK_CTOR_ARG,Hash)):
+    super(BOOST_MULTI_INDEX_CK_ENUM_PARAMS(k))
+  {}
+
+  composite_key_hash(const key_hasher_tuple& x):super(x){}
+
+  const key_hasher_tuple& key_hash_functions()const{return *this;}
+  key_hasher_tuple&       key_hash_functions(){return *this;}
+
+  template<typename CompositeKey>
+  std::size_t operator()(const composite_key_result<CompositeKey> & x)const
+  {
+    typedef typename CompositeKey::key_extractor_tuple key_extractor_tuple;
+    typedef typename CompositeKey::value_type          value_type;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_extractor_tuple>::value==
+      tuples::length<key_hasher_tuple>::value);
+
+    return detail::hash_ckey<
+      key_extractor_tuple,value_type,
+      key_hasher_tuple
+    >::hash(x.composite_key.key_extractors(),x.value,key_hash_functions());
+  }
+  
+  template<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(typename Value)>
+  std::size_t operator()(
+    const tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)>& x)const
+  {
+    typedef tuple<BOOST_MULTI_INDEX_CK_ENUM_PARAMS(Value)> key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      tuples::length<key_tuple>::value==
+      tuples::length<key_hasher_tuple>::value);
+
+    return detail::hash_cval<
+      key_tuple,key_hasher_tuple
+    >::hash(x,key_hash_functions());
+  }
+
+#if !defined(BOOST_NO_CXX11_HDR_TUPLE)&&\
+    !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+  template<typename... Values>
+  std::size_t operator()(const std::tuple<Values...>& x)const
+  {
+    typedef std::tuple<Values...>                key_tuple;
+    typedef typename detail::cons_stdtuple_ctor<
+      key_tuple>::result_type                    cons_key_tuple;
+
+    BOOST_STATIC_ASSERT(
+      std::tuple_size<key_tuple>::value==
+      static_cast<std::size_t>(tuples::length<key_hasher_tuple>::value));
+
+    return detail::hash_cval<
+      cons_key_tuple,key_hasher_tuple
+    >::hash(detail::make_cons_stdtuple(x),key_hash_functions());
+  }
+#endif
+};
+
+/* Instantiations of the former functors with "natural" basic components:
+ * composite_key_result_equal_to uses std::equal_to of the values.
+ * composite_key_result_less     uses std::less.
+ * composite_key_result_greater  uses std::greater.
+ * composite_key_result_hash     uses boost::hash.
+ */
+
+#define BOOST_MULTI_INDEX_CK_RESULT_EQUAL_TO_SUPER                           \
+composite_key_equal_to<                                                      \
+    BOOST_MULTI_INDEX_CK_ENUM(                                               \
+      BOOST_MULTI_INDEX_CK_APPLY_METAFUNCTION_N,                             \
+      /* the argument is a PP list */                                        \
+      (detail::nth_composite_key_equal_to,                                   \
+        (BOOST_DEDUCED_TYPENAME CompositeKeyResult::composite_key_type,      \
+          BOOST_PP_NIL)))                                                    \
+  >
+
+template<typename CompositeKeyResult>
+struct composite_key_result_equal_to:
+BOOST_MULTI_INDEX_PRIVATE_IF_USING_DECL_FOR_TEMPL_FUNCTIONS
+BOOST_MULTI_INDEX_CK_RESULT_EQUAL_TO_SUPER
+{
+private:
+  typedef BOOST_MULTI_INDEX_CK_RESULT_EQUAL_TO_SUPER super;
+
+public:
+  typedef CompositeKeyResult  first_argument_type;
+  typedef first_argument_type second_argument_type;
+  typedef bool                result_type;
+
+  using super::operator();
+};
+
+#define BOOST_MULTI_INDEX_CK_RESULT_LESS_SUPER                               \
+composite_key_compare<                                                       \
+    BOOST_MULTI_INDEX_CK_ENUM(                                               \
+      BOOST_MULTI_INDEX_CK_APPLY_METAFUNCTION_N,                             \
+      /* the argument is a PP list */                                        \
+      (detail::nth_composite_key_less,                                       \
+        (BOOST_DEDUCED_TYPENAME CompositeKeyResult::composite_key_type,      \
+          BOOST_PP_NIL)))                                                    \
+  >
+
+template<typename CompositeKeyResult>
+struct composite_key_result_less:
+BOOST_MULTI_INDEX_PRIVATE_IF_USING_DECL_FOR_TEMPL_FUNCTIONS
+BOOST_MULTI_INDEX_CK_RESULT_LESS_SUPER
+{
+private:
+  typedef BOOST_MULTI_INDEX_CK_RESULT_LESS_SUPER super;
+
+public:
+  typedef CompositeKeyResult  first_argument_type;
+  typedef first_argument_type second_argument_type;
+  typedef bool                result_type;
+
+  using super::operator();
+};
+
+#define BOOST_MULTI_INDEX_CK_RESULT_GREATER_SUPER                            \
+composite_key_compare<                                                       \
+    BOOST_MULTI_INDEX_CK_ENUM(                                               \
+      BOOST_MULTI_INDEX_CK_APPLY_METAFUNCTION_N,                             \
+      /* the argument is a PP list */                                        \
+      (detail::nth_composite_key_greater,                                    \
+        (BOOST_DEDUCED_TYPENAME CompositeKeyResult::composite_key_type,      \
+          BOOST_PP_NIL)))                                                    \
+  >
+
+template<typename CompositeKeyResult>
+struct composite_key_result_greater:
+BOOST_MULTI_INDEX_PRIVATE_IF_USING_DECL_FOR_TEMPL_FUNCTIONS
+BOOST_MULTI_INDEX_CK_RESULT_GREATER_SUPER
+{
+private:
+  typedef BOOST_MULTI_INDEX_CK_RESULT_GREATER_SUPER super;
+
+public:
+  typedef CompositeKeyResult  first_argument_type;
+  typedef first_argument_type second_argument_type;
+  typedef bool                result_type;
+
+  using super::operator();
+};
+
+#define BOOST_MULTI_INDEX_CK_RESULT_HASH_SUPER                               \
+composite_key_hash<                                                          \
+    BOOST_MULTI_INDEX_CK_ENUM(                                               \
+      BOOST_MULTI_INDEX_CK_APPLY_METAFUNCTION_N,                             \
+      /* the argument is a PP list */                                        \
+      (detail::nth_composite_key_hash,                                       \
+        (BOOST_DEDUCED_TYPENAME CompositeKeyResult::composite_key_type,      \
+          BOOST_PP_NIL)))                                                    \
+  >
+
+template<typename CompositeKeyResult>
+struct composite_key_result_hash:
+BOOST_MULTI_INDEX_PRIVATE_IF_USING_DECL_FOR_TEMPL_FUNCTIONS
+BOOST_MULTI_INDEX_CK_RESULT_HASH_SUPER
+{
+private:
+  typedef BOOST_MULTI_INDEX_CK_RESULT_HASH_SUPER super;
+
+public:
+  typedef CompositeKeyResult argument_type;
+  typedef std::size_t        result_type;
+
+  using super::operator();
+};
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+/* Specializations of std::equal_to, std::less, std::greater and boost::hash
+ * for composite_key_results enabling interoperation with tuples of values.
+ */
+
+namespace std{
+
+template<typename CompositeKey>
+struct equal_to<boost::multi_index::composite_key_result<CompositeKey> >:
+  boost::multi_index::composite_key_result_equal_to<
+    boost::multi_index::composite_key_result<CompositeKey>
+  >
+{
+};
+
+template<typename CompositeKey>
+struct less<boost::multi_index::composite_key_result<CompositeKey> >:
+  boost::multi_index::composite_key_result_less<
+    boost::multi_index::composite_key_result<CompositeKey>
+  >
+{
+};
+
+template<typename CompositeKey>
+struct greater<boost::multi_index::composite_key_result<CompositeKey> >:
+  boost::multi_index::composite_key_result_greater<
+    boost::multi_index::composite_key_result<CompositeKey>
+  >
+{
+};
+
+} /* namespace std */
+
+namespace boost{
+
+template<typename CompositeKey>
+struct hash<boost::multi_index::composite_key_result<CompositeKey> >:
+  boost::multi_index::composite_key_result_hash<
+    boost::multi_index::composite_key_result<CompositeKey>
+  >
+{
+};
+
+} /* namespace boost */
+
+#undef BOOST_MULTI_INDEX_CK_RESULT_HASH_SUPER
+#undef BOOST_MULTI_INDEX_CK_RESULT_GREATER_SUPER
+#undef BOOST_MULTI_INDEX_CK_RESULT_LESS_SUPER
+#undef BOOST_MULTI_INDEX_CK_RESULT_EQUAL_TO_SUPER
+#undef BOOST_MULTI_INDEX_CK_COMPLETE_COMP_OPS
+#undef BOOST_MULTI_INDEX_CK_IDENTITY_ENUM_MACRO
+#undef BOOST_MULTI_INDEX_CK_NTH_COMPOSITE_KEY_FUNCTOR
+#undef BOOST_MULTI_INDEX_CK_APPLY_METAFUNCTION_N
+#undef BOOST_MULTI_INDEX_CK_CTOR_ARG
+#undef BOOST_MULTI_INDEX_CK_TEMPLATE_PARM
+#undef BOOST_MULTI_INDEX_CK_ENUM_PARAMS
+#undef BOOST_MULTI_INDEX_CK_ENUM
+#undef BOOST_MULTI_INDEX_COMPOSITE_KEY_SIZE
+
+#endif

--- a/inst/include/boost/multi_index/detail/cons_stdtuple.hpp
+++ b/inst/include/boost/multi_index/detail/cons_stdtuple.hpp
@@ -1,0 +1,93 @@
+/* Copyright 2003-2014 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_DETAIL_CONS_STDTUPLE_HPP
+#define BOOST_MULTI_INDEX_DETAIL_CONS_STDTUPLE_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/mpl/if.hpp>
+#include <boost/tuple/tuple.hpp>
+#include <tuple>
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+/* std::tuple wrapper providing the cons-based interface of boost::tuple for
+ * composite_key interoperability.
+ */
+
+template<typename StdTuple,std::size_t N>
+struct cons_stdtuple;
+
+struct cons_stdtuple_ctor_terminal
+{
+  typedef boost::tuples::null_type result_type;
+
+  template<typename StdTuple>
+  static result_type create(const StdTuple&)
+  {
+    return boost::tuples::null_type();
+  }
+};
+
+template<typename StdTuple,std::size_t N>
+struct cons_stdtuple_ctor_normal
+{
+  typedef cons_stdtuple<StdTuple,N> result_type;
+
+  static result_type create(const StdTuple& t)
+  {
+    return result_type(t);
+  }
+};
+
+template<typename StdTuple,std::size_t N=0>
+struct cons_stdtuple_ctor:
+  boost::mpl::if_c<
+    N<std::tuple_size<StdTuple>::value,
+    cons_stdtuple_ctor_normal<StdTuple,N>,
+    cons_stdtuple_ctor_terminal
+  >::type
+{};
+
+template<typename StdTuple,std::size_t N>
+struct cons_stdtuple
+{
+  typedef typename std::tuple_element<N,StdTuple>::type head_type;
+  typedef cons_stdtuple_ctor<StdTuple,N+1>              tail_ctor;
+  typedef typename tail_ctor::result_type               tail_type;
+  
+  cons_stdtuple(const StdTuple& t_):t(t_){}
+
+  const head_type& get_head()const{return std::get<N>(t);}
+  tail_type get_tail()const{return tail_ctor::create(t);}
+    
+  const StdTuple& t;
+};
+
+template<typename StdTuple>
+typename cons_stdtuple_ctor<StdTuple>::result_type
+make_cons_stdtuple(const StdTuple& t)
+{
+  return cons_stdtuple_ctor<StdTuple>::create(t);
+}
+
+} /* namespace multi_index::detail */
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/detail/rnd_index_loader.hpp
+++ b/inst/include/boost/multi_index/detail/rnd_index_loader.hpp
@@ -1,0 +1,173 @@
+/* Copyright 2003-2013 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_DETAIL_RND_INDEX_LOADER_HPP
+#define BOOST_MULTI_INDEX_DETAIL_RND_INDEX_LOADER_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <algorithm>
+#include <boost/detail/allocator_utilities.hpp>
+#include <boost/multi_index/detail/auto_space.hpp>
+#include <boost/multi_index/detail/rnd_index_ptr_array.hpp>
+#include <boost/noncopyable.hpp>
+#include <cstddef>
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+/* This class implements a serialization rearranger for random access
+ * indices. In order to achieve O(n) performance, the following strategy
+ * is followed: the nodes of the index are handled as if in a bidirectional
+ * list, where the next pointers are stored in the original
+ * random_access_index_ptr_array and the prev pointers are stored in
+ * an auxiliary array. Rearranging of nodes in such a bidirectional list
+ * is constant time. Once all the arrangements are performed (on destruction
+ * time) the list is traversed in reverse order and
+ * pointers are swapped and set accordingly so that they recover its
+ * original semantics ( *(node->up())==node ) while retaining the
+ * new order.
+ */
+
+template<typename Allocator>
+class random_access_index_loader_base:private noncopyable
+{
+protected:
+  typedef random_access_index_node_impl<
+    typename boost::detail::allocator::rebind_to<
+      Allocator,
+      char
+    >::type
+  >                                                 node_impl_type;
+  typedef typename node_impl_type::pointer          node_impl_pointer;
+  typedef random_access_index_ptr_array<Allocator>  ptr_array;
+
+  random_access_index_loader_base(const Allocator& al_,ptr_array& ptrs_):
+    al(al_),
+    ptrs(ptrs_),
+    header(*ptrs.end()),
+    prev_spc(al,0),
+    preprocessed(false)
+  {}
+
+  ~random_access_index_loader_base()
+  {
+    if(preprocessed)
+    {
+      node_impl_pointer n=header;
+      next(n)=n;
+
+      for(std::size_t i=ptrs.size();i--;){
+        n=prev(n);
+        std::size_t d=position(n);
+        if(d!=i){
+          node_impl_pointer m=prev(next_at(i));
+          std::swap(m->up(),n->up());
+          next_at(d)=next_at(i);
+          std::swap(prev_at(d),prev_at(i));
+        }
+        next(n)=n;
+      }
+    }
+  }
+
+  void rearrange(node_impl_pointer position_,node_impl_pointer x)
+  {
+    preprocess(); /* only incur this penalty if rearrange() is ever called */
+    if(position_==node_impl_pointer(0))position_=header;
+    next(prev(x))=next(x);
+    prev(next(x))=prev(x);
+    prev(x)=position_;
+    next(x)=next(position_);
+    next(prev(x))=prev(next(x))=x;
+  }
+
+private:
+  void preprocess()
+  {
+    if(!preprocessed){
+      /* get space for the auxiliary prev array */
+      auto_space<node_impl_pointer,Allocator> tmp(al,ptrs.size()+1);
+      prev_spc.swap(tmp);
+
+      /* prev_spc elements point to the prev nodes */
+      std::rotate_copy(
+        &*ptrs.begin(),&*ptrs.end(),&*ptrs.end()+1,&*prev_spc.data());
+
+      /* ptrs elements point to the next nodes */
+      std::rotate(&*ptrs.begin(),&*ptrs.begin()+1,&*ptrs.end()+1);
+
+      preprocessed=true;
+    }
+  }
+
+  std::size_t position(node_impl_pointer x)const
+  {
+    return (std::size_t)(x->up()-ptrs.begin());
+  }
+
+  node_impl_pointer& next_at(std::size_t n)const
+  {
+    return *ptrs.at(n);
+  }
+
+  node_impl_pointer& prev_at(std::size_t n)const
+  {
+    return *(prev_spc.data()+n);
+  }
+
+  node_impl_pointer& next(node_impl_pointer x)const
+  {
+    return *(x->up());
+  }
+
+  node_impl_pointer& prev(node_impl_pointer x)const
+  {
+    return prev_at(position(x));
+  }
+
+  Allocator                               al;
+  ptr_array&                              ptrs;
+  node_impl_pointer                       header;
+  auto_space<node_impl_pointer,Allocator> prev_spc;
+  bool                                    preprocessed;
+};
+
+template<typename Node,typename Allocator>
+class random_access_index_loader:
+  private random_access_index_loader_base<Allocator>
+{
+  typedef random_access_index_loader_base<Allocator> super;
+  typedef typename super::node_impl_pointer          node_impl_pointer;
+  typedef typename super::ptr_array                  ptr_array;
+
+public:
+  random_access_index_loader(const Allocator& al_,ptr_array& ptrs_):
+    super(al_,ptrs_)
+  {}
+
+  void rearrange(Node* position_,Node *x)
+  {
+    super::rearrange(
+      position_?position_->impl():node_impl_pointer(0),x->impl());
+  }
+};
+
+} /* namespace multi_index::detail */
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/detail/rnd_index_node.hpp
+++ b/inst/include/boost/multi_index/detail/rnd_index_node.hpp
@@ -1,0 +1,273 @@
+/* Copyright 2003-2015 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_DETAIL_RND_INDEX_NODE_HPP
+#define BOOST_MULTI_INDEX_DETAIL_RND_INDEX_NODE_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <algorithm>
+#include <boost/detail/allocator_utilities.hpp>
+#include <boost/integer/common_factor_rt.hpp>
+#include <boost/multi_index/detail/raw_ptr.hpp>
+#include <cstddef>
+#include <functional>
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+template<typename Allocator>
+struct random_access_index_node_impl
+{
+  typedef typename
+  boost::detail::allocator::rebind_to<
+    Allocator,random_access_index_node_impl
+  >::type::pointer                          pointer;
+  typedef typename
+  boost::detail::allocator::rebind_to<
+    Allocator,random_access_index_node_impl
+  >::type::const_pointer                    const_pointer;
+  typedef typename
+  boost::detail::allocator::rebind_to<
+    Allocator,pointer
+  >::type::pointer                          ptr_pointer;
+
+  ptr_pointer& up(){return up_;}
+  ptr_pointer  up()const{return up_;}
+
+  /* interoperability with rnd_node_iterator */
+
+  static void increment(pointer& x)
+  {
+    x=*(x->up()+1);
+  }
+
+  static void decrement(pointer& x)
+  {
+    x=*(x->up()-1);
+  }
+
+  static void advance(pointer& x,std::ptrdiff_t n)
+  {
+    x=*(x->up()+n);
+  }
+
+  static std::ptrdiff_t distance(pointer x,pointer y)
+  {
+    return y->up()-x->up();
+  }
+
+  /* algorithmic stuff */
+
+  static void relocate(ptr_pointer pos,ptr_pointer x)
+  {
+    pointer n=*x;
+    if(x<pos){
+      extract(x,pos);
+      *(pos-1)=n;
+      n->up()=pos-1;
+    }
+    else{
+      while(x!=pos){
+        *x=*(x-1);
+        (*x)->up()=x;
+        --x;
+      }
+      *pos=n;
+      n->up()=pos;
+    }
+  };
+
+  static void relocate(ptr_pointer pos,ptr_pointer first,ptr_pointer last)
+  {
+    ptr_pointer begin,middle,end;
+    if(pos<first){
+      begin=pos;
+      middle=first;
+      end=last;
+    }
+    else{
+      begin=first;
+      middle=last;
+      end=pos;
+    }
+
+    std::ptrdiff_t n=end-begin;
+    std::ptrdiff_t m=middle-begin;
+    std::ptrdiff_t n_m=n-m;
+    std::ptrdiff_t p=integer::gcd(n,m);
+
+    for(std::ptrdiff_t i=0;i<p;++i){
+      pointer tmp=begin[i];
+      for(std::ptrdiff_t j=i,k;;){
+        if(j<n_m)k=j+m;
+        else     k=j-n_m;
+        if(k==i){
+          *(begin+j)=tmp;
+          (*(begin+j))->up()=begin+j;
+          break;
+        }
+        else{
+          *(begin+j)=*(begin+k);
+          (*(begin+j))->up()=begin+j;
+        }
+
+        if(k<n_m)j=k+m;
+        else     j=k-n_m;
+        if(j==i){
+          *(begin+k)=tmp;
+          (*(begin+k))->up()=begin+k;
+          break;
+        }
+        else{
+          *(begin+k)=*(begin+j);
+          (*(begin+k))->up()=begin+k;
+        }
+      }
+    }
+  };
+
+  static void extract(ptr_pointer x,ptr_pointer pend)
+  {
+    --pend;
+    while(x!=pend){
+      *x=*(x+1);
+      (*x)->up()=x;
+      ++x;
+    }
+  }
+
+  static void transfer(
+    ptr_pointer pbegin0,ptr_pointer pend0,ptr_pointer pbegin1)
+  {
+    while(pbegin0!=pend0){
+      *pbegin1=*pbegin0++;
+      (*pbegin1)->up()=pbegin1;
+      ++pbegin1;
+    }
+  }
+
+  static void reverse(ptr_pointer pbegin,ptr_pointer pend)
+  {
+    std::ptrdiff_t d=(pend-pbegin)/2;
+    for(std::ptrdiff_t i=0;i<d;++i){
+      std::swap(*pbegin,*--pend);
+      (*pbegin)->up()=pbegin;
+      (*pend)->up()=pend;
+      ++pbegin;
+    }
+  }
+
+private:
+  ptr_pointer up_;
+};
+
+template<typename Super>
+struct random_access_index_node_trampoline:
+  random_access_index_node_impl<
+    typename boost::detail::allocator::rebind_to<
+      typename Super::allocator_type,
+      char
+    >::type
+  >
+{
+  typedef random_access_index_node_impl<
+    typename boost::detail::allocator::rebind_to<
+      typename Super::allocator_type,
+      char
+    >::type
+  > impl_type;
+};
+
+template<typename Super>
+struct random_access_index_node:
+  Super,random_access_index_node_trampoline<Super>
+{
+private:
+  typedef random_access_index_node_trampoline<Super> trampoline;
+
+public:
+  typedef typename trampoline::impl_type     impl_type;
+  typedef typename trampoline::pointer       impl_pointer;
+  typedef typename trampoline::const_pointer const_impl_pointer;
+  typedef typename trampoline::ptr_pointer   impl_ptr_pointer;
+
+  impl_ptr_pointer& up(){return trampoline::up();}
+  impl_ptr_pointer  up()const{return trampoline::up();}
+
+  impl_pointer impl()
+  {
+    return static_cast<impl_pointer>(
+      static_cast<impl_type*>(static_cast<trampoline*>(this)));
+  }
+
+  const_impl_pointer impl()const
+  {
+    return static_cast<const_impl_pointer>(
+      static_cast<const impl_type*>(static_cast<const trampoline*>(this)));
+  }
+
+  static random_access_index_node* from_impl(impl_pointer x)
+  {
+    return
+      static_cast<random_access_index_node*>(
+        static_cast<trampoline*>(
+          raw_ptr<impl_type*>(x)));
+  }
+
+  static const random_access_index_node* from_impl(const_impl_pointer x)
+  {
+    return
+      static_cast<const random_access_index_node*>(
+        static_cast<const trampoline*>(
+          raw_ptr<const impl_type*>(x)));
+  }
+
+  /* interoperability with rnd_node_iterator */
+
+  static void increment(random_access_index_node*& x)
+  {
+    impl_pointer xi=x->impl();
+    trampoline::increment(xi);
+    x=from_impl(xi);
+  }
+
+  static void decrement(random_access_index_node*& x)
+  {
+    impl_pointer xi=x->impl();
+    trampoline::decrement(xi);
+    x=from_impl(xi);
+  }
+
+  static void advance(random_access_index_node*& x,std::ptrdiff_t n)
+  {
+    impl_pointer xi=x->impl();
+    trampoline::advance(xi,n);
+    x=from_impl(xi);
+  }
+
+  static std::ptrdiff_t distance(
+    random_access_index_node* x,random_access_index_node* y)
+  {
+    return trampoline::distance(x->impl(),y->impl());
+  }
+};
+
+} /* namespace multi_index::detail */
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/detail/rnd_index_ops.hpp
+++ b/inst/include/boost/multi_index/detail/rnd_index_ops.hpp
@@ -1,0 +1,203 @@
+/* Copyright 2003-2015 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_DETAIL_RND_INDEX_OPS_HPP
+#define BOOST_MULTI_INDEX_DETAIL_RND_INDEX_OPS_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <algorithm>
+#include <boost/multi_index/detail/rnd_index_ptr_array.hpp>
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+/* Common code for random_access_index memfuns having templatized and
+ * non-templatized versions.
+ */
+
+template<typename Node,typename Allocator,typename Predicate>
+Node* random_access_index_remove(
+  random_access_index_ptr_array<Allocator>& ptrs,Predicate pred)
+{
+  typedef typename Node::value_type value_type;
+  typedef typename Node::impl_ptr_pointer impl_ptr_pointer;
+
+  impl_ptr_pointer first=ptrs.begin(),
+                   res=first,
+                   last=ptrs.end();
+  for(;first!=last;++first){
+    if(!pred(
+        const_cast<const value_type&>(Node::from_impl(*first)->value()))){
+      if(first!=res){
+        std::swap(*first,*res);
+        (*first)->up()=first;
+        (*res)->up()=res;
+      }
+      ++res;
+    }
+  }
+  return Node::from_impl(*res);
+}
+
+template<typename Node,typename Allocator,class BinaryPredicate>
+Node* random_access_index_unique(
+  random_access_index_ptr_array<Allocator>& ptrs,BinaryPredicate binary_pred)
+{
+  typedef typename Node::value_type       value_type;
+  typedef typename Node::impl_ptr_pointer impl_ptr_pointer;
+
+  impl_ptr_pointer first=ptrs.begin(),
+                   res=first,
+                   last=ptrs.end();
+  if(first!=last){
+    for(;++first!=last;){
+      if(!binary_pred(
+           const_cast<const value_type&>(Node::from_impl(*res)->value()),
+           const_cast<const value_type&>(Node::from_impl(*first)->value()))){
+        ++res;
+        if(first!=res){
+          std::swap(*first,*res);
+          (*first)->up()=first;
+          (*res)->up()=res;
+        }
+      }
+    }
+    ++res;
+  }
+  return Node::from_impl(*res);
+}
+
+template<typename Node,typename Allocator,typename Compare>
+void random_access_index_inplace_merge(
+  const Allocator& al,
+  random_access_index_ptr_array<Allocator>& ptrs,
+  BOOST_DEDUCED_TYPENAME Node::impl_ptr_pointer first1,Compare comp)
+{
+  typedef typename Node::value_type       value_type;
+  typedef typename Node::impl_pointer     impl_pointer;
+  typedef typename Node::impl_ptr_pointer impl_ptr_pointer;
+
+  auto_space<impl_pointer,Allocator> spc(al,ptrs.size());
+
+  impl_ptr_pointer first0=ptrs.begin(),
+                   last0=first1,
+                   last1=ptrs.end(),
+                   out=spc.data();
+  while(first0!=last0&&first1!=last1){
+    if(comp(
+        const_cast<const value_type&>(Node::from_impl(*first1)->value()),
+        const_cast<const value_type&>(Node::from_impl(*first0)->value()))){
+      *out++=*first1++;
+    }
+    else{
+      *out++=*first0++;
+    }
+  }
+  std::copy(&*first0,&*last0,&*out);
+  std::copy(&*first1,&*last1,&*out);
+
+  first1=ptrs.begin();
+  out=spc.data();
+  while(first1!=last1){
+    *first1=*out++;
+    (*first1)->up()=first1;
+    ++first1;
+  }
+}
+
+/* sorting */
+
+/* auxiliary stuff */
+
+template<typename Node,typename Compare>
+struct random_access_index_sort_compare
+{
+  typedef typename Node::impl_pointer first_argument_type;
+  typedef typename Node::impl_pointer second_argument_type;
+  typedef bool                        result_type;
+
+  random_access_index_sort_compare(Compare comp_=Compare()):comp(comp_){}
+
+  bool operator()(
+    typename Node::impl_pointer x,typename Node::impl_pointer y)const
+  {
+    typedef typename Node::value_type value_type;
+
+    return comp(
+      const_cast<const value_type&>(Node::from_impl(x)->value()),
+      const_cast<const value_type&>(Node::from_impl(y)->value()));
+  }
+
+private:
+  Compare comp;
+};
+
+template<typename Node,typename Allocator,class Compare>
+void random_access_index_sort(
+  const Allocator& al,
+  random_access_index_ptr_array<Allocator>& ptrs,
+  Compare comp)
+{
+  /* The implementation is extremely simple: an auxiliary
+   * array of pointers is sorted using stdlib facilities and
+   * then used to rearrange the index. This is suboptimal
+   * in space and time, but has some advantages over other
+   * possible approaches:
+   *   - Use std::stable_sort() directly on ptrs using some
+   *     special iterator in charge of maintaining pointers
+   *     and up() pointers in sync: we cannot guarantee
+   *     preservation of the container invariants in the face of
+   *     exceptions, if, for instance, std::stable_sort throws
+   *     when ptrs transitorily contains duplicate elements.
+   *   - Rewrite the internal algorithms of std::stable_sort
+   *     adapted for this case: besides being a fair amount of
+   *     work, making a stable sort compatible with Boost.MultiIndex
+   *     invariants (basically, no duplicates or missing elements
+   *     even if an exception is thrown) is complicated, error-prone
+   *     and possibly won't perform much better than the
+   *     solution adopted.
+   */
+
+  if(ptrs.size()<=1)return;
+
+  typedef typename Node::impl_pointer       impl_pointer;
+  typedef typename Node::impl_ptr_pointer   impl_ptr_pointer;
+  typedef random_access_index_sort_compare<
+    Node,Compare>                           ptr_compare;
+  
+  impl_ptr_pointer   first=ptrs.begin();
+  impl_ptr_pointer   last=ptrs.end();
+  auto_space<
+    impl_pointer,
+    Allocator>       spc(al,ptrs.size());
+  impl_ptr_pointer   buf=spc.data();
+
+  std::copy(&*first,&*last,&*buf);
+  std::stable_sort(&*buf,&*buf+ptrs.size(),ptr_compare(comp));
+
+  while(first!=last){
+    *first=*buf++;
+    (*first)->up()=first;
+    ++first;
+  }
+}
+
+} /* namespace multi_index::detail */
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/detail/rnd_index_ptr_array.hpp
+++ b/inst/include/boost/multi_index/detail/rnd_index_ptr_array.hpp
@@ -1,0 +1,144 @@
+/* Copyright 2003-2013 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_DETAIL_RND_INDEX_PTR_ARRAY_HPP
+#define BOOST_MULTI_INDEX_DETAIL_RND_INDEX_PTR_ARRAY_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <algorithm>
+#include <boost/detail/allocator_utilities.hpp>
+#include <boost/multi_index/detail/auto_space.hpp>
+#include <boost/multi_index/detail/rnd_index_node.hpp>
+#include <boost/noncopyable.hpp>
+#include <cstddef>
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+/* pointer structure for use by random access indices */
+
+template<typename Allocator>
+class random_access_index_ptr_array:private noncopyable
+{
+  typedef random_access_index_node_impl<
+    typename boost::detail::allocator::rebind_to<
+      Allocator,
+      char
+    >::type
+  >                                                     node_impl_type;
+
+public:
+  typedef typename node_impl_type::pointer              value_type;
+  typedef typename boost::detail::allocator::rebind_to<
+    Allocator,value_type
+  >::type::pointer                                      pointer;
+
+  random_access_index_ptr_array(
+    const Allocator& al,value_type end_,std::size_t sz):
+    size_(sz),
+    capacity_(sz),
+    spc(al,capacity_+1)
+  {
+    *end()=end_;
+    end_->up()=end();
+  }
+
+  std::size_t size()const{return size_;}
+  std::size_t capacity()const{return capacity_;}
+
+  void room_for_one()
+  {
+    if(size_==capacity_){
+      reserve(capacity_<=10?15:capacity_+capacity_/2);
+    }
+  }
+
+  void reserve(std::size_t c)
+  {
+    if(c>capacity_)set_capacity(c);
+  }
+
+  void shrink_to_fit()
+  {
+    if(capacity_>size_)set_capacity(size_);
+  }
+
+  pointer begin()const{return ptrs();}
+  pointer end()const{return ptrs()+size_;}
+  pointer at(std::size_t n)const{return ptrs()+n;}
+
+  void push_back(value_type x)
+  {
+    *(end()+1)=*end();
+    (*(end()+1))->up()=end()+1;
+    *end()=x;
+    (*end())->up()=end();
+    ++size_;
+  }
+
+  void erase(value_type x)
+  {
+    node_impl_type::extract(x->up(),end()+1);
+    --size_;
+  }
+
+  void clear()
+  {
+    *begin()=*end();
+    (*begin())->up()=begin();
+    size_=0;
+  }
+
+  void swap(random_access_index_ptr_array& x)
+  {
+    std::swap(size_,x.size_);
+    std::swap(capacity_,x.capacity_);
+    spc.swap(x.spc);
+  }
+
+private:
+  std::size_t                      size_;
+  std::size_t                      capacity_;
+  auto_space<value_type,Allocator> spc;
+
+  pointer ptrs()const
+  {
+    return spc.data();
+  }
+
+  void set_capacity(std::size_t c)
+  {
+    auto_space<value_type,Allocator> spc1(spc.get_allocator(),c+1);
+    node_impl_type::transfer(begin(),end()+1,spc1.data());
+    spc.swap(spc1);
+    capacity_=c;
+  }
+};
+
+template<typename Allocator>
+void swap(
+  random_access_index_ptr_array<Allocator>& x,
+  random_access_index_ptr_array<Allocator>& y)
+{
+  x.swap(y);
+}
+
+} /* namespace multi_index::detail */
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/detail/rnd_node_iterator.hpp
+++ b/inst/include/boost/multi_index/detail/rnd_node_iterator.hpp
@@ -1,0 +1,140 @@
+/* Copyright 2003-2014 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_DETAIL_RND_NODE_ITERATOR_HPP
+#define BOOST_MULTI_INDEX_DETAIL_RND_NODE_ITERATOR_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/operators.hpp>
+
+#if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
+#endif
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+/* Iterator class for node-based indices with random access iterators. */
+
+template<typename Node>
+class rnd_node_iterator:
+  public random_access_iterator_helper<
+    rnd_node_iterator<Node>,
+    typename Node::value_type,
+    std::ptrdiff_t,
+    const typename Node::value_type*,
+    const typename Node::value_type&>
+{
+public:
+  /* coverity[uninit_ctor]: suppress warning */
+  rnd_node_iterator(){}
+  explicit rnd_node_iterator(Node* node_):node(node_){}
+
+  const typename Node::value_type& operator*()const
+  {
+    return node->value();
+  }
+
+  rnd_node_iterator& operator++()
+  {
+    Node::increment(node);
+    return *this;
+  }
+
+  rnd_node_iterator& operator--()
+  {
+    Node::decrement(node);
+    return *this;
+  }
+
+  rnd_node_iterator& operator+=(std::ptrdiff_t n)
+  {
+    Node::advance(node,n);
+    return *this;
+  }
+
+  rnd_node_iterator& operator-=(std::ptrdiff_t n)
+  {
+    Node::advance(node,-n);
+    return *this;
+  }
+
+#if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
+  /* Serialization. As for why the following is public,
+   * see explanation in safe_mode_iterator notes in safe_mode.hpp.
+   */
+
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
+
+  typedef typename Node::base_type node_base_type;
+
+  template<class Archive>
+  void save(Archive& ar,const unsigned int)const
+  {
+    node_base_type* bnode=node;
+    ar<<serialization::make_nvp("pointer",bnode);
+  }
+
+  template<class Archive>
+  void load(Archive& ar,const unsigned int)
+  {
+    node_base_type* bnode;
+    ar>>serialization::make_nvp("pointer",bnode);
+    node=static_cast<Node*>(bnode);
+  }
+#endif
+
+  /* get_node is not to be used by the user */
+
+  typedef Node node_type;
+
+  Node* get_node()const{return node;}
+
+private:
+  Node* node;
+};
+
+template<typename Node>
+bool operator==(
+  const rnd_node_iterator<Node>& x,
+  const rnd_node_iterator<Node>& y)
+{
+  return x.get_node()==y.get_node();
+}
+
+template<typename Node>
+bool operator<(
+  const rnd_node_iterator<Node>& x,
+  const rnd_node_iterator<Node>& y)
+{
+  return Node::distance(x.get_node(),y.get_node())>0;
+}
+
+template<typename Node>
+std::ptrdiff_t operator-(
+  const rnd_node_iterator<Node>& x,
+  const rnd_node_iterator<Node>& y)
+{
+  return Node::distance(y.get_node(),x.get_node());
+}
+
+} /* namespace multi_index::detail */
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/global_fun.hpp
+++ b/inst/include/boost/multi_index/global_fun.hpp
@@ -1,0 +1,185 @@
+/* Copyright 2003-2015 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_GLOBAL_FUN_HPP
+#define BOOST_MULTI_INDEX_GLOBAL_FUN_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/detail/workaround.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/is_reference.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/utility/enable_if.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/type_traits/is_convertible.hpp>
+#endif
+
+namespace boost{
+
+template<class T> class reference_wrapper; /* fwd decl. */
+
+namespace multi_index{
+
+namespace detail{
+
+/* global_fun is a read-only key extractor from Value based on a given global
+ * (or static member) function with signature:
+ *
+ *   Type f([const] Value [&]);
+ *
+ * Additionally, global_fun  and const_global_fun are overloaded to support
+ * referece_wrappers of Value and "chained pointers" to Value's. By chained
+ * pointer to T we  mean a type P such that, given a p of Type P
+ *   *...n...*x is convertible to T&, for some n>=1.
+ * Examples of chained pointers are raw and smart pointers, iterators and
+ * arbitrary combinations of these (vg. T** or unique_ptr<T*>.)
+ */
+
+template<class Value,typename Type,Type (*PtrToFunction)(Value)>
+struct const_ref_global_fun_base
+{
+  typedef typename remove_reference<Type>::type result_type;
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<const ChainedPtr&,Value>,Type>::type
+#else
+  Type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  Type operator()(Value x)const
+  {
+    return PtrToFunction(x);
+  }
+
+  Type operator()(
+    const reference_wrapper<
+      typename remove_reference<Value>::type>& x)const
+  { 
+    return operator()(x.get());
+  }
+
+  Type operator()(
+    const reference_wrapper<
+      typename remove_const<
+        typename remove_reference<Value>::type>::type>& x
+
+#if BOOST_WORKAROUND(BOOST_MSVC,==1310)
+/* http://lists.boost.org/Archives/boost/2015/10/226135.php */
+    ,int=0
+#endif
+
+  )const
+  { 
+    return operator()(x.get());
+  }
+};
+
+template<class Value,typename Type,Type (*PtrToFunction)(Value)>
+struct non_const_ref_global_fun_base
+{
+  typedef typename remove_reference<Type>::type result_type;
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<ChainedPtr&,Value>,Type>::type
+#else
+  Type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  Type operator()(Value x)const
+  {
+    return PtrToFunction(x);
+  }
+
+  Type operator()(
+    const reference_wrapper<
+      typename remove_reference<Value>::type>& x)const
+  { 
+    return operator()(x.get());
+  }
+};
+
+template<class Value,typename Type,Type (*PtrToFunction)(Value)>
+struct non_ref_global_fun_base
+{
+  typedef typename remove_reference<Type>::type result_type;
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<const ChainedPtr&,const Value&>,Type>::type
+#else
+  Type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  Type operator()(const Value& x)const
+  {
+    return PtrToFunction(x);
+  }
+
+  Type operator()(const reference_wrapper<const Value>& x)const
+  { 
+    return operator()(x.get());
+  }
+
+  Type operator()(
+    const reference_wrapper<typename remove_const<Value>::type>& x)const
+  { 
+    return operator()(x.get());
+  }
+};
+
+} /* namespace multi_index::detail */
+
+template<class Value,typename Type,Type (*PtrToFunction)(Value)>
+struct global_fun:
+  mpl::if_c<
+    is_reference<Value>::value,
+    typename mpl::if_c<
+      is_const<typename remove_reference<Value>::type>::value,
+      detail::const_ref_global_fun_base<Value,Type,PtrToFunction>,
+      detail::non_const_ref_global_fun_base<Value,Type,PtrToFunction>
+    >::type,
+    detail::non_ref_global_fun_base<Value,Type,PtrToFunction>
+  >::type
+{
+};
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/key_extractors.hpp
+++ b/inst/include/boost/multi_index/key_extractors.hpp
@@ -1,0 +1,22 @@
+/* Copyright 2003-2013 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_KEY_EXTRACTORS_HPP
+#define BOOST_MULTI_INDEX_KEY_EXTRACTORS_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/identity.hpp>
+#include <boost/multi_index/global_fun.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+
+#endif

--- a/inst/include/boost/multi_index/mem_fun.hpp
+++ b/inst/include/boost/multi_index/mem_fun.hpp
@@ -1,0 +1,205 @@
+/* Copyright 2003-2015 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_MEM_FUN_HPP
+#define BOOST_MULTI_INDEX_MEM_FUN_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <boost/mpl/if.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/utility/enable_if.hpp>
+
+#if !defined(BOOST_NO_SFINAE)
+#include <boost/type_traits/is_convertible.hpp>
+#endif
+
+namespace boost{
+
+template<class T> class reference_wrapper; /* fwd decl. */
+
+namespace multi_index{
+
+/* mem_fun implements a read-only key extractor based on a given non-const
+ * member function of a class.
+ * const_mem_fun does the same for const member functions.
+ * Additionally, mem_fun  and const_mem_fun are overloaded to support
+ * referece_wrappers of T and "chained pointers" to T's. By chained pointer
+ * to T we  mean a type P such that, given a p of Type P
+ *   *...n...*x is convertible to T&, for some n>=1.
+ * Examples of chained pointers are raw and smart pointers, iterators and
+ * arbitrary combinations of these (vg. T** or unique_ptr<T*>.)
+ */
+
+template<class Class,typename Type,Type (Class::*PtrToMemberFunction)()const>
+struct const_mem_fun
+{
+  typedef typename remove_reference<Type>::type result_type;
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<const ChainedPtr&,const Class&>,Type>::type
+#else
+  Type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  Type operator()(const Class& x)const
+  {
+    return (x.*PtrToMemberFunction)();
+  }
+
+  Type operator()(const reference_wrapper<const Class>& x)const
+  { 
+    return operator()(x.get());
+  }
+
+  Type operator()(const reference_wrapper<Class>& x)const
+  { 
+    return operator()(x.get());
+  }
+};
+
+template<class Class,typename Type,Type (Class::*PtrToMemberFunction)()>
+struct mem_fun
+{
+  typedef typename remove_reference<Type>::type result_type;
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<ChainedPtr&,Class&>,Type>::type
+#else
+  Type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  Type operator()(Class& x)const
+  {
+    return (x.*PtrToMemberFunction)();
+  }
+
+  Type operator()(const reference_wrapper<Class>& x)const
+  { 
+    return operator()(x.get());
+  }
+};
+
+/* MSVC++ 6.0 has problems with const member functions as non-type template
+ * parameters, somehow it takes them as non-const. const_mem_fun_explicit
+ * workarounds this deficiency by accepting an extra type parameter that
+ * specifies the signature of the member function. The workaround was found at:
+ *   Daniel, C.:"Re: weird typedef problem in VC",
+ *   news:microsoft.public.vc.language, 21st nov 2002, 
+ *   http://groups.google.com/groups?
+ *     hl=en&lr=&ie=UTF-8&selm=ukwvg3O0BHA.1512%40tkmsftngp05
+ *
+ * MSVC++ 6.0 support has been dropped and [const_]mem_fun_explicit is
+ * deprecated.
+ */
+
+template<
+  class Class,typename Type,
+  typename PtrToMemberFunctionType,PtrToMemberFunctionType PtrToMemberFunction>
+struct const_mem_fun_explicit
+{
+  typedef typename remove_reference<Type>::type result_type;
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<const ChainedPtr&,const Class&>,Type>::type
+#else
+  Type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  Type operator()(const Class& x)const
+  {
+    return (x.*PtrToMemberFunction)();
+  }
+
+  Type operator()(const reference_wrapper<const Class>& x)const
+  { 
+    return operator()(x.get());
+  }
+
+  Type operator()(const reference_wrapper<Class>& x)const
+  { 
+    return operator()(x.get());
+  }
+};
+
+template<
+  class Class,typename Type,
+  typename PtrToMemberFunctionType,PtrToMemberFunctionType PtrToMemberFunction>
+struct mem_fun_explicit
+{
+  typedef typename remove_reference<Type>::type result_type;
+
+  template<typename ChainedPtr>
+
+#if !defined(BOOST_NO_SFINAE)
+  typename disable_if<
+    is_convertible<ChainedPtr&,Class&>,Type>::type
+#else
+  Type
+#endif
+
+  operator()(const ChainedPtr& x)const
+  {
+    return operator()(*x);
+  }
+
+  Type operator()(Class& x)const
+  {
+    return (x.*PtrToMemberFunction)();
+  }
+
+  Type operator()(const reference_wrapper<Class>& x)const
+  { 
+    return operator()(x.get());
+  }
+};
+
+/* BOOST_MULTI_INDEX_CONST_MEM_FUN and BOOST_MULTI_INDEX_MEM_FUN used to
+ * resolve to [const_]mem_fun_explicit for MSVC++ 6.0 and to
+ * [const_]mem_fun otherwise. Support for this compiler having been dropped,
+ * they are now just wrappers over [const_]mem_fun kept for backwards-
+ * compatibility reasons.
+ */
+
+#define BOOST_MULTI_INDEX_CONST_MEM_FUN(Class,Type,MemberFunName) \
+::boost::multi_index::const_mem_fun< Class,Type,&Class::MemberFunName >
+#define BOOST_MULTI_INDEX_MEM_FUN(Class,Type,MemberFunName) \
+::boost::multi_index::mem_fun< Class,Type,&Class::MemberFunName >
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/multi_index/random_access_index.hpp
+++ b/inst/include/boost/multi_index/random_access_index.hpp
@@ -1,0 +1,1167 @@
+/* Copyright 2003-2015 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_RANDOM_ACCESS_INDEX_HPP
+#define BOOST_MULTI_INDEX_RANDOM_ACCESS_INDEX_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/config.hpp> /* keep it first to prevent nasty warns in MSVC */
+#include <algorithm>
+#include <boost/bind.hpp>
+#include <boost/call_traits.hpp>
+#include <boost/detail/no_exceptions_support.hpp>
+#include <boost/detail/workaround.hpp>
+#include <boost/foreach_fwd.hpp>
+#include <boost/iterator/reverse_iterator.hpp>
+#include <boost/move/core.hpp>
+#include <boost/move/utility.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/mpl/push_front.hpp>
+#include <boost/multi_index/detail/access_specifier.hpp>
+#include <boost/multi_index/detail/do_not_copy_elements_tag.hpp>
+#include <boost/multi_index/detail/index_node_base.hpp>
+#include <boost/multi_index/detail/rnd_node_iterator.hpp>
+#include <boost/multi_index/detail/rnd_index_node.hpp>
+#include <boost/multi_index/detail/rnd_index_ops.hpp>
+#include <boost/multi_index/detail/rnd_index_ptr_array.hpp>
+#include <boost/multi_index/detail/safe_mode.hpp>
+#include <boost/multi_index/detail/scope_guard.hpp>
+#include <boost/multi_index/detail/vartempl_support.hpp>
+#include <boost/multi_index/random_access_index_fwd.hpp>
+#include <boost/throw_exception.hpp> 
+#include <boost/tuple/tuple.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <cstddef>
+#include <functional>
+#include <stdexcept> 
+#include <utility>
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+#include<initializer_list>
+#endif
+
+#if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
+#include <boost/multi_index/detail/rnd_index_loader.hpp>
+#endif
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING)
+#define BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT_OF(x)                    \
+  detail::scope_guard BOOST_JOIN(check_invariant_,__LINE__)=                 \
+    detail::make_obj_guard(x,&random_access_index::check_invariant_);        \
+  BOOST_JOIN(check_invariant_,__LINE__).touch();
+#define BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT                          \
+  BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT_OF(*this)
+#else
+#define BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT_OF(x)
+#define BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT
+#endif
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+/* random_access_index adds a layer of random access indexing
+ * to a given Super
+ */
+
+template<typename SuperMeta,typename TagList>
+class random_access_index:
+  BOOST_MULTI_INDEX_PROTECTED_IF_MEMBER_TEMPLATE_FRIENDS SuperMeta::type
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+  ,public safe_mode::safe_container<
+    random_access_index<SuperMeta,TagList> >
+#endif
+
+{ 
+#if defined(BOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING)&&\
+    BOOST_WORKAROUND(__MWERKS__,<=0x3003)
+/* The "ISO C++ Template Parser" option in CW8.3 has a problem with the
+ * lifetime of const references bound to temporaries --precisely what
+ * scopeguards are.
+ */
+
+#pragma parse_mfunc_templ off
+#endif
+
+  typedef typename SuperMeta::type                 super;
+
+protected:
+  typedef random_access_index_node<
+    typename super::node_type>                     node_type;
+
+private:
+  typedef typename node_type::impl_type            node_impl_type;
+  typedef random_access_index_ptr_array<
+    typename super::final_allocator_type>          ptr_array;
+  typedef typename ptr_array::pointer              node_impl_ptr_pointer;
+
+public:
+  /* types */
+
+  typedef typename node_type::value_type           value_type;
+  typedef tuples::null_type                        ctor_args;
+  typedef typename super::final_allocator_type     allocator_type;
+  typedef typename allocator_type::reference       reference;
+  typedef typename allocator_type::const_reference const_reference;
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+  typedef safe_mode::safe_iterator<
+    rnd_node_iterator<node_type>,
+    random_access_index>                           iterator;
+#else
+  typedef rnd_node_iterator<node_type>             iterator;
+#endif
+
+  typedef iterator                                 const_iterator;
+
+  typedef std::size_t                              size_type;      
+  typedef std::ptrdiff_t                           difference_type;
+  typedef typename allocator_type::pointer         pointer;
+  typedef typename allocator_type::const_pointer   const_pointer;
+  typedef typename
+    boost::reverse_iterator<iterator>              reverse_iterator;
+  typedef typename
+    boost::reverse_iterator<const_iterator>        const_reverse_iterator;
+  typedef TagList                                  tag_list;
+
+protected:
+  typedef typename super::final_node_type     final_node_type;
+  typedef tuples::cons<
+    ctor_args, 
+    typename super::ctor_args_list>           ctor_args_list;
+  typedef typename mpl::push_front<
+    typename super::index_type_list,
+    random_access_index>::type                index_type_list;
+  typedef typename mpl::push_front<
+    typename super::iterator_type_list,
+    iterator>::type                           iterator_type_list;
+  typedef typename mpl::push_front<
+    typename super::const_iterator_type_list,
+    const_iterator>::type                     const_iterator_type_list;
+  typedef typename super::copy_map_type       copy_map_type;
+
+#if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
+  typedef typename super::index_saver_type    index_saver_type;
+  typedef typename super::index_loader_type   index_loader_type;
+#endif
+
+private:
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+  typedef safe_mode::safe_container<
+    random_access_index>                      safe_super;
+#endif
+
+  typedef typename call_traits<
+    value_type>::param_type                   value_param_type;
+
+  /* Needed to avoid commas in BOOST_MULTI_INDEX_OVERLOADS_TO_VARTEMPL
+   * expansion.
+   */
+
+  typedef std::pair<iterator,bool>            emplace_return_type;
+
+public:
+
+  /* construct/copy/destroy
+   * Default and copy ctors are in the protected section as indices are
+   * not supposed to be created on their own. No range ctor either.
+   */
+
+  random_access_index<SuperMeta,TagList>& operator=(
+    const random_access_index<SuperMeta,TagList>& x)
+  {
+    this->final()=x.final();
+    return *this;
+  }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+  random_access_index<SuperMeta,TagList>& operator=(
+    std::initializer_list<value_type> list)
+  {
+    this->final()=list;
+    return *this;
+  }
+#endif
+
+  template <class InputIterator>
+  void assign(InputIterator first,InputIterator last)
+  {
+    assign_iter(first,last,mpl::not_<is_integral<InputIterator> >());
+  }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+  void assign(std::initializer_list<value_type> list)
+  {
+    assign(list.begin(),list.end());
+  }
+#endif
+
+  void assign(size_type n,value_param_type value)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    clear();
+    for(size_type i=0;i<n;++i)push_back(value);
+  }
+    
+  allocator_type get_allocator()const BOOST_NOEXCEPT
+  {
+    return this->final().get_allocator();
+  }
+
+  /* iterators */
+
+  iterator begin()BOOST_NOEXCEPT
+    {return make_iterator(node_type::from_impl(*ptrs.begin()));}
+  const_iterator begin()const BOOST_NOEXCEPT
+    {return make_iterator(node_type::from_impl(*ptrs.begin()));}
+  iterator
+    end()BOOST_NOEXCEPT{return make_iterator(header());}
+  const_iterator
+    end()const BOOST_NOEXCEPT{return make_iterator(header());}
+  reverse_iterator
+    rbegin()BOOST_NOEXCEPT{return boost::make_reverse_iterator(end());}
+  const_reverse_iterator
+    rbegin()const BOOST_NOEXCEPT{return boost::make_reverse_iterator(end());}
+  reverse_iterator
+    rend()BOOST_NOEXCEPT{return boost::make_reverse_iterator(begin());}
+  const_reverse_iterator
+    rend()const BOOST_NOEXCEPT{return boost::make_reverse_iterator(begin());}
+  const_iterator
+    cbegin()const BOOST_NOEXCEPT{return begin();}
+  const_iterator
+    cend()const BOOST_NOEXCEPT{return end();}
+  const_reverse_iterator
+    crbegin()const BOOST_NOEXCEPT{return rbegin();}
+  const_reverse_iterator
+    crend()const BOOST_NOEXCEPT{return rend();}
+
+  iterator iterator_to(const value_type& x)
+  {
+    return make_iterator(node_from_value<node_type>(&x));
+  }
+
+  const_iterator iterator_to(const value_type& x)const
+  {
+    return make_iterator(node_from_value<node_type>(&x));
+  }
+
+  /* capacity */
+
+  bool      empty()const BOOST_NOEXCEPT{return this->final_empty_();}
+  size_type size()const BOOST_NOEXCEPT{return this->final_size_();}
+  size_type max_size()const BOOST_NOEXCEPT{return this->final_max_size_();}
+  size_type capacity()const BOOST_NOEXCEPT{return ptrs.capacity();}
+
+  void reserve(size_type n)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    ptrs.reserve(n);
+  }
+  
+  void shrink_to_fit()
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    ptrs.shrink_to_fit();
+  }
+
+  void resize(size_type n)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    if(n>size())
+      for(size_type m=n-size();m--;)
+        this->final_emplace_(BOOST_MULTI_INDEX_NULL_PARAM_PACK);
+    else if(n<size())erase(begin()+n,end());
+  }
+
+  void resize(size_type n,value_param_type x)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    if(n>size())for(size_type m=n-size();m--;)this->final_insert_(x); 
+    else if(n<size())erase(begin()+n,end());
+  }
+
+  /* access: no non-const versions provided as random_access_index
+   * handles const elements.
+   */
+
+  const_reference operator[](size_type n)const
+  {
+    BOOST_MULTI_INDEX_SAFE_MODE_ASSERT(n<size(),safe_mode::out_of_bounds);
+    return node_type::from_impl(*ptrs.at(n))->value();
+  }
+
+  const_reference at(size_type n)const
+  {
+    if(n>=size())throw_exception(std::out_of_range("random access index"));
+    return node_type::from_impl(*ptrs.at(n))->value();
+  }
+
+  const_reference front()const{return operator[](0);}
+  const_reference back()const{return operator[](size()-1);}
+
+  /* modifiers */
+
+  BOOST_MULTI_INDEX_OVERLOADS_TO_VARTEMPL(
+    emplace_return_type,emplace_front,emplace_front_impl)
+    
+  std::pair<iterator,bool> push_front(const value_type& x)
+                             {return insert(begin(),x);}
+  std::pair<iterator,bool> push_front(BOOST_RV_REF(value_type) x)
+                             {return insert(begin(),boost::move(x));}
+  void                     pop_front(){erase(begin());}
+
+  BOOST_MULTI_INDEX_OVERLOADS_TO_VARTEMPL(
+    emplace_return_type,emplace_back,emplace_back_impl)
+
+  std::pair<iterator,bool> push_back(const value_type& x)
+                             {return insert(end(),x);}
+  std::pair<iterator,bool> push_back(BOOST_RV_REF(value_type) x)
+                             {return insert(end(),boost::move(x));}
+  void                     pop_back(){erase(--end());}
+
+  BOOST_MULTI_INDEX_OVERLOADS_TO_VARTEMPL_EXTRA_ARG(
+    emplace_return_type,emplace,emplace_impl,iterator,position)
+    
+  std::pair<iterator,bool> insert(iterator position,const value_type& x)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    std::pair<final_node_type*,bool> p=this->final_insert_(x);
+    if(p.second&&position.get_node()!=header()){
+      relocate(position.get_node(),p.first);
+    }
+    return std::pair<iterator,bool>(make_iterator(p.first),p.second);
+  }
+
+  std::pair<iterator,bool> insert(iterator position,BOOST_RV_REF(value_type) x)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    std::pair<final_node_type*,bool> p=this->final_insert_rv_(x);
+    if(p.second&&position.get_node()!=header()){
+      relocate(position.get_node(),p.first);
+    }
+    return std::pair<iterator,bool>(make_iterator(p.first),p.second);
+  }
+
+  void insert(iterator position,size_type n,value_param_type x)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    size_type s=0;
+    BOOST_TRY{
+      while(n--){
+        if(push_back(x).second)++s;
+      }
+    }
+    BOOST_CATCH(...){
+      relocate(position,end()-s,end());
+      BOOST_RETHROW;
+    }
+    BOOST_CATCH_END
+    relocate(position,end()-s,end());
+  }
+ 
+  template<typename InputIterator>
+  void insert(iterator position,InputIterator first,InputIterator last)
+  {
+    insert_iter(position,first,last,mpl::not_<is_integral<InputIterator> >());
+  }
+
+#if !defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST)
+  void insert(iterator position,std::initializer_list<value_type> list)
+  {
+    insert(position,list.begin(),list.end());
+  }
+#endif
+
+  iterator erase(iterator position)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_DEREFERENCEABLE_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    this->final_erase_(static_cast<final_node_type*>(position++.get_node()));
+    return position;
+  }
+  
+  iterator erase(iterator first,iterator last)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(first);
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(last);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(first,*this);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(last,*this);
+    BOOST_MULTI_INDEX_CHECK_VALID_RANGE(first,last);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    difference_type n=last-first;
+    relocate(end(),first,last);
+    while(n--)pop_back();
+    return last;
+  }
+
+  bool replace(iterator position,const value_type& x)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_DEREFERENCEABLE_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    return this->final_replace_(
+      x,static_cast<final_node_type*>(position.get_node()));
+  }
+
+  bool replace(iterator position,BOOST_RV_REF(value_type) x)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_DEREFERENCEABLE_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    return this->final_replace_rv_(
+      x,static_cast<final_node_type*>(position.get_node()));
+  }
+
+  template<typename Modifier>
+  bool modify(iterator position,Modifier mod)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_DEREFERENCEABLE_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    /* MSVC++ 6.0 optimizer on safe mode code chokes if this
+     * this is not added. Left it for all compilers as it does no
+     * harm.
+     */
+
+    position.detach();
+#endif
+
+    return this->final_modify_(
+      mod,static_cast<final_node_type*>(position.get_node()));
+  }
+
+  template<typename Modifier,typename Rollback>
+  bool modify(iterator position,Modifier mod,Rollback back_)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_DEREFERENCEABLE_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    /* MSVC++ 6.0 optimizer on safe mode code chokes if this
+     * this is not added. Left it for all compilers as it does no
+     * harm.
+     */
+
+    position.detach();
+#endif
+
+    return this->final_modify_(
+      mod,back_,static_cast<final_node_type*>(position.get_node()));
+  }
+
+  void swap(random_access_index<SuperMeta,TagList>& x)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT_OF(x);
+    this->final_swap_(x.final());
+  }
+
+  void clear()BOOST_NOEXCEPT
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    this->final_clear_();
+  }
+
+  /* list operations */
+
+  void splice(iterator position,random_access_index<SuperMeta,TagList>& x)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_CHECK_DIFFERENT_CONTAINER(*this,x);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    iterator  first=x.begin(),last=x.end();
+    size_type n=0;
+    BOOST_TRY{
+      while(first!=last){
+        if(push_back(*first).second){
+          first=x.erase(first);
+          ++n;
+        }
+        else ++first;
+      }
+    }
+    BOOST_CATCH(...){
+      relocate(position,end()-n,end());
+      BOOST_RETHROW;
+    }
+    BOOST_CATCH_END
+    relocate(position,end()-n,end());
+  }
+
+  void splice(
+    iterator position,random_access_index<SuperMeta,TagList>& x,iterator i)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(i);
+    BOOST_MULTI_INDEX_CHECK_DEREFERENCEABLE_ITERATOR(i);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(i,x);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    if(&x==this)relocate(position,i);
+    else{
+      if(insert(position,*i).second){
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    /* MSVC++ 6.0 optimizer has a hard time with safe mode, and the following
+     * workaround is needed. Left it for all compilers as it does no
+     * harm.
+     */
+        i.detach();
+        x.erase(x.make_iterator(i.get_node()));
+#else
+        x.erase(i);
+#endif
+
+      }
+    }
+  }
+
+  void splice(
+    iterator position,random_access_index<SuperMeta,TagList>& x,
+    iterator first,iterator last)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(first);
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(last);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(first,x);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(last,x);
+    BOOST_MULTI_INDEX_CHECK_VALID_RANGE(first,last);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    if(&x==this)relocate(position,first,last);
+    else{
+      size_type n=0;
+      BOOST_TRY{
+        while(first!=last){
+          if(push_back(*first).second){
+            first=x.erase(first);
+            ++n;
+          }
+          else ++first;
+        }
+      }
+      BOOST_CATCH(...){
+        relocate(position,end()-n,end());
+        BOOST_RETHROW;
+      }
+      BOOST_CATCH_END
+      relocate(position,end()-n,end());
+    }
+  }
+
+  void remove(value_param_type value)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    difference_type n=
+      end()-make_iterator(
+        random_access_index_remove<node_type>(
+          ptrs,
+          ::boost::bind(std::equal_to<value_type>(),::boost::arg<1>(),value)));
+    while(n--)pop_back();
+  }
+
+  template<typename Predicate>
+  void remove_if(Predicate pred)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    difference_type n=
+      end()-make_iterator(random_access_index_remove<node_type>(ptrs,pred));
+    while(n--)pop_back();
+  }
+
+  void unique()
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    difference_type n=
+      end()-make_iterator(
+        random_access_index_unique<node_type>(
+          ptrs,std::equal_to<value_type>()));
+    while(n--)pop_back();
+  }
+
+  template <class BinaryPredicate>
+  void unique(BinaryPredicate binary_pred)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    difference_type n=
+      end()-make_iterator(
+        random_access_index_unique<node_type>(ptrs,binary_pred));
+    while(n--)pop_back();
+  }
+
+  void merge(random_access_index<SuperMeta,TagList>& x)
+  {
+    if(this!=&x){
+      BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+      size_type s=size();
+      splice(end(),x);
+      random_access_index_inplace_merge<node_type>(
+        get_allocator(),ptrs,ptrs.at(s),std::less<value_type>());
+    }
+  }
+
+  template <typename Compare>
+  void merge(random_access_index<SuperMeta,TagList>& x,Compare comp)
+  {
+    if(this!=&x){
+      BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+      size_type s=size();
+      splice(end(),x);
+      random_access_index_inplace_merge<node_type>(
+        get_allocator(),ptrs,ptrs.at(s),comp);
+    }
+  }
+
+  void sort()
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    random_access_index_sort<node_type>(
+      get_allocator(),ptrs,std::less<value_type>());
+  }
+
+  template <typename Compare>
+  void sort(Compare comp)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    random_access_index_sort<node_type>(
+      get_allocator(),ptrs,comp);
+  }
+
+  void reverse()BOOST_NOEXCEPT
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    node_impl_type::reverse(ptrs.begin(),ptrs.end());
+  }
+
+  /* rearrange operations */
+
+  void relocate(iterator position,iterator i)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(i);
+    BOOST_MULTI_INDEX_CHECK_DEREFERENCEABLE_ITERATOR(i);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(i,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    if(position!=i)relocate(position.get_node(),i.get_node());
+  }
+
+  void relocate(iterator position,iterator first,iterator last)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(first);
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(last);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(first,*this);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(last,*this);
+    BOOST_MULTI_INDEX_CHECK_VALID_RANGE(first,last);
+    BOOST_MULTI_INDEX_CHECK_OUTSIDE_RANGE(position,first,last);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    if(position!=last)relocate(
+      position.get_node(),first.get_node(),last.get_node());
+  }
+
+  template<typename InputIterator>
+  void rearrange(InputIterator first)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    for(node_impl_ptr_pointer p0=ptrs.begin(),p0_end=ptrs.end();
+        p0!=p0_end;++first,++p0){
+      const value_type& v1=*first;
+      node_impl_ptr_pointer p1=node_from_value<node_type>(&v1)->up();
+
+      std::swap(*p0,*p1);
+      (*p0)->up()=p0;
+      (*p1)->up()=p1;
+    }
+  }
+    
+BOOST_MULTI_INDEX_PROTECTED_IF_MEMBER_TEMPLATE_FRIENDS:
+  random_access_index(
+    const ctor_args_list& args_list,const allocator_type& al):
+    super(args_list.get_tail(),al),
+    ptrs(al,header()->impl(),0)
+  {
+  }
+
+  random_access_index(const random_access_index<SuperMeta,TagList>& x):
+    super(x),
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    safe_super(),
+#endif
+
+    ptrs(x.get_allocator(),header()->impl(),x.size())
+  {
+    /* The actual copying takes place in subsequent call to copy_().
+     */
+  }
+
+  random_access_index(
+    const random_access_index<SuperMeta,TagList>& x,do_not_copy_elements_tag):
+    super(x,do_not_copy_elements_tag()),
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    safe_super(),
+#endif
+
+    ptrs(x.get_allocator(),header()->impl(),0)
+  {
+  }
+
+  ~random_access_index()
+  {
+    /* the container is guaranteed to be empty by now */
+  }
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+  iterator       make_iterator(node_type* node){return iterator(node,this);}
+  const_iterator make_iterator(node_type* node)const
+    {return const_iterator(node,const_cast<random_access_index*>(this));}
+#else
+  iterator       make_iterator(node_type* node){return iterator(node);}
+  const_iterator make_iterator(node_type* node)const
+                   {return const_iterator(node);}
+#endif
+
+  void copy_(
+    const random_access_index<SuperMeta,TagList>& x,const copy_map_type& map)
+  {
+    for(node_impl_ptr_pointer begin_org=x.ptrs.begin(),
+                              begin_cpy=ptrs.begin(),
+                              end_org=x.ptrs.end();
+        begin_org!=end_org;++begin_org,++begin_cpy){
+      *begin_cpy=
+         static_cast<node_type*>(
+           map.find(
+             static_cast<final_node_type*>(
+               node_type::from_impl(*begin_org))))->impl();
+      (*begin_cpy)->up()=begin_cpy;
+    }
+
+    super::copy_(x,map);
+  }
+
+  template<typename Variant>
+  final_node_type* insert_(
+    value_param_type v,final_node_type*& x,Variant variant)
+  {
+    ptrs.room_for_one();
+    final_node_type* res=super::insert_(v,x,variant);
+    if(res==x)ptrs.push_back(static_cast<node_type*>(x)->impl());
+    return res;
+  }
+
+  template<typename Variant>
+  final_node_type* insert_(
+    value_param_type v,node_type* position,final_node_type*& x,Variant variant)
+  {
+    ptrs.room_for_one();
+    final_node_type* res=super::insert_(v,position,x,variant);
+    if(res==x)ptrs.push_back(static_cast<node_type*>(x)->impl());
+    return res;
+  }
+
+  void erase_(node_type* x)
+  {
+    ptrs.erase(x->impl());
+    super::erase_(x);
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    detach_iterators(x);
+#endif
+  }
+
+  void delete_all_nodes_()
+  {
+    for(node_impl_ptr_pointer x=ptrs.begin(),x_end=ptrs.end();x!=x_end;++x){
+      this->final_delete_node_(
+        static_cast<final_node_type*>(node_type::from_impl(*x)));
+    }
+  }
+
+  void clear_()
+  {
+    super::clear_();
+    ptrs.clear();
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    safe_super::detach_dereferenceable_iterators();
+#endif
+  }
+
+  void swap_(random_access_index<SuperMeta,TagList>& x)
+  {
+    ptrs.swap(x.ptrs);
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    safe_super::swap(x);
+#endif
+
+    super::swap_(x);
+  }
+
+  void swap_elements_(random_access_index<SuperMeta,TagList>& x)
+  {
+    ptrs.swap(x.ptrs);
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+    safe_super::swap(x);
+#endif
+
+    super::swap_elements_(x);
+  }
+
+  template<typename Variant>
+  bool replace_(value_param_type v,node_type* x,Variant variant)
+  {
+    return super::replace_(v,x,variant);
+  }
+
+  bool modify_(node_type* x)
+  {
+    BOOST_TRY{
+      if(!super::modify_(x)){
+        ptrs.erase(x->impl());
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+        detach_iterators(x);
+#endif
+
+        return false;
+      }
+      else return true;
+    }
+    BOOST_CATCH(...){
+      ptrs.erase(x->impl());
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+      detach_iterators(x);
+#endif
+
+      BOOST_RETHROW;
+    }
+    BOOST_CATCH_END
+  }
+
+  bool modify_rollback_(node_type* x)
+  {
+    return super::modify_rollback_(x);
+  }
+
+#if !defined(BOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
+  /* serialization */
+
+  template<typename Archive>
+  void save_(
+    Archive& ar,const unsigned int version,const index_saver_type& sm)const
+  {
+    sm.save(begin(),end(),ar,version);
+    super::save_(ar,version,sm);
+  }
+
+  template<typename Archive>
+  void load_(
+    Archive& ar,const unsigned int version,const index_loader_type& lm)
+  {
+    {
+      typedef random_access_index_loader<node_type,allocator_type> loader;
+
+      loader ld(get_allocator(),ptrs);
+      lm.load(
+        ::boost::bind(
+          &loader::rearrange,&ld,::boost::arg<1>(),::boost::arg<2>()),
+        ar,version);
+    } /* exit scope so that ld frees its resources */
+    super::load_(ar,version,lm);
+  }
+#endif
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING)
+  /* invariant stuff */
+
+  bool invariant_()const
+  {
+    if(size()>capacity())return false;
+    if(size()==0||begin()==end()){
+      if(size()!=0||begin()!=end())return false;
+    }
+    else{
+      size_type s=0;
+      for(const_iterator it=begin(),it_end=end();;++it,++s){
+        if(*(it.get_node()->up())!=it.get_node()->impl())return false;
+        if(it==it_end)break;
+      }
+      if(s!=size())return false;
+    }
+
+    return super::invariant_();
+  }
+
+  /* This forwarding function eases things for the boost::mem_fn construct
+   * in BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT. Actually,
+   * final_check_invariant is already an inherited member function of index.
+   */
+  void check_invariant_()const{this->final_check_invariant_();}
+#endif
+
+private:
+  node_type* header()const{return this->final_header();}
+
+  static void relocate(node_type* position,node_type* x)
+  {
+    node_impl_type::relocate(position->up(),x->up());
+  }
+
+  static void relocate(node_type* position,node_type* first,node_type* last)
+  {
+    node_impl_type::relocate(
+      position->up(),first->up(),last->up());
+  }
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_SAFE_MODE)
+  void detach_iterators(node_type* x)
+  {
+    iterator it=make_iterator(x);
+    safe_mode::detach_equivalent_iterators(it);
+  }
+#endif
+
+  template <class InputIterator>
+  void assign_iter(InputIterator first,InputIterator last,mpl::true_)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    clear();
+    for(;first!=last;++first)this->final_insert_ref_(*first);
+  }
+
+  void assign_iter(size_type n,value_param_type value,mpl::false_)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    clear();
+    for(size_type i=0;i<n;++i)push_back(value);
+  }
+
+  template<typename InputIterator>
+  void insert_iter(
+    iterator position,InputIterator first,InputIterator last,mpl::true_)
+  {
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    size_type s=0;
+    BOOST_TRY{
+      for(;first!=last;++first){
+        if(this->final_insert_ref_(*first).second)++s;
+      }
+    }
+    BOOST_CATCH(...){
+      relocate(position,end()-s,end());
+      BOOST_RETHROW;
+    }
+    BOOST_CATCH_END
+    relocate(position,end()-s,end());
+  }
+
+  void insert_iter(
+    iterator position,size_type n,value_param_type x,mpl::false_)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    size_type  s=0;
+    BOOST_TRY{
+      while(n--){
+        if(push_back(x).second)++s;
+      }
+    }
+    BOOST_CATCH(...){
+      relocate(position,end()-s,end());
+      BOOST_RETHROW;
+    }
+    BOOST_CATCH_END
+    relocate(position,end()-s,end());
+  }
+ 
+  template<BOOST_MULTI_INDEX_TEMPLATE_PARAM_PACK>
+  std::pair<iterator,bool> emplace_front_impl(
+    BOOST_MULTI_INDEX_FUNCTION_PARAM_PACK)
+  {
+    return emplace_impl(begin(),BOOST_MULTI_INDEX_FORWARD_PARAM_PACK);
+  }
+
+  template<BOOST_MULTI_INDEX_TEMPLATE_PARAM_PACK>
+  std::pair<iterator,bool> emplace_back_impl(
+    BOOST_MULTI_INDEX_FUNCTION_PARAM_PACK)
+  {
+    return emplace_impl(end(),BOOST_MULTI_INDEX_FORWARD_PARAM_PACK);
+  }
+
+  template<BOOST_MULTI_INDEX_TEMPLATE_PARAM_PACK>
+  std::pair<iterator,bool> emplace_impl(
+    iterator position,BOOST_MULTI_INDEX_FUNCTION_PARAM_PACK)
+  {
+    BOOST_MULTI_INDEX_CHECK_VALID_ITERATOR(position);
+    BOOST_MULTI_INDEX_CHECK_IS_OWNER(position,*this);
+    BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT;
+    std::pair<final_node_type*,bool> p=
+      this->final_emplace_(BOOST_MULTI_INDEX_FORWARD_PARAM_PACK);
+    if(p.second&&position.get_node()!=header()){
+      relocate(position.get_node(),p.first);
+    }
+    return std::pair<iterator,bool>(make_iterator(p.first),p.second);
+  }
+
+  ptr_array ptrs;
+
+#if defined(BOOST_MULTI_INDEX_ENABLE_INVARIANT_CHECKING)&&\
+    BOOST_WORKAROUND(__MWERKS__,<=0x3003)
+#pragma parse_mfunc_templ reset
+#endif
+};
+
+/* comparison */
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator==(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y)
+{
+  return x.size()==y.size()&&std::equal(x.begin(),x.end(),y.begin());
+}
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator<(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y)
+{
+  return std::lexicographical_compare(x.begin(),x.end(),y.begin(),y.end());
+}
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator!=(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y)
+{
+  return !(x==y);
+}
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator>(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y)
+{
+  return y<x;
+}
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator>=(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y)
+{
+  return !(x<y);
+}
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator<=(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y)
+{
+  return !(x>y);
+}
+
+/*  specialized algorithms */
+
+template<typename SuperMeta,typename TagList>
+void swap(
+  random_access_index<SuperMeta,TagList>& x,
+  random_access_index<SuperMeta,TagList>& y)
+{
+  x.swap(y);
+}
+
+} /* namespace multi_index::detail */
+
+/* random access index specifier */
+
+template <typename TagList>
+struct random_access
+{
+  BOOST_STATIC_ASSERT(detail::is_tag<TagList>::value);
+
+  template<typename Super>
+  struct node_class
+  {
+    typedef detail::random_access_index_node<Super> type;
+  };
+
+  template<typename SuperMeta>
+  struct index_class
+  {
+    typedef detail::random_access_index<
+      SuperMeta,typename TagList::type>  type;
+  };
+};
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+/* Boost.Foreach compatibility */
+
+template<typename SuperMeta,typename TagList>
+inline boost::mpl::true_* boost_foreach_is_noncopyable(
+  boost::multi_index::detail::random_access_index<SuperMeta,TagList>*&,
+  boost_foreach_argument_dependent_lookup_hack)
+{
+  return 0;
+}
+
+#undef BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT
+#undef BOOST_MULTI_INDEX_RND_INDEX_CHECK_INVARIANT_OF
+
+#endif

--- a/inst/include/boost/multi_index/random_access_index_fwd.hpp
+++ b/inst/include/boost/multi_index/random_access_index_fwd.hpp
@@ -1,0 +1,91 @@
+/* Copyright 2003-2013 Joaquin M Lopez Munoz.
+ * Distributed under the Boost Software License, Version 1.0.
+ * (See accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ *
+ * See http://www.boost.org/libs/multi_index for library home page.
+ */
+
+#ifndef BOOST_MULTI_INDEX_RANDOM_ACCESS_INDEX_FWD_HPP
+#define BOOST_MULTI_INDEX_RANDOM_ACCESS_INDEX_FWD_HPP
+
+#if defined(_MSC_VER)
+#pragma once
+#endif
+
+#include <boost/multi_index/tag.hpp>
+
+namespace boost{
+
+namespace multi_index{
+
+namespace detail{
+
+template<typename SuperMeta,typename TagList>
+class random_access_index;
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator==(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y);
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator<(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y);
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator!=(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y);
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator>(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y);
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator>=(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y);
+
+template<
+  typename SuperMeta1,typename TagList1,
+  typename SuperMeta2,typename TagList2
+>
+bool operator<=(
+  const random_access_index<SuperMeta1,TagList1>& x,
+  const random_access_index<SuperMeta2,TagList2>& y);
+
+template<typename SuperMeta,typename TagList>
+void swap(
+  random_access_index<SuperMeta,TagList>& x,
+  random_access_index<SuperMeta,TagList>& y);
+
+} /* namespace multi_index::detail */
+
+/* index specifiers */
+
+template <typename TagList=tag<> >
+struct random_access;
+
+} /* namespace multi_index */
+
+} /* namespace boost */
+
+#endif

--- a/inst/include/boost/numeric/odeint/stepper/generation.hpp
+++ b/inst/include/boost/numeric/odeint/stepper/generation.hpp
@@ -24,7 +24,7 @@
 #include <boost/numeric/odeint/stepper/generation/generation_controlled_runge_kutta.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_dense_output_runge_kutta.hpp>
 
-#include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_cl.hpp>
+#include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_dopri5.hpp>
 #include <boost/numeric/odeint/stepper/generation/generation_runge_kutta_fehlberg78.hpp>

--- a/inst/include/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp
+++ b/inst/include/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp
@@ -1,0 +1,48 @@
+/*
+ [auto_generated]
+ boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp
+
+ [begin_description]
+ Enable the factory functions for the controller and the dense output of the
+ Runge-Kutta-Cash-Karp 54 method with the classical implementation.
+ [end_description]
+
+ Copyright 2011 Karsten Ahnert
+ Copyright 2011 Mario Mulansky
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+
+#ifndef BOOST_NUMERIC_ODEINT_STEPPER_GENERATION_GENERATION_RUNGE_KUTTA_CASH_KARP54_CLASSIC_HPP_INCLUDED
+#define BOOST_NUMERIC_ODEINT_STEPPER_GENERATION_GENERATION_RUNGE_KUTTA_CASH_KARP54_CLASSIC_HPP_INCLUDED
+
+#include <boost/numeric/odeint/stepper/controlled_runge_kutta.hpp>
+#include <boost/numeric/odeint/stepper/runge_kutta_cash_karp54_classic.hpp>
+#include <boost/numeric/odeint/stepper/generation/make_controlled.hpp>
+
+
+namespace boost {
+namespace numeric {
+namespace odeint {
+
+
+// Specializations for runge_kutta_cash_karp54
+template< class State , class Value , class Deriv , class Time , class Algebra , class Operations , class Resize >
+struct get_controller< runge_kutta_cash_karp54_classic< State , Value , Deriv , Time , Algebra , Operations , Resize > >
+{
+    typedef runge_kutta_cash_karp54_classic< State , Value , Deriv , Time , Algebra , Operations , Resize > stepper_type;
+    typedef controlled_runge_kutta< stepper_type > type;
+};
+
+
+
+
+} // odeint
+} // numeric
+} // boost
+
+
+#endif // BOOST_NUMERIC_ODEINT_STEPPER_GENERATION_GENERATION_RUNGE_KUTTA_CASH_KARP54_CLASSIC_HPP_INCLUDED

--- a/inst/include/boost/xpressive/detail/core/matcher/action_matcher.hpp
+++ b/inst/include/boost/xpressive/detail/core/matcher/action_matcher.hpp
@@ -1,0 +1,501 @@
+///////////////////////////////////////////////////////////////////////////////
+// action_matcher.hpp
+//
+//  Copyright 2008 Eric Niebler.
+//  Copyright 2008 David Jenkins.
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_CORE_MATCHER_ACTION_MATCHER_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_DETAIL_CORE_MATCHER_ACTION_MATCHER_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/config.hpp>
+#include <boost/version.hpp>
+#include <boost/ref.hpp>
+#include <boost/assert.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/utility/result_of.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/core/quant_style.hpp>
+#include <boost/xpressive/detail/core/action.hpp>
+#include <boost/xpressive/detail/core/state.hpp>
+#include <boost/proto/core.hpp>
+#include <boost/proto/context.hpp>
+#include <boost/xpressive/match_results.hpp> // for type_info_less
+#include <boost/xpressive/detail/static/transforms/as_action.hpp> // for 'read_attr'
+#if BOOST_VERSION >= 103500
+# include <boost/proto/fusion.hpp>
+# include <boost/fusion/include/transform_view.hpp>
+# include <boost/fusion/include/invoke.hpp>
+# include <boost/fusion/include/push_front.hpp>
+# include <boost/fusion/include/pop_front.hpp>
+#endif
+
+#if BOOST_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4510) // default constructor could not be generated
+#pragma warning(disable : 4512) // assignment operator could not be generated
+#pragma warning(disable : 4610) // can never be instantiated - user defined constructor required
+#endif
+
+namespace boost { namespace xpressive { namespace detail
+{
+
+    #if BOOST_VERSION >= 103500
+    struct DataMember
+      : proto::mem_ptr<proto::_, proto::terminal<proto::_> >
+    {};
+
+    template<typename Expr, long N>
+    struct child_
+      : remove_reference<
+            typename proto::result_of::child_c<Expr &, N>::type
+        >
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // mem_ptr_eval
+    //  Rewrites expressions of the form x->*foo(a) into foo(x, a) and then
+    //  evaluates them.
+    template<typename Expr, typename Context, bool IsDataMember = proto::matches<Expr, DataMember>::value>
+    struct mem_ptr_eval
+    {
+        typedef typename child_<Expr, 0>::type left_type;
+        typedef typename child_<Expr, 1>::type right_type;
+
+        typedef
+            typename proto::result_of::value<
+                typename proto::result_of::child_c<right_type, 0>::type
+            >::type
+        function_type;
+
+        typedef
+            fusion::transform_view<
+                typename fusion::result_of::push_front<
+                    typename fusion::result_of::pop_front<right_type>::type const
+                  , reference_wrapper<left_type>
+                >::type const
+              , proto::eval_fun<Context>
+            >
+        evaluated_args;
+
+        typedef
+            typename fusion::result_of::invoke<function_type, evaluated_args>::type
+        result_type;
+
+        result_type operator()(Expr &expr, Context &ctx) const
+        {
+            return fusion::invoke<function_type>(
+                proto::value(proto::child_c<0>(proto::right(expr)))
+              , evaluated_args(
+                    fusion::push_front(fusion::pop_front(proto::right(expr)), boost::ref(proto::left(expr)))
+                  , proto::eval_fun<Context>(ctx)
+                )
+            );
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // mem_ptr_eval
+    //  Rewrites expressions of the form x->*foo into foo(x) and then
+    //  evaluates them.
+    template<typename Expr, typename Context>
+    struct mem_ptr_eval<Expr, Context, true>
+    {
+        typedef typename child_<Expr, 0>::type left_type;
+        typedef typename child_<Expr, 1>::type right_type;
+
+        typedef
+            typename proto::result_of::value<right_type>::type
+        function_type;
+
+        typedef typename boost::result_of<
+            function_type(typename proto::result_of::eval<left_type, Context>::type)
+        >::type result_type;
+
+        result_type operator()(Expr &expr, Context &ctx) const
+        {
+            return proto::value(proto::right(expr))(
+                proto::eval(proto::left(expr), ctx)
+            );
+        }
+    };
+    #endif
+
+    struct attr_with_default_tag
+    {};
+
+    template<typename T>
+    struct opt;
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // action_context
+    //
+    struct action_context
+    {
+        explicit action_context(action_args_type *action_args)
+          : action_args_(action_args)
+        {}
+
+        action_args_type const &args() const
+        {
+            return *this->action_args_;
+        }
+
+        // eval_terminal
+        template<typename Expr, typename Arg>
+        struct eval_terminal
+          : proto::default_eval<Expr, action_context const>
+        {};
+
+        template<typename Expr, typename Arg>
+        struct eval_terminal<Expr, reference_wrapper<Arg> >
+        {
+            typedef Arg &result_type;
+            result_type operator()(Expr &expr, action_context const &) const
+            {
+                return proto::value(expr).get();
+            }
+        };
+
+        template<typename Expr, typename Arg>
+        struct eval_terminal<Expr, opt<Arg> >
+        {
+            typedef Arg const &result_type;
+            result_type operator()(Expr &expr, action_context const &) const
+            {
+                return proto::value(expr);
+            }
+        };
+
+        template<typename Expr, typename Type, typename Int>
+        struct eval_terminal<Expr, action_arg<Type, Int> >
+        {
+            typedef typename action_arg<Type, Int>::reference result_type;
+            result_type operator()(Expr &expr, action_context const &ctx) const
+            {
+                action_args_type::const_iterator where_ = ctx.args().find(&typeid(proto::value(expr)));
+                if(where_ == ctx.args().end())
+                {
+                    BOOST_THROW_EXCEPTION(
+                        regex_error(
+                            regex_constants::error_badarg
+                          , "An argument to an action was unspecified"
+                        )
+                    );
+                }
+                return proto::value(expr).cast(where_->second);
+            }
+        };
+
+        // eval
+        template<typename Expr, typename Tag = typename Expr::proto_tag>
+        struct eval
+          : proto::default_eval<Expr, action_context const>
+        {};
+
+        template<typename Expr>
+        struct eval<Expr, proto::tag::terminal>
+          : eval_terminal<Expr, typename proto::result_of::value<Expr>::type>
+        {};
+
+        // Evaluate attributes like a1|42
+        template<typename Expr>
+        struct eval<Expr, attr_with_default_tag>
+        {
+            typedef
+                typename proto::result_of::value<
+                    typename proto::result_of::left<
+                        typename proto::result_of::child<
+                            Expr
+                        >::type
+                    >::type
+                >::type
+            temp_type;
+
+            typedef typename temp_type::type result_type;
+
+            result_type operator ()(Expr const &expr, action_context const &ctx) const
+            {
+                return proto::value(proto::left(proto::child(expr))).t_
+                    ? *proto::value(proto::left(proto::child(expr))).t_
+                    :  proto::eval(proto::right(proto::child(expr)), ctx);
+            }
+        };
+
+        #if BOOST_VERSION >= 103500
+        template<typename Expr>
+        struct eval<Expr, proto::tag::mem_ptr>
+          : mem_ptr_eval<Expr, action_context const>
+        {};
+        #endif
+
+    private:
+        action_args_type *action_args_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // action
+    //
+    template<typename Actor>
+    struct action
+      : actionable
+    {
+        action(Actor const &actor)
+          : actionable()
+          , actor_(actor)
+        {
+        }
+
+        virtual void execute(action_args_type *action_args) const
+        {
+            action_context const ctx(action_args);
+            proto::eval(this->actor_, ctx);
+        }
+
+    private:
+        Actor actor_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // subreg_transform
+    //
+    struct subreg_transform : proto::transform<subreg_transform>
+    {
+        template<typename Expr, typename State, typename Data>
+        struct impl : proto::transform_impl<Expr, State, Data>
+        {
+            typedef typename impl::state state_type;
+
+            typedef
+                typename proto::terminal<sub_match<typename state_type::iterator> >::type
+            result_type;
+
+            result_type operator ()(
+                typename impl::expr_param
+              , typename impl::state_param state
+              , typename impl::data_param data
+            ) const
+            {
+                return result_type::make(state.sub_matches_[ data ]);
+            }
+        };
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // mark_transform
+    //
+    struct mark_transform : proto::transform<mark_transform>
+    {
+        template<typename Expr, typename State, typename Data>
+        struct impl : proto::transform_impl<Expr, State, Data>
+        {
+            typedef typename impl::state state_type;
+            typedef
+                typename proto::terminal<sub_match<typename state_type::iterator> >::type
+            result_type;
+
+            result_type operator ()(
+                typename impl::expr_param expr
+              , typename impl::state_param state
+              , typename impl::data_param
+            ) const
+            {
+                return result_type::make(state.sub_matches_[ proto::value(expr).mark_number_ ]);
+            }
+        };
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // opt
+    //
+    template<typename T>
+    struct opt
+    {
+        typedef T type;
+        typedef T const &reference;
+
+        opt(T const *t)
+          : t_(t)
+        {}
+
+        operator reference() const
+        {
+            BOOST_XPR_ENSURE_(0 != this->t_, regex_constants::error_badattr, "Use of uninitialized regex attribute");
+            return *this->t_;
+        }
+
+        T const *t_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // attr_transform
+    //
+    struct attr_transform : proto::transform<attr_transform>
+    {
+        template<typename Expr, typename State, typename Data>
+        struct impl : proto::transform_impl<Expr, State, Data>
+        {
+            typedef typename impl::expr expr_type;
+
+            typedef
+                typename expr_type::proto_child0::matcher_type::value_type::second_type
+            attr_type;
+
+            typedef
+                typename proto::terminal<opt<attr_type> >::type
+            result_type;
+
+            result_type operator ()(
+                typename impl::expr_param
+              , typename impl::state_param state
+              , typename impl::data_param
+            ) const
+            {
+                int slot = typename expr_type::proto_child0::nbr_type();
+                attr_type const *attr = static_cast<attr_type const *>(state.attr_context_.attr_slots_[slot-1]);
+                return result_type::make(opt<attr_type>(attr));
+            }
+        };
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // attr_with_default_transform
+    //
+    template<typename Grammar, typename Callable = proto::callable>
+    struct attr_with_default_transform : proto::transform<attr_with_default_transform<Grammar, Callable> >
+    {
+        template<typename Expr, typename State, typename Data>
+        struct impl : proto::transform_impl<Expr, State, Data>
+        {
+            typedef
+                typename proto::unary_expr<
+                    attr_with_default_tag
+                  , typename Grammar::template impl<Expr, State, Data>::result_type
+                >::type
+            result_type;
+
+            result_type operator ()(
+                typename impl::expr_param expr
+              , typename impl::state_param state
+              , typename impl::data_param data
+            ) const
+            {
+                result_type that = {
+                    typename Grammar::template impl<Expr, State, Data>()(expr, state, data)
+                };
+                return that;
+            }
+        };
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // by_ref_transform
+    //
+    struct by_ref_transform : proto::transform<by_ref_transform>
+    {
+        template<typename Expr, typename State, typename Data>
+        struct impl : proto::transform_impl<Expr, State, Data>
+        {
+            typedef
+                typename proto::result_of::value<typename impl::expr_param>::type
+            reference;
+
+            typedef
+                typename proto::terminal<reference>::type
+            result_type;
+
+            result_type operator ()(
+                typename impl::expr_param expr
+              , typename impl::state_param
+              , typename impl::data_param
+            ) const
+            {
+                return result_type::make(proto::value(expr));
+            }
+        };
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // BindActionArgs
+    //
+    struct BindActionArgs
+      : proto::or_<
+            proto::when<proto::terminal<any_matcher>,                      subreg_transform>
+          , proto::when<proto::terminal<mark_placeholder>,                 mark_transform>
+          , proto::when<proto::terminal<read_attr<proto::_, proto::_> >,   attr_transform>
+          , proto::when<proto::terminal<proto::_>,                         by_ref_transform>
+          , proto::when<
+                proto::bitwise_or<proto::terminal<read_attr<proto::_, proto::_> >, BindActionArgs>
+              , attr_with_default_transform<proto::bitwise_or<attr_transform, BindActionArgs> >
+            >
+          , proto::otherwise<proto::nary_expr<proto::_, proto::vararg<BindActionArgs> > >
+        >
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // action_matcher
+    //
+    template<typename Actor>
+    struct action_matcher
+      : quant_style<quant_none, 0, false>
+    {
+        int sub_;
+        Actor actor_;
+
+        action_matcher(Actor const &actor, int sub)
+          : sub_(sub)
+          , actor_(actor)
+        {
+        }
+
+        template<typename BidiIter, typename Next>
+        bool match(match_state<BidiIter> &state, Next const &next) const
+        {
+            // Bind the arguments
+            typedef
+                typename boost::result_of<BindActionArgs(
+                    Actor const &
+                  , match_state<BidiIter> &
+                  , int const &
+                )>::type
+            action_type;
+
+            action<action_type> actor(BindActionArgs()(this->actor_, state, this->sub_));
+
+            // Put the action in the action list
+            actionable const **action_list_tail = state.action_list_tail_;
+            *state.action_list_tail_ = &actor;
+            state.action_list_tail_ = &actor.next;
+
+            // Match the rest of the pattern
+            if(next.match(state))
+            {
+                return true;
+            }
+
+            BOOST_ASSERT(0 == actor.next);
+            // remove action from list
+            *action_list_tail = 0;
+            state.action_list_tail_ = action_list_tail;
+            return false;
+        }
+    };
+
+}}}
+
+#if BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+#endif

--- a/inst/include/boost/xpressive/detail/core/matcher/attr_begin_matcher.hpp
+++ b/inst/include/boost/xpressive/detail/core/matcher/attr_begin_matcher.hpp
@@ -1,0 +1,50 @@
+///////////////////////////////////////////////////////////////////////////////
+// attr_begin_matcher.hpp
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_CORE_MATCHER_ATTR_BEGIN_MATCHER_HPP_EAN_06_09_2007
+#define BOOST_XPRESSIVE_DETAIL_CORE_MATCHER_ATTR_BEGIN_MATCHER_HPP_EAN_06_09_2007
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/core/quant_style.hpp>
+#include <boost/xpressive/detail/core/state.hpp>
+
+namespace boost { namespace xpressive { namespace detail
+{
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // attr_begin_matcher
+    //
+    template<typename Nbr>
+    struct attr_begin_matcher
+      : quant_style<quant_none, 0, false>
+    {
+        template<typename BidiIter, typename Next>
+        static bool match(match_state<BidiIter> &state, Next const &next)
+        {
+            void const *attr_slots[Nbr::value] = {};
+            attr_context old_attr_context = state.attr_context_;
+            state.attr_context_.attr_slots_ = attr_slots;
+            state.attr_context_.prev_attr_context_ = &old_attr_context;
+
+            if(next.match(state))
+            {
+                return true;
+            }
+
+            state.attr_context_ = old_attr_context;
+            return false;
+        }
+    };
+
+}}}
+
+#endif

--- a/inst/include/boost/xpressive/detail/core/matcher/predicate_matcher.hpp
+++ b/inst/include/boost/xpressive/detail/core/matcher/predicate_matcher.hpp
@@ -1,0 +1,174 @@
+///////////////////////////////////////////////////////////////////////////////
+// predicate_matcher.hpp
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_CORE_MATCHER_PREDICATE_MATCHER_HPP_EAN_03_22_2007
+#define BOOST_XPRESSIVE_DETAIL_CORE_MATCHER_PREDICATE_MATCHER_HPP_EAN_03_22_2007
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/mpl/not.hpp>
+#include <boost/mpl/placeholders.hpp>
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/core/quant_style.hpp>
+#include <boost/xpressive/detail/core/matcher/action_matcher.hpp>
+#include <boost/xpressive/detail/core/state.hpp>
+#include <boost/proto/core.hpp>
+
+namespace boost { namespace xpressive { namespace detail
+{
+    ///////////////////////////////////////////////////////////////////////////////
+    // predicate_context
+    //
+    template<typename BidiIter>
+    struct predicate_context
+    {
+        explicit predicate_context(int sub, sub_match_impl<BidiIter> const *sub_matches, action_args_type *action_args)
+          : sub_(sub)
+          , sub_matches_(sub_matches)
+          , action_args_(action_args)
+        {}
+
+        action_args_type const &args() const
+        {
+            return *this->action_args_;
+        }
+
+        // eval_terminal
+        template<typename Expr, typename Arg>
+        struct eval_terminal
+          : proto::default_eval<Expr, predicate_context const>
+        {};
+
+        template<typename Expr, typename Arg>
+        struct eval_terminal<Expr, reference_wrapper<Arg> >
+        {
+            typedef Arg &result_type;
+            result_type operator()(Expr &expr, predicate_context const &) const
+            {
+                return proto::value(expr).get();
+            }
+        };
+
+        template<typename Expr>
+        struct eval_terminal<Expr, any_matcher>
+        {
+            typedef sub_match<BidiIter> const &result_type;
+            result_type operator()(Expr &, predicate_context const &ctx) const
+            {
+                return ctx.sub_matches_[ctx.sub_];
+            }
+        };
+
+        template<typename Expr>
+        struct eval_terminal<Expr, mark_placeholder>
+        {
+            typedef sub_match<BidiIter> const &result_type;
+            result_type operator()(Expr &expr, predicate_context const &ctx) const
+            {
+                return ctx.sub_matches_[proto::value(expr).mark_number_];
+            }
+        };
+
+        template<typename Expr, typename Type, typename Int>
+        struct eval_terminal<Expr, action_arg<Type, Int> >
+        {
+            typedef typename action_arg<Type, Int>::reference result_type;
+            result_type operator()(Expr &expr, predicate_context const &ctx) const
+            {
+                action_args_type::const_iterator where_ = ctx.args().find(&typeid(proto::value(expr)));
+                if(where_ == ctx.args().end())
+                {
+                    BOOST_THROW_EXCEPTION(
+                        regex_error(
+                            regex_constants::error_badarg
+                          , "An argument to an action was unspecified"
+                        )
+                    );
+                }
+                return proto::value(expr).cast(where_->second);
+            }
+        };
+
+        // eval
+        template<typename Expr, typename Tag = typename Expr::proto_tag>
+        struct eval
+          : proto::default_eval<Expr, predicate_context const>
+        {};
+
+        template<typename Expr>
+        struct eval<Expr, proto::tag::terminal>
+          : eval_terminal<Expr, typename proto::result_of::value<Expr>::type>
+        {};
+
+        #if BOOST_VERSION >= 103500
+        template<typename Expr>
+        struct eval<Expr, proto::tag::mem_ptr>
+          : mem_ptr_eval<Expr, predicate_context const>
+        {};
+        #endif
+
+        int sub_;
+        sub_match_impl<BidiIter> const *sub_matches_;
+        action_args_type *action_args_;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // AssertionFunctor
+    //
+    struct AssertionFunctor
+      : proto::function<
+            proto::terminal<check_tag>
+          , proto::terminal<proto::_>
+        >
+    {};
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // predicate_matcher
+    //
+    template<typename Predicate>
+    struct predicate_matcher
+      : quant_style_assertion
+    {
+        int sub_;
+        Predicate predicate_;
+
+        predicate_matcher(Predicate const &pred, int sub)
+          : sub_(sub)
+          , predicate_(pred)
+        {
+        }
+
+        template<typename BidiIter, typename Next>
+        bool match(match_state<BidiIter> &state, Next const &next) const
+        {
+            // Predicate is check(assertion), where assertion can be
+            // a lambda or a function object.
+            return this->match_(state, next, proto::matches<Predicate, AssertionFunctor>());
+        }
+
+    private:
+        template<typename BidiIter, typename Next>
+        bool match_(match_state<BidiIter> &state, Next const &next, mpl::true_) const
+        {
+            sub_match<BidiIter> const &sub = state.sub_match(this->sub_);
+            return proto::value(proto::child_c<1>(this->predicate_))(sub) && next.match(state);
+        }
+
+        template<typename BidiIter, typename Next>
+        bool match_(match_state<BidiIter> &state, Next const &next, mpl::false_) const
+        {
+            predicate_context<BidiIter> ctx(this->sub_, state.sub_matches_, state.action_args_);
+            return proto::eval(proto::child_c<1>(this->predicate_), ctx) && next.match(state);
+        }
+    };
+
+}}}
+
+#endif // BOOST_XPRESSIVE_DETAIL_CORE_MATCHER_PREDICATE_MATCHER_HPP_EAN_03_22_2007

--- a/inst/include/boost/xpressive/detail/dynamic/dynamic.hpp
+++ b/inst/include/boost/xpressive/detail/dynamic/dynamic.hpp
@@ -1,0 +1,337 @@
+///////////////////////////////////////////////////////////////////////////////
+// dynamic.hpp
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_DYNAMIC_DYNAMIC_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_DETAIL_DYNAMIC_DYNAMIC_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <boost/assert.hpp>
+#include <boost/mpl/int.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/core/quant_style.hpp>
+#include <boost/xpressive/detail/dynamic/matchable.hpp>
+#include <boost/xpressive/detail/dynamic/sequence.hpp>
+#include <boost/xpressive/detail/core/icase.hpp>
+
+namespace boost { namespace xpressive { namespace detail
+{
+
+///////////////////////////////////////////////////////////////////////////////
+// invalid_xpression
+template<typename BidiIter>
+struct invalid_xpression
+  : matchable_ex<BidiIter>
+{
+    invalid_xpression()
+      : matchable_ex<BidiIter>()
+    {
+        intrusive_ptr_add_ref(this); // keep alive forever
+    }
+
+    bool match(match_state<BidiIter> &) const
+    {
+        BOOST_ASSERT(false);
+        return false;
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// get_invalid_xpression
+template<typename BidiIter>
+inline shared_matchable<BidiIter> const &get_invalid_xpression()
+{
+    static invalid_xpression<BidiIter> const invalid_xpr;
+    static intrusive_ptr<matchable_ex<BidiIter> const> const invalid_ptr(&invalid_xpr);
+    static shared_matchable<BidiIter> const invalid_matchable(invalid_ptr);
+    return invalid_matchable;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// dynamic_xpression
+template<typename Matcher, typename BidiIter>
+struct dynamic_xpression
+  : Matcher
+  , matchable_ex<BidiIter>
+{
+    typedef typename iterator_value<BidiIter>::type char_type;
+
+    dynamic_xpression(Matcher const &matcher = Matcher())
+      : Matcher(matcher)
+      , next_(get_invalid_xpression<BidiIter>())
+    {
+    }
+
+    virtual bool match(match_state<BidiIter> &state) const
+    {
+        return this->Matcher::match(state, *this->next_.matchable());
+    }
+
+    virtual void link(xpression_linker<char_type> &linker) const
+    {
+        linker.accept(*static_cast<Matcher const *>(this), this->next_.matchable().get());
+        this->next_.link(linker);
+    }
+
+    virtual void peek(xpression_peeker<char_type> &peeker) const
+    {
+        this->peek_next_(peeker.accept(*static_cast<Matcher const *>(this)), peeker);
+    }
+
+    virtual void repeat(quant_spec const &spec, sequence<BidiIter> &seq) const
+    {
+        this->repeat_(spec, seq, quant_type<Matcher>(), is_same<Matcher, mark_begin_matcher>());
+    }
+
+private:
+    friend struct sequence<BidiIter>;
+
+    void peek_next_(mpl::true_, xpression_peeker<char_type> &peeker) const
+    {
+        this->next_.peek(peeker);
+    }
+
+    void peek_next_(mpl::false_, xpression_peeker<char_type> &) const
+    {
+        // no-op
+    }
+
+    void repeat_(quant_spec const &spec, sequence<BidiIter> &seq, mpl::int_<quant_none>, mpl::false_) const
+    {
+        if(quant_none == seq.quant())
+        {
+            BOOST_THROW_EXCEPTION(
+                regex_error(regex_constants::error_badrepeat, "expression cannot be quantified")
+            );
+        }
+        else
+        {
+            this->repeat_(spec, seq, mpl::int_<quant_variable_width>(), mpl::false_());
+        }
+    }
+
+    void repeat_(quant_spec const &spec, sequence<BidiIter> &seq, mpl::int_<quant_fixed_width>, mpl::false_) const
+    {
+        if(this->next_ == get_invalid_xpression<BidiIter>())
+        {
+            make_simple_repeat(spec, seq, matcher_wrapper<Matcher>(*this));
+        }
+        else
+        {
+            this->repeat_(spec, seq, mpl::int_<quant_variable_width>(), mpl::false_());
+        }
+    }
+
+    void repeat_(quant_spec const &spec, sequence<BidiIter> &seq, mpl::int_<quant_variable_width>, mpl::false_) const
+    {
+        if(!is_unknown(seq.width()) && seq.pure())
+        {
+            make_simple_repeat(spec, seq);
+        }
+        else
+        {
+            make_repeat(spec, seq);
+        }
+    }
+
+    void repeat_(quant_spec const &spec, sequence<BidiIter> &seq, mpl::int_<quant_fixed_width>, mpl::true_) const
+    {
+        make_repeat(spec, seq, this->mark_number_);
+    }
+
+    shared_matchable<BidiIter> next_;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// make_dynamic
+template<typename BidiIter, typename Matcher>
+inline sequence<BidiIter> make_dynamic(Matcher const &matcher)
+{
+    typedef dynamic_xpression<Matcher, BidiIter> xpression_type;
+    intrusive_ptr<xpression_type> xpr(new xpression_type(matcher));
+    return sequence<BidiIter>(xpr);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// alternates_vector
+template<typename BidiIter>
+struct alternates_vector
+  : std::vector<shared_matchable<BidiIter> >
+{
+    BOOST_STATIC_CONSTANT(std::size_t, width = unknown_width::value);
+    BOOST_STATIC_CONSTANT(bool, pure = false);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// matcher_wrapper
+template<typename Matcher>
+struct matcher_wrapper
+  : Matcher
+{
+    matcher_wrapper(Matcher const &matcher = Matcher())
+      : Matcher(matcher)
+    {
+    }
+
+    template<typename BidiIter>
+    bool match(match_state<BidiIter> &state) const
+    {
+        return this->Matcher::match(state, matcher_wrapper<true_matcher>());
+    }
+
+    template<typename Char>
+    void link(xpression_linker<Char> &linker) const
+    {
+        linker.accept(*static_cast<Matcher const *>(this), 0);
+    }
+
+    template<typename Char>
+    void peek(xpression_peeker<Char> &peeker) const
+    {
+        peeker.accept(*static_cast<Matcher const *>(this));
+    }
+};
+
+//////////////////////////////////////////////////////////////////////////
+// make_simple_repeat
+template<typename BidiIter, typename Xpr>
+inline void
+make_simple_repeat(quant_spec const &spec, sequence<BidiIter> &seq, Xpr const &xpr)
+{
+    if(spec.greedy_)
+    {
+        simple_repeat_matcher<Xpr, mpl::true_> quant(xpr, spec.min_, spec.max_, seq.width().value());
+        seq = make_dynamic<BidiIter>(quant);
+    }
+    else
+    {
+        simple_repeat_matcher<Xpr, mpl::false_> quant(xpr, spec.min_, spec.max_, seq.width().value());
+        seq = make_dynamic<BidiIter>(quant);
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+// make_simple_repeat
+template<typename BidiIter>
+inline void
+make_simple_repeat(quant_spec const &spec, sequence<BidiIter> &seq)
+{
+    seq += make_dynamic<BidiIter>(true_matcher());
+    make_simple_repeat(spec, seq, seq.xpr());
+}
+
+//////////////////////////////////////////////////////////////////////////
+// make_optional
+template<typename BidiIter>
+inline void
+make_optional(quant_spec const &spec, sequence<BidiIter> &seq)
+{
+    typedef shared_matchable<BidiIter> xpr_type;
+    seq += make_dynamic<BidiIter>(alternate_end_matcher());
+    if(spec.greedy_)
+    {
+        optional_matcher<xpr_type, mpl::true_> opt(seq.xpr());
+        seq = make_dynamic<BidiIter>(opt);
+    }
+    else
+    {
+        optional_matcher<xpr_type, mpl::false_> opt(seq.xpr());
+        seq = make_dynamic<BidiIter>(opt);
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+// make_optional
+template<typename BidiIter>
+inline void
+make_optional(quant_spec const &spec, sequence<BidiIter> &seq, int mark_nbr)
+{
+    typedef shared_matchable<BidiIter> xpr_type;
+    seq += make_dynamic<BidiIter>(alternate_end_matcher());
+    if(spec.greedy_)
+    {
+        optional_mark_matcher<xpr_type, mpl::true_> opt(seq.xpr(), mark_nbr);
+        seq = make_dynamic<BidiIter>(opt);
+    }
+    else
+    {
+        optional_mark_matcher<xpr_type, mpl::false_> opt(seq.xpr(), mark_nbr);
+        seq = make_dynamic<BidiIter>(opt);
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+// make_repeat
+template<typename BidiIter>
+inline void
+make_repeat(quant_spec const &spec, sequence<BidiIter> &seq)
+{
+    // only bother creating a repeater if max is greater than one
+    if(1 < spec.max_)
+    {
+        // create a hidden mark so this expression can be quantified
+        int mark_nbr = -static_cast<int>(++*spec.hidden_mark_count_);
+        seq = make_dynamic<BidiIter>(mark_begin_matcher(mark_nbr)) + seq
+            + make_dynamic<BidiIter>(mark_end_matcher(mark_nbr));
+        make_repeat(spec, seq, mark_nbr);
+        return;
+    }
+
+    // if min is 0, the repeat must be made optional
+    if(0 == spec.min_)
+    {
+        make_optional(spec, seq);
+    }
+}
+
+//////////////////////////////////////////////////////////////////////////
+// make_repeat
+template<typename BidiIter>
+inline void
+make_repeat(quant_spec const &spec, sequence<BidiIter> &seq, int mark_nbr)
+{
+    BOOST_ASSERT(spec.max_); // we should never get here if max is 0
+
+    // only bother creating a repeater if max is greater than one
+    if(1 < spec.max_)
+    {
+        // TODO: statically bind the repeat matchers to the mark matchers for better perf
+        unsigned int min = spec.min_ ? spec.min_ : 1U;
+        repeat_begin_matcher repeat_begin(mark_nbr);
+        if(spec.greedy_)
+        {
+            repeat_end_matcher<mpl::true_> repeat_end(mark_nbr, min, spec.max_);
+            seq = make_dynamic<BidiIter>(repeat_begin) + seq
+                + make_dynamic<BidiIter>(repeat_end);
+        }
+        else
+        {
+            repeat_end_matcher<mpl::false_> repeat_end(mark_nbr, min, spec.max_);
+            seq = make_dynamic<BidiIter>(repeat_begin) + seq
+                + make_dynamic<BidiIter>(repeat_end);
+        }
+    }
+
+    // if min is 0, the repeat must be made optional
+    if(0 == spec.min_)
+    {
+        make_optional(spec, seq, mark_nbr);
+    }
+}
+
+}}} // namespace boost::xpressive::detail
+
+#endif

--- a/inst/include/boost/xpressive/detail/dynamic/parse_charset.hpp
+++ b/inst/include/boost/xpressive/detail/dynamic/parse_charset.hpp
@@ -1,0 +1,368 @@
+///////////////////////////////////////////////////////////////////////////////
+// parse_charset.hpp
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSE_CHARSET_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSE_CHARSET_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/config.hpp>
+#include <boost/integer.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/numeric/conversion/converter.hpp>
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/dynamic/parser_enum.hpp>
+#include <boost/xpressive/detail/utility/literals.hpp>
+#include <boost/xpressive/detail/utility/chset/chset.hpp>
+#include <boost/xpressive/regex_constants.hpp>
+
+namespace boost { namespace xpressive { namespace detail
+{
+
+enum escape_type
+{
+    escape_char
+  , escape_mark
+  , escape_class
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// escape_value
+//
+template<typename Char, typename Class>
+struct escape_value
+{
+    Char ch_;
+    int mark_nbr_;
+    Class class_;
+    escape_type type_;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// char_overflow_handler
+//
+struct char_overflow_handler
+{
+    void operator ()(numeric::range_check_result result) const // throw(regex_error)
+    {
+        if(numeric::cInRange != result)
+        {
+            BOOST_THROW_EXCEPTION(
+                regex_error(
+                    regex_constants::error_escape
+                  , "character escape too large to fit in target character type"
+                )
+            );
+        }
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// parse_escape
+//
+template<typename FwdIter, typename CompilerTraits>
+escape_value<typename iterator_value<FwdIter>::type, typename CompilerTraits::regex_traits::char_class_type>
+parse_escape(FwdIter &begin, FwdIter end, CompilerTraits &tr)
+{
+    using namespace regex_constants;
+    typedef typename iterator_value<FwdIter>::type char_type;
+    typedef typename CompilerTraits::regex_traits regex_traits;
+    typedef typename regex_traits::char_class_type char_class_type;
+
+    // define an unsigned type the same size as char_type
+    typedef typename boost::uint_t<CHAR_BIT * sizeof(char_type)>::least uchar_t;
+    BOOST_MPL_ASSERT_RELATION(sizeof(uchar_t), ==, sizeof(char_type));
+    typedef numeric::conversion_traits<uchar_t, int> converstion_traits;
+
+    BOOST_XPR_ENSURE_(begin != end, error_escape, "unexpected end of pattern found");
+    numeric::converter<int, uchar_t, converstion_traits, char_overflow_handler> converter;
+    escape_value<char_type,char_class_type> esc = { 0, 0, 0, escape_char };
+    bool const icase = (0 != (regex_constants::icase_ & tr.flags()));
+    regex_traits const &rxtraits = tr.traits();
+    FwdIter tmp;
+
+    esc.class_ = rxtraits.lookup_classname(begin, begin + 1, icase);
+    if(0 != esc.class_)
+    {
+        esc.type_ = escape_class;
+        return esc;
+    }
+
+    if(-1 != rxtraits.value(*begin, 8))
+    {
+        esc.ch_ = converter(toi(begin, end, rxtraits, 8, 0777));
+        return esc;
+    }
+
+    switch(*begin)
+    {
+    // bell character
+    case BOOST_XPR_CHAR_(char_type, 'a'):
+        esc.ch_ = BOOST_XPR_CHAR_(char_type, '\a');
+        ++begin;
+        break;
+    // escape character
+    case BOOST_XPR_CHAR_(char_type, 'e'):
+        esc.ch_ = converter(27);
+        ++begin;
+        break;
+    // control character
+    case BOOST_XPR_CHAR_(char_type, 'c'):
+        BOOST_XPR_ENSURE_(++begin != end, error_escape, "unexpected end of pattern found");
+        BOOST_XPR_ENSURE_
+        (
+            rxtraits.in_range(BOOST_XPR_CHAR_(char_type, 'a'), BOOST_XPR_CHAR_(char_type, 'z'), *begin)
+         || rxtraits.in_range(BOOST_XPR_CHAR_(char_type, 'A'), BOOST_XPR_CHAR_(char_type, 'Z'), *begin)
+          , error_escape
+          , "invalid escape control letter; must be one of a-z or A-Z"
+        );
+        // Convert to character according to ECMA-262, section 15.10.2.10:
+        esc.ch_ = converter(*begin % 32);
+        ++begin;
+        break;
+    // formfeed character
+    case BOOST_XPR_CHAR_(char_type, 'f'):
+        esc.ch_ = BOOST_XPR_CHAR_(char_type, '\f');
+        ++begin;
+        break;
+    // newline
+    case BOOST_XPR_CHAR_(char_type, 'n'):
+        esc.ch_ = BOOST_XPR_CHAR_(char_type, '\n');
+        ++begin;
+        break;
+    // return
+    case BOOST_XPR_CHAR_(char_type, 'r'):
+        esc.ch_ = BOOST_XPR_CHAR_(char_type, '\r');
+        ++begin;
+        break;
+    // horizontal tab
+    case BOOST_XPR_CHAR_(char_type, 't'):
+        esc.ch_ = BOOST_XPR_CHAR_(char_type, '\t');
+        ++begin;
+        break;
+    // vertical tab
+    case BOOST_XPR_CHAR_(char_type, 'v'):
+        esc.ch_ = BOOST_XPR_CHAR_(char_type, '\v');
+        ++begin;
+        break;
+    // hex escape sequence
+    case BOOST_XPR_CHAR_(char_type, 'x'):
+        BOOST_XPR_ENSURE_(++begin != end, error_escape, "unexpected end of pattern found");
+        tmp = begin;
+        esc.ch_ = converter(toi(begin, end, rxtraits, 16, 0xff));
+        BOOST_XPR_ENSURE_(2 == std::distance(tmp, begin), error_escape, "invalid hex escape : "
+            "must be \\x HexDigit HexDigit");
+        break;
+    // Unicode escape sequence
+    case BOOST_XPR_CHAR_(char_type, 'u'):
+        BOOST_XPR_ENSURE_(++begin != end, error_escape, "unexpected end of pattern found");
+        tmp = begin;
+        esc.ch_ = converter(toi(begin, end, rxtraits, 16, 0xffff));
+        BOOST_XPR_ENSURE_(4 == std::distance(tmp, begin), error_escape, "invalid Unicode escape : "
+            "must be \\u HexDigit HexDigit HexDigit HexDigit");
+        break;
+    // backslash
+    case BOOST_XPR_CHAR_(char_type, '\\'):
+        //esc.ch_ = BOOST_XPR_CHAR_(char_type, '\\');
+        //++begin;
+        //break;
+    // all other escaped characters represent themselves
+    default:
+        esc.ch_ = *begin;
+        ++begin;
+        break;
+    }
+
+    return esc;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// parse_charset
+//
+template<typename FwdIter, typename RegexTraits, typename CompilerTraits>
+inline void parse_charset
+(
+    FwdIter &begin
+  , FwdIter end
+  , compound_charset<RegexTraits> &chset
+  , CompilerTraits &tr
+)
+{
+    using namespace regex_constants;
+    typedef typename RegexTraits::char_type char_type;
+    typedef typename RegexTraits::char_class_type char_class_type;
+    BOOST_XPR_ENSURE_(begin != end, error_brack, "unexpected end of pattern found");
+    RegexTraits const &rxtraits = tr.traits();
+    bool const icase = (0 != (regex_constants::icase_ & tr.flags()));
+    FwdIter iprev = FwdIter();
+    escape_value<char_type, char_class_type> esc = {0, 0, 0, escape_char};
+    bool invert = false;
+
+    // check to see if we have an inverse charset
+    if(begin != end && token_charset_invert == tr.get_charset_token(iprev = begin, end))
+    {
+        begin = iprev;
+        invert = true;
+    }
+
+    // skip the end token if-and-only-if it is the first token in the charset
+    if(begin != end && token_charset_end == tr.get_charset_token(iprev = begin, end))
+    {
+        for(; begin != iprev; ++begin)
+        {
+            chset.set_char(*begin, rxtraits, icase);
+        }
+    }
+
+    compiler_token_type tok;
+    char_type ch_prev = char_type(), ch_next = char_type();
+    bool have_prev = false;
+
+    BOOST_XPR_ENSURE_(begin != end, error_brack, "unexpected end of pattern found");
+
+    // remember the current position and grab the next token
+    iprev = begin;
+    tok = tr.get_charset_token(begin, end);
+    do
+    {
+        BOOST_XPR_ENSURE_(begin != end, error_brack, "unexpected end of pattern found");
+
+        if(token_charset_hyphen == tok && have_prev)
+        {
+            // remember the current position
+            FwdIter iprev2 = begin;
+            have_prev = false;
+
+            // ch_prev is lower bound of a range
+            switch(tr.get_charset_token(begin, end))
+            {
+            case token_charset_hyphen:
+            case token_charset_invert:
+                begin = iprev2; // un-get these tokens and fall through
+                BOOST_FALLTHROUGH;
+            case token_literal:
+                ch_next = *begin++;
+                BOOST_XPR_ENSURE_(ch_prev <= ch_next, error_range, "invalid charset range");
+                chset.set_range(ch_prev, ch_next, rxtraits, icase);
+                continue;
+            case token_charset_backspace:
+                ch_next = char_type(8); // backspace
+                BOOST_XPR_ENSURE_(ch_prev <= ch_next, error_range, "invalid charset range");
+                chset.set_range(ch_prev, ch_next, rxtraits, icase);
+                continue;
+            case token_escape:
+                esc = parse_escape(begin, end, tr);
+                if(escape_char == esc.type_)
+                {
+                    BOOST_XPR_ENSURE_(ch_prev <= esc.ch_, error_range, "invalid charset range");
+                    chset.set_range(ch_prev, esc.ch_, rxtraits, icase);
+                    continue;
+                }
+                BOOST_FALLTHROUGH;
+            case token_charset_end:
+            default:                // not a range.
+                begin = iprev;      // backup to hyphen token
+                chset.set_char(ch_prev, rxtraits, icase);
+                chset.set_char(*begin++, rxtraits, icase);
+                continue;
+            }
+        }
+
+        if(have_prev)
+        {
+            chset.set_char(ch_prev, rxtraits, icase);
+            have_prev = false;
+        }
+
+        switch(tok)
+        {
+        case token_charset_hyphen:
+        case token_charset_invert:
+        case token_charset_end:
+        case token_posix_charset_end:
+            begin = iprev; // un-get these tokens
+            ch_prev = *begin++;
+            have_prev = true;
+            continue;
+
+        case token_charset_backspace:
+            ch_prev = char_type(8); // backspace
+            have_prev = true;
+            continue;
+
+        case token_posix_charset_begin:
+            {
+                FwdIter tmp = begin, start = begin;
+                bool invert = (token_charset_invert == tr.get_charset_token(tmp, end));
+                if(invert)
+                {
+                    begin = start = tmp;
+                }
+                while(token_literal == (tok = tr.get_charset_token(begin, end)))
+                {
+                    tmp = ++begin;
+                    BOOST_XPR_ENSURE_(begin != end, error_brack, "unexpected end of pattern found");
+                }
+                if(token_posix_charset_end == tok)
+                {
+                    char_class_type chclass = rxtraits.lookup_classname(start, tmp, icase);
+                    BOOST_XPR_ENSURE_(0 != chclass, error_ctype, "unknown class name");
+                    chset.set_class(chclass, invert);
+                    continue;
+                }
+                begin = iprev; // un-get this token
+                ch_prev = *begin++;
+                have_prev = true;
+            }
+            continue;
+
+        case token_escape:
+            esc = parse_escape(begin, end, tr);
+            if(escape_char == esc.type_)
+            {
+                ch_prev = esc.ch_;
+                have_prev = true;
+            }
+            else if(escape_class == esc.type_)
+            {
+                char_class_type upper_ = lookup_classname(rxtraits, "upper");
+                BOOST_ASSERT(0 != upper_);
+                chset.set_class(esc.class_, rxtraits.isctype(*begin++, upper_));
+            }
+            else
+            {
+                BOOST_ASSERT(false);
+            }
+            continue;
+
+        default:
+            ch_prev = *begin++;
+            have_prev = true;
+            continue;
+        }
+    }
+    while(BOOST_XPR_ENSURE_((iprev = begin) != end, error_brack, "unexpected end of pattern found"),
+          token_charset_end != (tok = tr.get_charset_token(begin, end)));
+
+    if(have_prev)
+    {
+        chset.set_char(ch_prev, rxtraits, icase);
+    }
+
+    if(invert)
+    {
+        chset.inverse();
+    }
+}
+
+}}} // namespace boost::xpressive::detail
+
+#endif

--- a/inst/include/boost/xpressive/detail/dynamic/parser.hpp
+++ b/inst/include/boost/xpressive/detail/dynamic/parser.hpp
@@ -1,0 +1,359 @@
+///////////////////////////////////////////////////////////////////////////////
+/// \file parser.hpp
+/// Contains the definition of regex_compiler, a factory for building regex objects
+/// from strings.
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSER_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSER_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+# pragma warning(push)
+# pragma warning(disable : 4127) // conditional expression is constant
+#endif
+
+#include <boost/assert.hpp>
+#include <boost/xpressive/regex_constants.hpp>
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/core/matchers.hpp>
+#include <boost/xpressive/detail/utility/ignore_unused.hpp>
+#include <boost/xpressive/detail/dynamic/dynamic.hpp>
+
+// The Regular Expression grammar, in pseudo BNF:
+//
+// expression   = alternates ;
+//
+// alternates   = sequence, *('|', sequence) ;
+//
+// sequence     = quant, *(quant) ;
+//
+// quant        = atom, [*+?] ;
+//
+// atom         = literal             |
+//                '.'                 |
+//                '\' any             |
+//                '(' expression ')' ;
+//
+// literal      = not a meta-character ;
+//
+
+namespace boost { namespace xpressive { namespace detail
+{
+
+///////////////////////////////////////////////////////////////////////////////
+// make_char_xpression
+//
+template<typename BidiIter, typename Char, typename Traits>
+inline sequence<BidiIter> make_char_xpression
+(
+    Char ch
+  , regex_constants::syntax_option_type flags
+  , Traits const &tr
+)
+{
+    if(0 != (regex_constants::icase_ & flags))
+    {
+        literal_matcher<Traits, mpl::true_, mpl::false_> matcher(ch, tr);
+        return make_dynamic<BidiIter>(matcher);
+    }
+    else
+    {
+        literal_matcher<Traits, mpl::false_, mpl::false_> matcher(ch, tr);
+        return make_dynamic<BidiIter>(matcher);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_any_xpression
+//
+template<typename BidiIter, typename Traits>
+inline sequence<BidiIter> make_any_xpression
+(
+    regex_constants::syntax_option_type flags
+  , Traits const &tr
+)
+{
+    using namespace regex_constants;
+    typedef typename iterator_value<BidiIter>::type char_type;
+    typedef detail::set_matcher<Traits, mpl::int_<2> > set_matcher;
+    typedef literal_matcher<Traits, mpl::false_, mpl::true_> literal_matcher;
+
+    char_type const newline = tr.widen('\n');
+    set_matcher s;
+    s.set_[0] = newline;
+    s.set_[1] = 0;
+    s.inverse();
+
+    switch(((int)not_dot_newline | not_dot_null) & flags)
+    {
+    case not_dot_null:
+        return make_dynamic<BidiIter>(literal_matcher(char_type(0), tr));
+
+    case not_dot_newline:
+        return make_dynamic<BidiIter>(literal_matcher(newline, tr));
+
+    case (int)not_dot_newline | not_dot_null:
+        return make_dynamic<BidiIter>(s);
+
+    default:
+        return make_dynamic<BidiIter>(any_matcher());
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_literal_xpression
+//
+template<typename BidiIter, typename Traits>
+inline sequence<BidiIter> make_literal_xpression
+(
+    typename Traits::string_type const &literal
+  , regex_constants::syntax_option_type flags
+  , Traits const &tr
+)
+{
+    BOOST_ASSERT(0 != literal.size());
+    if(1 == literal.size())
+    {
+        return make_char_xpression<BidiIter>(literal[0], flags, tr);
+    }
+
+    if(0 != (regex_constants::icase_ & flags))
+    {
+        string_matcher<Traits, mpl::true_> matcher(literal, tr);
+        return make_dynamic<BidiIter>(matcher);
+    }
+    else
+    {
+        string_matcher<Traits, mpl::false_> matcher(literal, tr);
+        return make_dynamic<BidiIter>(matcher);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_backref_xpression
+//
+template<typename BidiIter, typename Traits>
+inline sequence<BidiIter> make_backref_xpression
+(
+    int mark_nbr
+  , regex_constants::syntax_option_type flags
+  , Traits const &tr
+)
+{
+    if(0 != (regex_constants::icase_ & flags))
+    {
+        return make_dynamic<BidiIter>
+        (
+            mark_matcher<Traits, mpl::true_>(mark_nbr, tr)
+        );
+    }
+    else
+    {
+        return make_dynamic<BidiIter>
+        (
+            mark_matcher<Traits, mpl::false_>(mark_nbr, tr)
+        );
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// merge_charset
+//
+template<typename Char, typename Traits>
+inline void merge_charset
+(
+    basic_chset<Char> &basic
+  , compound_charset<Traits> const &compound
+  , Traits const &tr
+)
+{
+    detail::ignore_unused(tr);
+    if(0 != compound.posix_yes())
+    {
+        typename Traits::char_class_type mask = compound.posix_yes();
+        for(int i = 0; i <= static_cast<int>(UCHAR_MAX); ++i)
+        {
+            if(tr.isctype((Char)i, mask))
+            {
+                basic.set((Char)i);
+            }
+        }
+    }
+
+    if(!compound.posix_no().empty())
+    {
+        for(std::size_t j = 0; j < compound.posix_no().size(); ++j)
+        {
+            typename Traits::char_class_type mask = compound.posix_no()[j];
+            for(int i = 0; i <= static_cast<int>(UCHAR_MAX); ++i)
+            {
+                if(!tr.isctype((Char)i, mask))
+                {
+                    basic.set((Char)i);
+                }
+            }
+        }
+    }
+
+    if(compound.is_inverted())
+    {
+        basic.inverse();
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_charset_xpression
+//
+template<typename BidiIter, typename Traits>
+inline sequence<BidiIter> make_charset_xpression
+(
+    compound_charset<Traits> &chset
+  , Traits const &tr
+  , regex_constants::syntax_option_type flags
+)
+{
+    typedef typename Traits::char_type char_type;
+    bool const icase = (0 != (regex_constants::icase_ & flags));
+    bool const optimize = is_narrow_char<char_type>::value && 0 != (regex_constants::optimize & flags);
+
+    // don't care about compile speed -- fold eveything into a bitset<256>
+    if(optimize)
+    {
+        typedef basic_chset<char_type> charset_type;
+        charset_type charset(chset.base());
+        if(icase)
+        {
+            charset_matcher<Traits, mpl::true_, charset_type> matcher(charset);
+            merge_charset(matcher.charset_, chset, tr);
+            return make_dynamic<BidiIter>(matcher);
+        }
+        else
+        {
+            charset_matcher<Traits, mpl::false_, charset_type> matcher(charset);
+            merge_charset(matcher.charset_, chset, tr);
+            return make_dynamic<BidiIter>(matcher);
+        }
+    }
+
+    // special case to make [[:digit:]] fast
+    else if(chset.base().empty() && chset.posix_no().empty())
+    {
+        BOOST_ASSERT(0 != chset.posix_yes());
+        posix_charset_matcher<Traits> matcher(chset.posix_yes(), chset.is_inverted());
+        return make_dynamic<BidiIter>(matcher);
+    }
+
+    // default, slow
+    else
+    {
+        if(icase)
+        {
+            charset_matcher<Traits, mpl::true_> matcher(chset);
+            return make_dynamic<BidiIter>(matcher);
+        }
+        else
+        {
+            charset_matcher<Traits, mpl::false_> matcher(chset);
+            return make_dynamic<BidiIter>(matcher);
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_posix_charset_xpression
+//
+template<typename BidiIter, typename Traits>
+inline sequence<BidiIter> make_posix_charset_xpression
+(
+    typename Traits::char_class_type m
+  , bool no
+  , regex_constants::syntax_option_type //flags
+  , Traits const & //traits
+)
+{
+    posix_charset_matcher<Traits> charset(m, no);
+    return make_dynamic<BidiIter>(charset);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_assert_begin_line
+//
+template<typename BidiIter, typename Traits>
+inline sequence<BidiIter> make_assert_begin_line
+(
+    regex_constants::syntax_option_type flags
+  , Traits const &tr
+)
+{
+    if(0 != (regex_constants::single_line & flags))
+    {
+        return detail::make_dynamic<BidiIter>(detail::assert_bos_matcher());
+    }
+    else
+    {
+        detail::assert_bol_matcher<Traits> matcher(tr);
+        return detail::make_dynamic<BidiIter>(matcher);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_assert_end_line
+//
+template<typename BidiIter, typename Traits>
+inline sequence<BidiIter> make_assert_end_line
+(
+    regex_constants::syntax_option_type flags
+  , Traits const &tr
+)
+{
+    if(0 != (regex_constants::single_line & flags))
+    {
+        return detail::make_dynamic<BidiIter>(detail::assert_eos_matcher());
+    }
+    else
+    {
+        detail::assert_eol_matcher<Traits> matcher(tr);
+        return detail::make_dynamic<BidiIter>(matcher);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_assert_word
+//
+template<typename BidiIter, typename Cond, typename Traits>
+inline sequence<BidiIter> make_assert_word(Cond, Traits const &tr)
+{
+    return detail::make_dynamic<BidiIter>
+    (
+        detail::assert_word_matcher<Cond, Traits>(tr)
+    );
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// make_independent_end_xpression
+//
+template<typename BidiIter>
+inline sequence<BidiIter> make_independent_end_xpression(bool pure)
+{
+    if(pure)
+    {
+        return detail::make_dynamic<BidiIter>(detail::true_matcher());
+    }
+    else
+    {
+        return detail::make_dynamic<BidiIter>(detail::independent_end_matcher());
+    }
+}
+
+}}} // namespace boost::xpressive::detail
+
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
+
+#endif

--- a/inst/include/boost/xpressive/detail/dynamic/parser_enum.hpp
+++ b/inst/include/boost/xpressive/detail/dynamic/parser_enum.hpp
@@ -1,0 +1,81 @@
+///////////////////////////////////////////////////////////////////////////////
+// parser_enum.hpp
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSER_ENUM_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSER_ENUM_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+namespace boost { namespace xpressive { namespace regex_constants
+{
+
+///////////////////////////////////////////////////////////////////////////////
+// compiler_token_type
+//
+enum compiler_token_type
+{
+    token_literal,
+    token_any,                          // .
+    token_escape,                       //
+    token_group_begin,                  // (
+    token_group_end,                    // )
+    token_alternate,                    // |
+    token_invalid_quantifier,           // {
+    token_charset_begin,                // [
+    token_charset_end,                  // ]
+    token_charset_invert,               // ^
+    token_charset_hyphen,               // -
+    token_charset_backspace,            // \b
+    token_posix_charset_begin,          // [:
+    token_posix_charset_end,            // :]
+    token_equivalence_class_begin,      // [=
+    token_equivalence_class_end,        // =]
+    token_collation_element_begin,      // [.
+    token_collation_element_end,        // .]
+
+    token_quote_meta_begin,             // \Q
+    token_quote_meta_end,               // \E
+
+    token_no_mark,                      // ?:
+    token_positive_lookahead,           // ?=
+    token_negative_lookahead,           // ?!
+    token_positive_lookbehind,          // ?<=
+    token_negative_lookbehind,          // ?<!
+    token_independent_sub_expression,   // ?>
+    token_comment,                      // ?#
+    token_recurse,                      // ?R
+    token_rule_assign,                  // ?$[name]=
+    token_rule_ref,                     // ?$[name]
+    token_named_mark,                   // ?P<name>
+    token_named_mark_ref,               // ?P=name
+
+    token_assert_begin_sequence,        // \A
+    token_assert_end_sequence,          // \Z
+    token_assert_begin_line,            // ^
+    token_assert_end_line,              // $
+    token_assert_word_begin,            // \<
+    token_assert_word_end,              // \>
+    token_assert_word_boundary,         // \b
+    token_assert_not_word_boundary,     // \B
+
+    token_escape_newline,               // \n
+    token_escape_escape,                // \e
+    token_escape_formfeed,              // \f
+    token_escape_horizontal_tab,        // \t
+    token_escape_vertical_tab,          // \v
+    token_escape_bell,                  // \a
+    token_escape_control,               // \c
+
+    token_end_of_pattern
+};
+
+}}} // namespace boost::xpressive::regex_constants
+
+#endif

--- a/inst/include/boost/xpressive/detail/dynamic/parser_traits.hpp
+++ b/inst/include/boost/xpressive/detail/dynamic/parser_traits.hpp
@@ -1,0 +1,475 @@
+///////////////////////////////////////////////////////////////////////////////
+// detail/dynamic/parser_traits.hpp
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSER_TRAITS_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_DETAIL_DYNAMIC_PARSER_TRAITS_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <string>
+#include <climits>
+#include <boost/config.hpp>
+#include <boost/assert.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/xpressive/regex_error.hpp>
+#include <boost/xpressive/regex_traits.hpp>
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/dynamic/matchable.hpp>
+#include <boost/xpressive/detail/dynamic/parser_enum.hpp>
+#include <boost/xpressive/detail/utility/literals.hpp>
+#include <boost/xpressive/detail/utility/algorithm.hpp>
+
+namespace boost { namespace xpressive
+{
+
+///////////////////////////////////////////////////////////////////////////////
+// compiler_traits
+//  this works for char and wchar_t. it must be specialized for anything else.
+//
+template<typename RegexTraits>
+struct compiler_traits
+{
+    typedef RegexTraits regex_traits;
+    typedef typename regex_traits::char_type char_type;
+    typedef typename regex_traits::string_type string_type;
+    typedef typename regex_traits::locale_type locale_type;
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // constructor
+    explicit compiler_traits(RegexTraits const &traits = RegexTraits())
+      : traits_(traits)
+      , flags_(regex_constants::ECMAScript)
+      , space_(lookup_classname(traits_, "space"))
+      , alnum_(lookup_classname(traits_, "alnum"))
+    {
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // flags
+    regex_constants::syntax_option_type flags() const
+    {
+        return this->flags_;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // flags
+    void flags(regex_constants::syntax_option_type flags)
+    {
+        this->flags_ = flags;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // traits
+    regex_traits &traits()
+    {
+        return this->traits_;
+    }
+
+    regex_traits const &traits() const
+    {
+        return this->traits_;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // imbue
+    locale_type imbue(locale_type const &loc)
+    {
+        locale_type oldloc = this->traits().imbue(loc);
+        this->space_ = lookup_classname(this->traits(), "space");
+        this->alnum_ = lookup_classname(this->traits(), "alnum");
+        return oldloc;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // getloc
+    locale_type getloc() const
+    {
+        return this->traits().getloc();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // get_token
+    //  get a token and advance the iterator
+    template<typename FwdIter>
+    regex_constants::compiler_token_type get_token(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        if(this->eat_ws_(begin, end) == end)
+        {
+            return regex_constants::token_end_of_pattern;
+        }
+
+        switch(*begin)
+        {
+        case BOOST_XPR_CHAR_(char_type, '\\'): return this->get_escape_token(++begin, end);
+        case BOOST_XPR_CHAR_(char_type, '.'): ++begin; return token_any;
+        case BOOST_XPR_CHAR_(char_type, '^'): ++begin; return token_assert_begin_line;
+        case BOOST_XPR_CHAR_(char_type, '$'): ++begin; return token_assert_end_line;
+        case BOOST_XPR_CHAR_(char_type, '('): ++begin; return token_group_begin;
+        case BOOST_XPR_CHAR_(char_type, ')'): ++begin; return token_group_end;
+        case BOOST_XPR_CHAR_(char_type, '|'): ++begin; return token_alternate;
+        case BOOST_XPR_CHAR_(char_type, '['): ++begin; return token_charset_begin;
+
+        case BOOST_XPR_CHAR_(char_type, '*'):
+        case BOOST_XPR_CHAR_(char_type, '+'):
+        case BOOST_XPR_CHAR_(char_type, '?'):
+            return token_invalid_quantifier;
+
+        case BOOST_XPR_CHAR_(char_type, ']'):
+        case BOOST_XPR_CHAR_(char_type, '{'):
+        default:
+            return token_literal;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // get_quant_spec
+    template<typename FwdIter>
+    bool get_quant_spec(FwdIter &begin, FwdIter end, detail::quant_spec &spec)
+    {
+        using namespace regex_constants;
+        FwdIter old_begin;
+
+        if(this->eat_ws_(begin, end) == end)
+        {
+            return false;
+        }
+
+        switch(*begin)
+        {
+        case BOOST_XPR_CHAR_(char_type, '*'):
+            spec.min_ = 0;
+            spec.max_ = (std::numeric_limits<unsigned int>::max)();
+            break;
+
+        case BOOST_XPR_CHAR_(char_type, '+'):
+            spec.min_ = 1;
+            spec.max_ = (std::numeric_limits<unsigned int>::max)();
+            break;
+
+        case BOOST_XPR_CHAR_(char_type, '?'):
+            spec.min_ = 0;
+            spec.max_ = 1;
+            break;
+
+        case BOOST_XPR_CHAR_(char_type, '{'):
+            old_begin = this->eat_ws_(++begin, end);
+            spec.min_ = spec.max_ = detail::toi(begin, end, this->traits());
+            BOOST_XPR_ENSURE_
+            (
+                begin != old_begin && begin != end, error_brace, "invalid quantifier"
+            );
+
+            if(*begin == BOOST_XPR_CHAR_(char_type, ','))
+            {
+                old_begin = this->eat_ws_(++begin, end);
+                spec.max_ = detail::toi(begin, end, this->traits());
+                BOOST_XPR_ENSURE_
+                (
+                    begin != end && BOOST_XPR_CHAR_(char_type, '}') == *begin
+                  , error_brace, "invalid quantifier"
+                );
+
+                if(begin == old_begin)
+                {
+                    spec.max_ = (std::numeric_limits<unsigned int>::max)();
+                }
+                else
+                {
+                    BOOST_XPR_ENSURE_
+                    (
+                        spec.min_ <= spec.max_, error_badbrace, "invalid quantification range"
+                    );
+                }
+            }
+            else
+            {
+                BOOST_XPR_ENSURE_
+                (
+                    BOOST_XPR_CHAR_(char_type, '}') == *begin, error_brace, "invalid quantifier"
+                );
+            }
+            break;
+
+        default:
+            return false;
+        }
+
+        spec.greedy_ = true;
+        if(this->eat_ws_(++begin, end) != end && BOOST_XPR_CHAR_(char_type, '?') == *begin)
+        {
+            ++begin;
+            spec.greedy_ = false;
+        }
+
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // get_group_type
+    template<typename FwdIter>
+    regex_constants::compiler_token_type get_group_type(FwdIter &begin, FwdIter end, string_type &name)
+    {
+        using namespace regex_constants;
+        if(this->eat_ws_(begin, end) != end && BOOST_XPR_CHAR_(char_type, '?') == *begin)
+        {
+            this->eat_ws_(++begin, end);
+            BOOST_XPR_ENSURE_(begin != end, error_paren, "incomplete extension");
+
+            switch(*begin)
+            {
+            case BOOST_XPR_CHAR_(char_type, ':'): ++begin; return token_no_mark;
+            case BOOST_XPR_CHAR_(char_type, '>'): ++begin; return token_independent_sub_expression;
+            case BOOST_XPR_CHAR_(char_type, '#'): ++begin; return token_comment;
+            case BOOST_XPR_CHAR_(char_type, '='): ++begin; return token_positive_lookahead;
+            case BOOST_XPR_CHAR_(char_type, '!'): ++begin; return token_negative_lookahead;
+            case BOOST_XPR_CHAR_(char_type, 'R'): ++begin; return token_recurse;
+            case BOOST_XPR_CHAR_(char_type, '$'):
+                this->get_name_(++begin, end, name);
+                BOOST_XPR_ENSURE_(begin != end, error_paren, "incomplete extension");
+                if(BOOST_XPR_CHAR_(char_type, '=') == *begin)
+                {
+                    ++begin;
+                    return token_rule_assign;
+                }
+                return token_rule_ref;
+
+            case BOOST_XPR_CHAR_(char_type, '<'):
+                this->eat_ws_(++begin, end);
+                BOOST_XPR_ENSURE_(begin != end, error_paren, "incomplete extension");
+                switch(*begin)
+                {
+                case BOOST_XPR_CHAR_(char_type, '='): ++begin; return token_positive_lookbehind;
+                case BOOST_XPR_CHAR_(char_type, '!'): ++begin; return token_negative_lookbehind;
+                default:
+                    BOOST_THROW_EXCEPTION(regex_error(error_badbrace, "unrecognized extension"));
+                }
+
+            case BOOST_XPR_CHAR_(char_type, 'P'):
+                this->eat_ws_(++begin, end);
+                BOOST_XPR_ENSURE_(begin != end, error_paren, "incomplete extension");
+                switch(*begin)
+                {
+                case BOOST_XPR_CHAR_(char_type, '<'):
+                    this->get_name_(++begin, end, name);
+                    BOOST_XPR_ENSURE_(begin != end && BOOST_XPR_CHAR_(char_type, '>') == *begin++, error_paren, "incomplete extension");
+                    return token_named_mark;
+                case BOOST_XPR_CHAR_(char_type, '='):
+                    this->get_name_(++begin, end, name);
+                    BOOST_XPR_ENSURE_(begin != end, error_paren, "incomplete extension");
+                    return token_named_mark_ref;
+                default:
+                    BOOST_THROW_EXCEPTION(regex_error(error_badbrace, "unrecognized extension"));
+                }
+
+            case BOOST_XPR_CHAR_(char_type, 'i'):
+            case BOOST_XPR_CHAR_(char_type, 'm'):
+            case BOOST_XPR_CHAR_(char_type, 's'):
+            case BOOST_XPR_CHAR_(char_type, 'x'):
+            case BOOST_XPR_CHAR_(char_type, '-'):
+                return this->parse_mods_(begin, end);
+
+            default:
+                BOOST_THROW_EXCEPTION(regex_error(error_badbrace, "unrecognized extension"));
+            }
+        }
+
+        return token_literal;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // get_charset_token
+    //  NOTE: white-space is *never* ignored in a charset.
+    template<typename FwdIter>
+    regex_constants::compiler_token_type get_charset_token(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        BOOST_ASSERT(begin != end);
+        switch(*begin)
+        {
+        case BOOST_XPR_CHAR_(char_type, '^'): ++begin; return token_charset_invert;
+        case BOOST_XPR_CHAR_(char_type, '-'): ++begin; return token_charset_hyphen;
+        case BOOST_XPR_CHAR_(char_type, ']'): ++begin; return token_charset_end;
+        case BOOST_XPR_CHAR_(char_type, '['):
+            {
+                FwdIter next = begin; ++next;
+                if(next != end)
+                {
+                    BOOST_XPR_ENSURE_(
+                        *next != BOOST_XPR_CHAR_(char_type, '=')
+                      , error_collate
+                      , "equivalence classes are not yet supported"
+                    );
+
+                    BOOST_XPR_ENSURE_(
+                        *next != BOOST_XPR_CHAR_(char_type, '.')
+                      , error_collate
+                      , "collation sequences are not yet supported"
+                    );
+
+                    if(*next == BOOST_XPR_CHAR_(char_type, ':'))
+                    {
+                        begin = ++next;
+                        return token_posix_charset_begin;
+                    }
+                }
+            }
+            break;
+        case BOOST_XPR_CHAR_(char_type, ':'):
+            {
+                FwdIter next = begin; ++next;
+                if(next != end && *next == BOOST_XPR_CHAR_(char_type, ']'))
+                {
+                    begin = ++next;
+                    return token_posix_charset_end;
+                }
+            }
+            break;
+        case BOOST_XPR_CHAR_(char_type, '\\'):
+            if(++begin != end)
+            {
+                switch(*begin)
+                {
+                case BOOST_XPR_CHAR_(char_type, 'b'): ++begin; return token_charset_backspace;
+                default:;
+                }
+            }
+            return token_escape;
+        default:;
+        }
+        return token_literal;
+    }
+
+    //////////////////////////////////////////////////////////////////////////
+    // get_escape_token
+    template<typename FwdIter>
+    regex_constants::compiler_token_type get_escape_token(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        if(begin != end)
+        {
+            switch(*begin)
+            {
+            //case BOOST_XPR_CHAR_(char_type, 'a'): ++begin; return token_escape_bell;
+            //case BOOST_XPR_CHAR_(char_type, 'c'): ++begin; return token_escape_control;
+            //case BOOST_XPR_CHAR_(char_type, 'e'): ++begin; return token_escape_escape;
+            //case BOOST_XPR_CHAR_(char_type, 'f'): ++begin; return token_escape_formfeed;
+            //case BOOST_XPR_CHAR_(char_type, 'n'): ++begin; return token_escape_newline;
+            //case BOOST_XPR_CHAR_(char_type, 't'): ++begin; return token_escape_horizontal_tab;
+            //case BOOST_XPR_CHAR_(char_type, 'v'): ++begin; return token_escape_vertical_tab;
+            case BOOST_XPR_CHAR_(char_type, 'A'): ++begin; return token_assert_begin_sequence;
+            case BOOST_XPR_CHAR_(char_type, 'b'): ++begin; return token_assert_word_boundary;
+            case BOOST_XPR_CHAR_(char_type, 'B'): ++begin; return token_assert_not_word_boundary;
+            case BOOST_XPR_CHAR_(char_type, 'E'): ++begin; return token_quote_meta_end;
+            case BOOST_XPR_CHAR_(char_type, 'Q'): ++begin; return token_quote_meta_begin;
+            case BOOST_XPR_CHAR_(char_type, 'Z'): ++begin; return token_assert_end_sequence;
+            // Non-standard extension to ECMAScript syntax
+            case BOOST_XPR_CHAR_(char_type, '<'): ++begin; return token_assert_word_begin;
+            case BOOST_XPR_CHAR_(char_type, '>'): ++begin; return token_assert_word_end;
+            default:; // fall-through
+            }
+        }
+
+        return token_escape;
+    }
+
+private:
+
+    //////////////////////////////////////////////////////////////////////////
+    // parse_mods_
+    template<typename FwdIter>
+    regex_constants::compiler_token_type parse_mods_(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        bool set = true;
+        do switch(*begin)
+        {
+        case BOOST_XPR_CHAR_(char_type, 'i'): this->flag_(set, icase_); break;
+        case BOOST_XPR_CHAR_(char_type, 'm'): this->flag_(!set, single_line); break;
+        case BOOST_XPR_CHAR_(char_type, 's'): this->flag_(!set, not_dot_newline); break;
+        case BOOST_XPR_CHAR_(char_type, 'x'): this->flag_(set, ignore_white_space); break;
+        case BOOST_XPR_CHAR_(char_type, ':'): ++begin; BOOST_FALLTHROUGH;
+        case BOOST_XPR_CHAR_(char_type, ')'): return token_no_mark;
+        case BOOST_XPR_CHAR_(char_type, '-'): if(false == (set = !set)) break; BOOST_FALLTHROUGH;
+        default: BOOST_THROW_EXCEPTION(regex_error(error_paren, "unknown pattern modifier"));
+        }
+        while(BOOST_XPR_ENSURE_(++begin != end, error_paren, "incomplete extension"));
+        // this return is technically unreachable, but this must
+        // be here to work around a bug in gcc 4.0
+        return token_no_mark;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // flag_
+    void flag_(bool set, regex_constants::syntax_option_type flag)
+    {
+        this->flags_ = set ? (this->flags_ | flag) : (this->flags_ & ~flag);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // is_space_
+    bool is_space_(char_type ch) const
+    {
+        return 0 != this->space_ && this->traits().isctype(ch, this->space_);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // is_alnum_
+    bool is_alnum_(char_type ch) const
+    {
+        return 0 != this->alnum_ && this->traits().isctype(ch, this->alnum_);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // get_name_
+    template<typename FwdIter>
+    void get_name_(FwdIter &begin, FwdIter end, string_type &name)
+    {
+        this->eat_ws_(begin, end);
+        for(name.clear(); begin != end && this->is_alnum_(*begin); ++begin)
+        {
+            name.push_back(*begin);
+        }
+        this->eat_ws_(begin, end);
+        BOOST_XPR_ENSURE_(!name.empty(), regex_constants::error_paren, "incomplete extension");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // eat_ws_
+    template<typename FwdIter>
+    FwdIter &eat_ws_(FwdIter &begin, FwdIter end)
+    {
+        if(0 != (regex_constants::ignore_white_space & this->flags()))
+        {
+            while(end != begin && (BOOST_XPR_CHAR_(char_type, '#') == *begin || this->is_space_(*begin)))
+            {
+                if(BOOST_XPR_CHAR_(char_type, '#') == *begin++)
+                {
+                    while(end != begin && BOOST_XPR_CHAR_(char_type, '\n') != *begin++) {}
+                }
+                else
+                {
+                    for(; end != begin && this->is_space_(*begin); ++begin) {}
+                }
+            }
+        }
+
+        return begin;
+    }
+
+    regex_traits traits_;
+    regex_constants::syntax_option_type flags_;
+    typename regex_traits::char_class_type space_;
+    typename regex_traits::char_class_type alnum_;
+};
+
+}} // namespace boost::xpressive
+
+#endif

--- a/inst/include/boost/xpressive/regex_actions.hpp
+++ b/inst/include/boost/xpressive/regex_actions.hpp
@@ -1,0 +1,1574 @@
+///////////////////////////////////////////////////////////////////////////////
+/// \file regex_actions.hpp
+/// Defines the syntax elements of xpressive's action expressions.
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_ACTIONS_HPP_EAN_03_22_2007
+#define BOOST_XPRESSIVE_ACTIONS_HPP_EAN_03_22_2007
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/config.hpp>
+#include <boost/preprocessor/punctuation/comma_if.hpp>
+#include <boost/ref.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/int.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/decay.hpp>
+#include <boost/type_traits/remove_cv.hpp>
+#include <boost/type_traits/remove_reference.hpp>
+#include <boost/range/iterator_range.hpp>
+#include <boost/xpressive/detail/detail_fwd.hpp>
+#include <boost/xpressive/detail/core/state.hpp>
+#include <boost/xpressive/detail/core/matcher/attr_matcher.hpp>
+#include <boost/xpressive/detail/core/matcher/attr_end_matcher.hpp>
+#include <boost/xpressive/detail/core/matcher/attr_begin_matcher.hpp>
+#include <boost/xpressive/detail/core/matcher/predicate_matcher.hpp>
+#include <boost/xpressive/detail/utility/ignore_unused.hpp>
+#include <boost/xpressive/detail/static/type_traits.hpp>
+
+// These are very often needed by client code.
+#include <boost/typeof/std/map.hpp>
+#include <boost/typeof/std/string.hpp>
+
+// Doxygen can't handle proto :-(
+#ifndef BOOST_XPRESSIVE_DOXYGEN_INVOKED
+# include <boost/proto/core.hpp>
+# include <boost/proto/transform.hpp>
+# include <boost/xpressive/detail/core/matcher/action_matcher.hpp>
+#endif
+
+#if BOOST_MSVC
+#pragma warning(push)
+#pragma warning(disable : 4510) // default constructor could not be generated
+#pragma warning(disable : 4512) // assignment operator could not be generated
+#pragma warning(disable : 4610) // can never be instantiated - user defined constructor required
+#endif
+
+namespace boost { namespace xpressive
+{
+
+    namespace detail
+    {
+        template<typename T, typename U>
+        struct action_arg
+        {
+            typedef T type;
+            typedef typename add_reference<T>::type reference;
+
+            reference cast(void *pv) const
+            {
+                return *static_cast<typename remove_reference<T>::type *>(pv);
+            }
+        };
+
+        template<typename T>
+        struct value_wrapper
+          : private noncopyable
+        {
+            value_wrapper()
+              : value()
+            {}
+
+            value_wrapper(T const &t)
+              : value(t)
+            {}
+
+            T value;
+        };
+
+        struct check_tag
+        {};
+
+        struct BindArg
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename MatchResults, typename Expr>
+            struct result<This(MatchResults, Expr)>
+            {
+                typedef Expr type;
+            };
+
+            template<typename MatchResults, typename Expr>
+            Expr const & operator ()(MatchResults &what, Expr const &expr) const
+            {
+                what.let(expr);
+                return expr;
+            }
+        };
+
+        struct let_tag
+        {};
+
+        // let(_a = b, _c = d)
+        struct BindArgs
+          : proto::function<
+                proto::terminal<let_tag>
+              , proto::vararg<
+                    proto::when<
+                        proto::assign<proto::_, proto::_>
+                      , proto::call<BindArg(proto::_data, proto::_)>
+                    >
+                >
+            >
+        {};
+
+        struct let_domain
+          : boost::proto::domain<boost::proto::pod_generator<let_> >
+        {};
+
+        template<typename Expr>
+        struct let_
+        {
+            BOOST_PROTO_BASIC_EXTENDS(Expr, let_<Expr>, let_domain)
+            BOOST_PROTO_EXTENDS_FUNCTION()
+        };
+
+        template<typename Args, typename BidiIter>
+        void bind_args(let_<Args> const &args, match_results<BidiIter> &what)
+        {
+            BindArgs()(args, 0, what);
+        }
+
+        typedef boost::proto::functional::make_expr<proto::tag::function, proto::default_domain> make_function;
+    }
+
+    namespace op
+    {
+        /// \brief \c at is a PolymorphicFunctionObject for indexing into a sequence
+        struct at
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Cont, typename Idx>
+            struct result<This(Cont &, Idx)>
+            {
+                typedef typename Cont::reference type;
+            };
+
+            template<typename This, typename Cont, typename Idx>
+            struct result<This(Cont const &, Idx)>
+            {
+                typedef typename Cont::const_reference type;
+            };
+
+            template<typename This, typename Cont, typename Idx>
+            struct result<This(Cont, Idx)>
+            {
+                typedef typename Cont::const_reference type;
+            };
+
+            /// \pre    \c Cont is a model of RandomAccessSequence
+            /// \param  c The RandomAccessSequence to index into
+            /// \param  idx The index
+            /// \return <tt>c[idx]</tt>
+            template<typename Cont, typename Idx>
+            typename Cont::reference operator()(Cont &c, Idx idx BOOST_PROTO_DISABLE_IF_IS_CONST(Cont)) const
+            {
+                return c[idx];
+            }
+
+            /// \overload
+            ///
+            template<typename Cont, typename Idx>
+            typename Cont::const_reference operator()(Cont const &c, Idx idx) const
+            {
+                return c[idx];
+            }
+        };
+
+        /// \brief \c push is a PolymorphicFunctionObject for pushing an element into a container.
+        struct push
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef void result_type;
+
+            /// \param seq The sequence into which the value should be pushed.
+            /// \param val The value to push into the sequence.
+            /// \brief Equivalent to <tt>seq.push(val)</tt>.
+            /// \return \c void
+            template<typename Sequence, typename Value>
+            void operator()(Sequence &seq, Value const &val) const
+            {
+                seq.push(val);
+            }
+        };
+
+        /// \brief \c push_back is a PolymorphicFunctionObject for pushing an element into the back of a container.
+        struct push_back
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef void result_type;
+
+            /// \param seq The sequence into which the value should be pushed.
+            /// \param val The value to push into the sequence.
+            /// \brief Equivalent to <tt>seq.push_back(val)</tt>.
+            /// \return \c void
+            template<typename Sequence, typename Value>
+            void operator()(Sequence &seq, Value const &val) const
+            {
+                seq.push_back(val);
+            }
+        };
+
+        /// \brief \c push_front is a PolymorphicFunctionObject for pushing an element into the front of a container.
+        struct push_front
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef void result_type;
+
+            /// \param seq The sequence into which the value should be pushed.
+            /// \param val The value to push into the sequence.
+            /// \brief Equivalent to <tt>seq.push_front(val)</tt>.
+            /// \return \c void
+            template<typename Sequence, typename Value>
+            void operator()(Sequence &seq, Value const &val) const
+            {
+                seq.push_front(val);
+            }
+        };
+
+        /// \brief \c pop is a PolymorphicFunctionObject for popping an element from a container.
+        struct pop
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef void result_type;
+
+            /// \param seq The sequence from which to pop.
+            /// \brief Equivalent to <tt>seq.pop()</tt>.
+            /// \return \c void
+            template<typename Sequence>
+            void operator()(Sequence &seq) const
+            {
+                seq.pop();
+            }
+        };
+
+        /// \brief \c pop_back is a PolymorphicFunctionObject for popping an element from the back of a container.
+        struct pop_back
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef void result_type;
+
+            /// \param seq The sequence from which to pop.
+            /// \brief Equivalent to <tt>seq.pop_back()</tt>.
+            /// \return \c void
+            template<typename Sequence>
+            void operator()(Sequence &seq) const
+            {
+                seq.pop_back();
+            }
+        };
+
+        /// \brief \c pop_front is a PolymorphicFunctionObject for popping an element from the front of a container.
+        struct pop_front
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef void result_type;
+
+            /// \param seq The sequence from which to pop.
+            /// \brief Equivalent to <tt>seq.pop_front()</tt>.
+            /// \return \c void
+            template<typename Sequence>
+            void operator()(Sequence &seq) const
+            {
+                seq.pop_front();
+            }
+        };
+
+        /// \brief \c front is a PolymorphicFunctionObject for fetching the front element of a container.
+        struct front
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Sequence>
+            struct result<This(Sequence)>
+            {
+                typedef typename remove_reference<Sequence>::type sequence_type;
+                typedef
+                    typename mpl::if_c<
+                        is_const<sequence_type>::value
+                      , typename sequence_type::const_reference
+                      , typename sequence_type::reference
+                    >::type
+                type;
+            };
+
+            /// \param seq The sequence from which to fetch the front.
+            /// \return <tt>seq.front()</tt>
+            template<typename Sequence>
+            typename result<front(Sequence &)>::type operator()(Sequence &seq) const
+            {
+                return seq.front();
+            }
+        };
+
+        /// \brief \c back is a PolymorphicFunctionObject for fetching the back element of a container.
+        struct back
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Sequence>
+            struct result<This(Sequence)>
+            {
+                typedef typename remove_reference<Sequence>::type sequence_type;
+                typedef
+                    typename mpl::if_c<
+                        is_const<sequence_type>::value
+                      , typename sequence_type::const_reference
+                      , typename sequence_type::reference
+                    >::type
+                type;
+            };
+
+            /// \param seq The sequence from which to fetch the back.
+            /// \return <tt>seq.back()</tt>
+            template<typename Sequence>
+            typename result<back(Sequence &)>::type operator()(Sequence &seq) const
+            {
+                return seq.back();
+            }
+        };
+
+        /// \brief \c top is a PolymorphicFunctionObject for fetching the top element of a stack.
+        struct top
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Sequence>
+            struct result<This(Sequence)>
+            {
+                typedef typename remove_reference<Sequence>::type sequence_type;
+                typedef
+                    typename mpl::if_c<
+                        is_const<sequence_type>::value
+                      , typename sequence_type::value_type const &
+                      , typename sequence_type::value_type &
+                    >::type
+                type;
+            };
+
+            /// \param seq The sequence from which to fetch the top.
+            /// \return <tt>seq.top()</tt>
+            template<typename Sequence>
+            typename result<top(Sequence &)>::type operator()(Sequence &seq) const
+            {
+                return seq.top();
+            }
+        };
+
+        /// \brief \c first is a PolymorphicFunctionObject for fetching the first element of a pair.
+        struct first
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Pair>
+            struct result<This(Pair)>
+            {
+                typedef typename remove_reference<Pair>::type::first_type type;
+            };
+
+            /// \param p The pair from which to fetch the first element.
+            /// \return <tt>p.first</tt>
+            template<typename Pair>
+            typename Pair::first_type operator()(Pair const &p) const
+            {
+                return p.first;
+            }
+        };
+
+        /// \brief \c second is a PolymorphicFunctionObject for fetching the second element of a pair.
+        struct second
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Pair>
+            struct result<This(Pair)>
+            {
+                typedef typename remove_reference<Pair>::type::second_type type;
+            };
+
+            /// \param p The pair from which to fetch the second element.
+            /// \return <tt>p.second</tt>
+            template<typename Pair>
+            typename Pair::second_type operator()(Pair const &p) const
+            {
+                return p.second;
+            }
+        };
+
+        /// \brief \c matched is a PolymorphicFunctionObject for assessing whether a \c sub_match object
+        ///        matched or not.
+        struct matched
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef bool result_type;
+
+            /// \param sub The \c sub_match object.
+            /// \return <tt>sub.matched</tt>
+            template<typename Sub>
+            bool operator()(Sub const &sub) const
+            {
+                return sub.matched;
+            }
+        };
+
+        /// \brief \c length is a PolymorphicFunctionObject for fetching the length of \c sub_match.
+        struct length
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Sub>
+            struct result<This(Sub)>
+            {
+                typedef typename remove_reference<Sub>::type::difference_type type;
+            };
+
+            /// \param sub The \c sub_match object.
+            /// \return <tt>sub.length()</tt>
+            template<typename Sub>
+            typename Sub::difference_type operator()(Sub const &sub) const
+            {
+                return sub.length();
+            }
+        };
+
+        /// \brief \c str is a PolymorphicFunctionObject for turning a \c sub_match into an
+        ///        equivalent \c std::string.
+        struct str
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Sub>
+            struct result<This(Sub)>
+            {
+                typedef typename remove_reference<Sub>::type::string_type type;
+            };
+
+            /// \param sub The \c sub_match object.
+            /// \return <tt>sub.str()</tt>
+            template<typename Sub>
+            typename Sub::string_type operator()(Sub const &sub) const
+            {
+                return sub.str();
+            }
+        };
+
+        // This codifies the return types of the various insert member
+        // functions found in sequence containers, the 2 flavors of
+        // associative containers, and strings.
+        //
+        /// \brief \c insert is a PolymorphicFunctionObject for inserting a value or a
+        ///        sequence of values into a sequence container, an associative
+        ///        container, or a string.
+        struct insert
+        {
+            BOOST_PROTO_CALLABLE()
+
+            /// INTERNAL ONLY
+            ///
+            struct detail
+            {
+                template<typename Sig, typename EnableIf = void>
+                struct result_detail
+                {};
+
+                // assoc containers
+                template<typename This, typename Cont, typename Value>
+                struct result_detail<This(Cont, Value), void>
+                {
+                    typedef typename remove_reference<Cont>::type cont_type;
+                    typedef typename remove_reference<Value>::type value_type;
+                    static cont_type &scont_;
+                    static value_type &svalue_;
+                    typedef char yes_type;
+                    typedef char (&no_type)[2];
+                    static yes_type check_insert_return(typename cont_type::iterator);
+                    static no_type check_insert_return(std::pair<typename cont_type::iterator, bool>);
+                    BOOST_STATIC_CONSTANT(bool, is_iterator = (sizeof(yes_type) == sizeof(check_insert_return(scont_.insert(svalue_)))));
+                    typedef
+                        typename mpl::if_c<
+                            is_iterator
+                          , typename cont_type::iterator
+                          , std::pair<typename cont_type::iterator, bool>
+                        >::type
+                    type;
+                };
+
+                // sequence containers, assoc containers, strings
+                template<typename This, typename Cont, typename It, typename Value>
+                struct result_detail<This(Cont, It, Value),
+                    typename disable_if<
+                        mpl::or_<
+                            is_integral<typename remove_cv<typename remove_reference<It>::type>::type>
+                          , is_same<
+                                typename remove_cv<typename remove_reference<It>::type>::type
+                              , typename remove_cv<typename remove_reference<Value>::type>::type
+                            >
+                        >
+                    >::type
+                >
+                {
+                    typedef typename remove_reference<Cont>::type::iterator type;
+                };
+
+                // strings
+                template<typename This, typename Cont, typename Size, typename T>
+                struct result_detail<This(Cont, Size, T),
+                    typename enable_if<
+                        is_integral<typename remove_cv<typename remove_reference<Size>::type>::type>
+                    >::type
+                >
+                {
+                    typedef typename remove_reference<Cont>::type &type;
+                };
+
+                // assoc containers
+                template<typename This, typename Cont, typename It>
+                struct result_detail<This(Cont, It, It), void>
+                {
+                    typedef void type;
+                };
+
+                // sequence containers, strings
+                template<typename This, typename Cont, typename It, typename Size, typename Value>
+                struct result_detail<This(Cont, It, Size, Value),
+                    typename disable_if<
+                        is_integral<typename remove_cv<typename remove_reference<It>::type>::type>
+                    >::type
+                >
+                {
+                    typedef void type;
+                };
+
+                // strings
+                template<typename This, typename Cont, typename Size, typename A0, typename A1>
+                struct result_detail<This(Cont, Size, A0, A1),
+                    typename enable_if<
+                        is_integral<typename remove_cv<typename remove_reference<Size>::type>::type>
+                    >::type
+                >
+                {
+                    typedef typename remove_reference<Cont>::type &type;
+                };
+
+                // strings
+                template<typename This, typename Cont, typename Pos0, typename String, typename Pos1, typename Length>
+                struct result_detail<This(Cont, Pos0, String, Pos1, Length)>
+                {
+                    typedef typename remove_reference<Cont>::type &type;
+                };
+            };
+
+            template<typename Sig>
+            struct result
+            {
+                typedef typename detail::result_detail<Sig>::type type;
+            };
+
+            /// \overload
+            ///
+            template<typename Cont, typename A0>
+            typename result<insert(Cont &, A0 const &)>::type
+            operator()(Cont &cont, A0 const &a0) const
+            {
+                return cont.insert(a0);
+            }
+
+            /// \overload
+            ///
+            template<typename Cont, typename A0, typename A1>
+            typename result<insert(Cont &, A0 const &, A1 const &)>::type
+            operator()(Cont &cont, A0 const &a0, A1 const &a1) const
+            {
+                return cont.insert(a0, a1);
+            }
+
+            /// \overload
+            ///
+            template<typename Cont, typename A0, typename A1, typename A2>
+            typename result<insert(Cont &, A0 const &, A1 const &, A2 const &)>::type
+            operator()(Cont &cont, A0 const &a0, A1 const &a1, A2 const &a2) const
+            {
+                return cont.insert(a0, a1, a2);
+            }
+
+            /// \param cont The container into which to insert the element(s)
+            /// \param a0 A value, iterator, or count
+            /// \param a1 A value, iterator, string, count, or character
+            /// \param a2 A value, iterator, or count
+            /// \param a3 A count
+            /// \return \li For the form <tt>insert()(cont, a0)</tt>, return <tt>cont.insert(a0)</tt>.
+            ///         \li For the form <tt>insert()(cont, a0, a1)</tt>, return <tt>cont.insert(a0, a1)</tt>.
+            ///         \li For the form <tt>insert()(cont, a0, a1, a2)</tt>, return <tt>cont.insert(a0, a1, a2)</tt>.
+            ///         \li For the form <tt>insert()(cont, a0, a1, a2, a3)</tt>, return <tt>cont.insert(a0, a1, a2, a3)</tt>.
+            template<typename Cont, typename A0, typename A1, typename A2, typename A3>
+            typename result<insert(Cont &, A0 const &, A1 const &, A2 const &, A3 const &)>::type
+            operator()(Cont &cont, A0 const &a0, A1 const &a1, A2 const &a2, A3 const &a3) const
+            {
+                return cont.insert(a0, a1, a2, a3);
+            }
+        };
+
+        /// \brief \c make_pair is a PolymorphicFunctionObject for building a \c std::pair out of two parameters
+        struct make_pair
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename First, typename Second>
+            struct result<This(First, Second)>
+            {
+                /// \brief For exposition only
+                typedef typename decay<First>::type first_type;
+                /// \brief For exposition only
+                typedef typename decay<Second>::type second_type;
+                typedef std::pair<first_type, second_type> type;
+            };
+
+            /// \param first The first element of the pair
+            /// \param second The second element of the pair
+            /// \return <tt>std::make_pair(first, second)</tt>
+            template<typename First, typename Second>
+            std::pair<First, Second> operator()(First const &first, Second const &second) const
+            {
+                return std::make_pair(first, second);
+            }
+        };
+
+        /// \brief \c as\<\> is a PolymorphicFunctionObject for lexically casting a parameter to a different type.
+        /// \tparam T The type to which to lexically cast the parameter.
+        template<typename T>
+        struct as
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef T result_type;
+
+            /// \param val The value to lexically cast.
+            /// \return <tt>boost::lexical_cast\<T\>(val)</tt>
+            template<typename Value>
+            T operator()(Value const &val) const
+            {
+                return boost::lexical_cast<T>(val);
+            }
+
+            // Hack around some limitations in boost::lexical_cast
+            /// INTERNAL ONLY
+            T operator()(csub_match const &val) const
+            {
+                return val.matched
+                  ? boost::lexical_cast<T>(boost::make_iterator_range(val.first, val.second))
+                  : boost::lexical_cast<T>("");
+            }
+
+            #ifndef BOOST_XPRESSIVE_NO_WREGEX
+            /// INTERNAL ONLY
+            T operator()(wcsub_match const &val) const
+            {
+                return val.matched
+                  ? boost::lexical_cast<T>(boost::make_iterator_range(val.first, val.second))
+                  : boost::lexical_cast<T>("");
+            }
+            #endif
+
+            /// INTERNAL ONLY
+            template<typename BidiIter>
+            T operator()(sub_match<BidiIter> const &val) const
+            {
+                // If this assert fires, you're trying to coerce a sequences of non-characters
+                // to some other type. Xpressive doesn't know how to do that.
+                typedef typename iterator_value<BidiIter>::type char_type;
+                BOOST_MPL_ASSERT_MSG(
+                    (xpressive::detail::is_char<char_type>::value)
+                  , CAN_ONLY_CONVERT_FROM_CHARACTER_SEQUENCES
+                  , (char_type)
+                );
+                return this->impl(val, xpressive::detail::is_string_iterator<BidiIter>());
+            }
+
+        private:
+            /// INTERNAL ONLY
+            template<typename RandIter>
+            T impl(sub_match<RandIter> const &val, mpl::true_) const
+            {
+                return val.matched
+                  ? boost::lexical_cast<T>(boost::make_iterator_range(&*val.first, &*val.first + (val.second - val.first)))
+                  : boost::lexical_cast<T>("");
+            }
+
+            /// INTERNAL ONLY
+            template<typename BidiIter>
+            T impl(sub_match<BidiIter> const &val, mpl::false_) const
+            {
+                return boost::lexical_cast<T>(val.str());
+            }
+        };
+
+        /// \brief \c static_cast_\<\> is a PolymorphicFunctionObject for statically casting a parameter to a different type.
+        /// \tparam T The type to which to statically cast the parameter.
+        template<typename T>
+        struct static_cast_
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef T result_type;
+
+            /// \param val The value to statically cast.
+            /// \return <tt>static_cast\<T\>(val)</tt>
+            template<typename Value>
+            T operator()(Value const &val) const
+            {
+                return static_cast<T>(val);
+            }
+        };
+
+        /// \brief \c dynamic_cast_\<\> is a PolymorphicFunctionObject for dynamically casting a parameter to a different type.
+        /// \tparam T The type to which to dynamically cast the parameter.
+        template<typename T>
+        struct dynamic_cast_
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef T result_type;
+
+            /// \param val The value to dynamically cast.
+            /// \return <tt>dynamic_cast\<T\>(val)</tt>
+            template<typename Value>
+            T operator()(Value const &val) const
+            {
+                return dynamic_cast<T>(val);
+            }
+        };
+
+        /// \brief \c const_cast_\<\> is a PolymorphicFunctionObject for const-casting a parameter to a cv qualification.
+        /// \tparam T The type to which to const-cast the parameter.
+        template<typename T>
+        struct const_cast_
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef T result_type;
+
+            /// \param val The value to const-cast.
+            /// \pre Types \c T and \c Value differ only in cv-qualification.
+            /// \return <tt>const_cast\<T\>(val)</tt>
+            template<typename Value>
+            T operator()(Value const &val) const
+            {
+                return const_cast<T>(val);
+            }
+        };
+
+        /// \brief \c construct\<\> is a PolymorphicFunctionObject for constructing a new object.
+        /// \tparam T The type of the object to construct.
+        template<typename T>
+        struct construct
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef T result_type;
+
+            /// \overload
+            T operator()() const
+            {
+                return T();
+            }
+
+            /// \overload
+            template<typename A0>
+            T operator()(A0 const &a0) const
+            {
+                return T(a0);
+            }
+
+            /// \overload
+            template<typename A0, typename A1>
+            T operator()(A0 const &a0, A1 const &a1) const
+            {
+                return T(a0, a1);
+            }
+
+            /// \param a0 The first argument to the constructor
+            /// \param a1 The second argument to the constructor
+            /// \param a2 The third argument to the constructor
+            /// \return <tt>T(a0,a1,...)</tt>
+            template<typename A0, typename A1, typename A2>
+            T operator()(A0 const &a0, A1 const &a1, A2 const &a2) const
+            {
+                return T(a0, a1, a2);
+            }
+        };
+
+        /// \brief \c throw_\<\> is a PolymorphicFunctionObject for throwing an exception.
+        /// \tparam Except The type of the object to throw.
+        template<typename Except>
+        struct throw_
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef void result_type;
+
+            /// \overload
+            void operator()() const
+            {
+                BOOST_THROW_EXCEPTION(Except());
+            }
+
+            /// \overload
+            template<typename A0>
+            void operator()(A0 const &a0) const
+            {
+                BOOST_THROW_EXCEPTION(Except(a0));
+            }
+
+            /// \overload
+            template<typename A0, typename A1>
+            void operator()(A0 const &a0, A1 const &a1) const
+            {
+                BOOST_THROW_EXCEPTION(Except(a0, a1));
+            }
+
+            /// \param a0 The first argument to the constructor
+            /// \param a1 The second argument to the constructor
+            /// \param a2 The third argument to the constructor
+            /// \throw <tt>Except(a0,a1,...)</tt>
+            /// \note This function makes use of the \c BOOST_THROW_EXCEPTION macro
+            ///       to actually throw the exception. See the documentation for the
+            ///       Boost.Exception library.
+            template<typename A0, typename A1, typename A2>
+            void operator()(A0 const &a0, A1 const &a1, A2 const &a2) const
+            {
+                BOOST_THROW_EXCEPTION(Except(a0, a1, a2));
+            }
+        };
+
+        /// \brief \c unwrap_reference is a PolymorphicFunctionObject for unwrapping a <tt>boost::reference_wrapper\<\></tt>.
+        struct unwrap_reference
+        {
+            BOOST_PROTO_CALLABLE()
+            template<typename Sig>
+            struct result {};
+
+            template<typename This, typename Ref>
+            struct result<This(Ref)>
+            {
+                typedef typename boost::unwrap_reference<Ref>::type &type;
+            };
+
+            template<typename This, typename Ref>
+            struct result<This(Ref &)>
+            {
+                typedef typename boost::unwrap_reference<Ref>::type &type;
+            };
+
+            /// \param r The <tt>boost::reference_wrapper\<T\></tt> to unwrap.
+            /// \return <tt>static_cast\<T &\>(r)</tt>
+            template<typename T>
+            T &operator()(boost::reference_wrapper<T> r) const
+            {
+                return static_cast<T &>(r);
+            }
+        };
+    }
+
+    /// \brief A unary metafunction that turns an ordinary function object type into the type of
+    /// a deferred function object for use in xpressive semantic actions.
+    ///
+    /// Use \c xpressive::function\<\> to turn an ordinary polymorphic function object type
+    /// into a type that can be used to declare an object for use in xpressive semantic actions.
+    ///
+    /// For example, the global object \c xpressive::push_back can be used to create deferred actions
+    /// that have the effect of pushing a value into a container. It is defined with
+    /// \c xpressive::function\<\> as follows:
+    ///
+    /** \code
+        xpressive::function<xpressive::op::push_back>::type const push_back = {};
+        \endcode
+    */
+    ///
+    /// where \c op::push_back is an ordinary function object that pushes its second argument into
+    /// its first. Thus defined, \c xpressive::push_back can be used in semantic actions as follows:
+    ///
+    /** \code
+        namespace xp = boost::xpressive;
+        using xp::_;
+        std::list<int> result;
+        std::string str("1 23 456 7890");
+        xp::sregex rx = (+_d)[ xp::push_back(xp::ref(result), xp::as<int>(_) ]
+            >> *(' ' >> (+_d)[ xp::push_back(xp::ref(result), xp::as<int>(_) ) ]);
+        \endcode
+    */
+    template<typename PolymorphicFunctionObject>
+    struct function
+    {
+        typedef typename proto::terminal<PolymorphicFunctionObject>::type type;
+    };
+
+    /// \brief \c at is a lazy PolymorphicFunctionObject for indexing into a sequence in an
+    /// xpressive semantic action.
+    function<op::at>::type const at = {{}};
+
+    /// \brief \c push is a lazy PolymorphicFunctionObject for pushing a value into a container in an
+    /// xpressive semantic action.
+    function<op::push>::type const push = {{}};
+
+    /// \brief \c push_back is a lazy PolymorphicFunctionObject for pushing a value into a container in an
+    /// xpressive semantic action.
+    function<op::push_back>::type const push_back = {{}};
+
+    /// \brief \c push_front is a lazy PolymorphicFunctionObject for pushing a value into a container in an
+    /// xpressive semantic action.
+    function<op::push_front>::type const push_front = {{}};
+
+    /// \brief \c pop is a lazy PolymorphicFunctionObject for popping the top element from a sequence in an
+    /// xpressive semantic action.
+    function<op::pop>::type const pop = {{}};
+
+    /// \brief \c pop_back is a lazy PolymorphicFunctionObject for popping the back element from a sequence in an
+    /// xpressive semantic action.
+    function<op::pop_back>::type const pop_back = {{}};
+
+    /// \brief \c pop_front is a lazy PolymorphicFunctionObject for popping the front element from a sequence in an
+    /// xpressive semantic action.
+    function<op::pop_front>::type const pop_front = {{}};
+
+    /// \brief \c top is a lazy PolymorphicFunctionObject for accessing the top element from a stack in an
+    /// xpressive semantic action.
+    function<op::top>::type const top = {{}};
+
+    /// \brief \c back is a lazy PolymorphicFunctionObject for fetching the back element of a sequence in an
+    /// xpressive semantic action.
+    function<op::back>::type const back = {{}};
+
+    /// \brief \c front is a lazy PolymorphicFunctionObject for fetching the front element of a sequence in an
+    /// xpressive semantic action.
+    function<op::front>::type const front = {{}};
+
+    /// \brief \c first is a lazy PolymorphicFunctionObject for accessing the first element of a \c std::pair\<\> in an
+    /// xpressive semantic action.
+    function<op::first>::type const first = {{}};
+
+    /// \brief \c second is a lazy PolymorphicFunctionObject for accessing the second element of a \c std::pair\<\> in an
+    /// xpressive semantic action.
+    function<op::second>::type const second = {{}};
+
+    /// \brief \c matched is a lazy PolymorphicFunctionObject for accessing the \c matched member of a \c xpressive::sub_match\<\> in an
+    /// xpressive semantic action.
+    function<op::matched>::type const matched = {{}};
+
+    /// \brief \c length is a lazy PolymorphicFunctionObject for computing the length of a \c xpressive::sub_match\<\> in an
+    /// xpressive semantic action.
+    function<op::length>::type const length = {{}};
+
+    /// \brief \c str is a lazy PolymorphicFunctionObject for converting a \c xpressive::sub_match\<\> to a \c std::basic_string\<\> in an
+    /// xpressive semantic action.
+    function<op::str>::type const str = {{}};
+
+    /// \brief \c insert is a lazy PolymorphicFunctionObject for inserting a value or a range of values into a sequence in an
+    /// xpressive semantic action.
+    function<op::insert>::type const insert = {{}};
+
+    /// \brief \c make_pair is a lazy PolymorphicFunctionObject for making a \c std::pair\<\> in an
+    /// xpressive semantic action.
+    function<op::make_pair>::type const make_pair = {{}};
+
+    /// \brief \c unwrap_reference is a lazy PolymorphicFunctionObject for unwrapping a \c boost::reference_wrapper\<\> in an
+    /// xpressive semantic action.
+    function<op::unwrap_reference>::type const unwrap_reference = {{}};
+
+    /// \brief \c value\<\> is a lazy wrapper for a value that can be used in xpressive semantic actions.
+    /// \tparam T The type of the value to store.
+    ///
+    /// Below is an example that shows where \c <tt>value\<\></tt> is useful.
+    ///
+    /** \code
+        sregex good_voodoo(boost::shared_ptr<int> pi)
+        {
+            using namespace boost::xpressive;
+            // Use val() to hold the shared_ptr by value:
+            sregex rex = +( _d [ ++*val(pi) ] >> '!' );
+            // OK, rex holds a reference count to the integer.
+            return rex;
+        }
+        \endcode
+    */
+    ///
+    /// In the above code, \c xpressive::val() is a function that returns a \c value\<\> object. Had
+    /// \c val() not been used here, the operation <tt>++*pi</tt> would have been evaluated eagerly
+    /// once, instead of lazily when the regex match happens.
+    template<typename T>
+    struct value
+      : proto::extends<typename proto::terminal<T>::type, value<T> >
+    {
+        /// INTERNAL ONLY
+        typedef proto::extends<typename proto::terminal<T>::type, value<T> > base_type;
+
+        /// \brief Store a default-constructed \c T
+        value()
+          : base_type()
+        {}
+
+        /// \param t The initial value.
+        /// \brief Store a copy of \c t.
+        explicit value(T const &t)
+          : base_type(base_type::proto_base_expr::make(t))
+        {}
+
+        using base_type::operator=;
+
+        /// \overload
+        T &get()
+        {
+            return proto::value(*this);
+        }
+
+        /// \brief Fetch the stored value
+        T const &get() const
+        {
+            return proto::value(*this);
+        }
+    };
+
+    /// \brief \c reference\<\> is a lazy wrapper for a reference that can be used in 
+    /// xpressive semantic actions.
+    ///
+    /// \tparam T The type of the referent.
+    ///
+    /// Here is an example of how to use \c reference\<\> to create a lazy reference to
+    /// an existing object so it can be read and written in an xpressive semantic action.
+    ///
+    /** \code
+        using namespace boost::xpressive;
+        std::map<std::string, int> result;
+        reference<std::map<std::string, int> > result_ref(result);
+       
+        // Match a word and an integer, separated by =>,
+        // and then stuff the result into a std::map<>
+        sregex pair = ( (s1= +_w) >> "=>" >> (s2= +_d) )
+            [ result_ref[s1] = as<int>(s2) ];
+        \endcode
+    */
+    template<typename T>
+    struct reference
+      : proto::extends<typename proto::terminal<reference_wrapper<T> >::type, reference<T> >
+    {
+        /// INTERNAL ONLY
+        typedef proto::extends<typename proto::terminal<reference_wrapper<T> >::type, reference<T> > base_type;
+
+        /// \param t Reference to object
+        /// \brief Store a reference to \c t
+        explicit reference(T &t)
+          : base_type(base_type::proto_base_expr::make(boost::ref(t)))
+        {}
+
+        using base_type::operator=;
+
+        /// \brief Fetch the stored value
+        T &get() const
+        {
+            return proto::value(*this).get();
+        }
+    };
+
+    /// \brief \c local\<\> is a lazy wrapper for a reference to a value that is stored within the local itself.
+    /// It is for use within xpressive semantic actions.
+    ///
+    /// \tparam T The type of the local variable.
+    ///
+    /// Below is an example of how to use \c local\<\> in semantic actions.
+    ///
+    /** \code
+        using namespace boost::xpressive;
+        local<int> i(0);
+        std::string str("1!2!3?");
+        // count the exciting digits, but not the
+        // questionable ones.
+        sregex rex = +( _d [ ++i ] >> '!' );
+        regex_search(str, rex);
+        assert( i.get() == 2 );
+        \endcode
+    */
+    ///
+    /// \note As the name "local" suggests, \c local\<\> objects and the regexes
+    /// that refer to them should never leave the local scope. The value stored
+    /// within the local object will be destroyed at the end of the \c local\<\>'s
+    /// lifetime, and any regex objects still holding the \c local\<\> will be
+    /// left with a dangling reference.
+    template<typename T>
+    struct local
+      : detail::value_wrapper<T>
+      , proto::terminal<reference_wrapper<T> >::type
+    {
+        /// INTERNAL ONLY
+        typedef typename proto::terminal<reference_wrapper<T> >::type base_type;
+
+        /// \brief Store a default-constructed value of type \c T
+        local()
+          : detail::value_wrapper<T>()
+          , base_type(base_type::make(boost::ref(detail::value_wrapper<T>::value)))
+        {}
+
+        /// \param t The initial value.
+        /// \brief Store a default-constructed value of type \c T
+        explicit local(T const &t)
+          : detail::value_wrapper<T>(t)
+          , base_type(base_type::make(boost::ref(detail::value_wrapper<T>::value)))
+        {}
+
+        using base_type::operator=;
+
+        /// Fetch the wrapped value.
+        T &get()
+        {
+            return proto::value(*this);
+        }
+
+        /// \overload
+        T const &get() const
+        {
+            return proto::value(*this);
+        }
+    };
+
+    /// \brief \c as() is a lazy funtion for lexically casting a parameter to a different type.
+    /// \tparam T The type to which to lexically cast the parameter.
+    /// \param a The lazy value to lexically cast.
+    /// \return A lazy object that, when evaluated, lexically casts its argument to the desired type.
+    template<typename T, typename A>
+    typename detail::make_function::impl<op::as<T> const, A const &>::result_type const
+    as(A const &a)
+    {
+        return detail::make_function::impl<op::as<T> const, A const &>()((op::as<T>()), a);
+    }
+
+    /// \brief \c static_cast_ is a lazy funtion for statically casting a parameter to a different type.
+    /// \tparam T The type to which to statically cast the parameter.
+    /// \param a The lazy value to statically cast.
+    /// \return A lazy object that, when evaluated, statically casts its argument to the desired type.
+    template<typename T, typename A>
+    typename detail::make_function::impl<op::static_cast_<T> const, A const &>::result_type const
+    static_cast_(A const &a)
+    {
+        return detail::make_function::impl<op::static_cast_<T> const, A const &>()((op::static_cast_<T>()), a);
+    }
+
+    /// \brief \c dynamic_cast_ is a lazy funtion for dynamically casting a parameter to a different type.
+    /// \tparam T The type to which to dynamically cast the parameter.
+    /// \param a The lazy value to dynamically cast.
+    /// \return A lazy object that, when evaluated, dynamically casts its argument to the desired type.
+    template<typename T, typename A>
+    typename detail::make_function::impl<op::dynamic_cast_<T> const, A const &>::result_type const
+    dynamic_cast_(A const &a)
+    {
+        return detail::make_function::impl<op::dynamic_cast_<T> const, A const &>()((op::dynamic_cast_<T>()), a);
+    }
+
+    /// \brief \c dynamic_cast_ is a lazy funtion for const-casting a parameter to a different type.
+    /// \tparam T The type to which to const-cast the parameter.
+    /// \param a The lazy value to const-cast.
+    /// \return A lazy object that, when evaluated, const-casts its argument to the desired type.
+    template<typename T, typename A>
+    typename detail::make_function::impl<op::const_cast_<T> const, A const &>::result_type const
+    const_cast_(A const &a)
+    {
+        return detail::make_function::impl<op::const_cast_<T> const, A const &>()((op::const_cast_<T>()), a);
+    }
+
+    /// \brief Helper for constructing \c value\<\> objects.
+    /// \return <tt>value\<T\>(t)</tt>
+    template<typename T>
+    value<T> const val(T const &t)
+    {
+        return value<T>(t);
+    }
+
+    /// \brief Helper for constructing \c reference\<\> objects.
+    /// \return <tt>reference\<T\>(t)</tt>
+    template<typename T>
+    reference<T> const ref(T &t)
+    {
+        return reference<T>(t);
+    }
+
+    /// \brief Helper for constructing \c reference\<\> objects that
+    /// store a reference to const.
+    /// \return <tt>reference\<T const\>(t)</tt>
+    template<typename T>
+    reference<T const> const cref(T const &t)
+    {
+        return reference<T const>(t);
+    }
+
+    /// \brief For adding user-defined assertions to your regular expressions.
+    ///
+    /// \param t The UnaryPredicate object or Boolean semantic action.
+    ///
+    /// A \RefSect{user_s_guide.semantic_actions_and_user_defined_assertions.user_defined_assertions,user-defined assertion}
+    /// is a kind of semantic action that evaluates
+    /// a Boolean lambda and, if it evaluates to false, causes the match to
+    /// fail at that location in the string. This will cause backtracking,
+    /// so the match may ultimately succeed.
+    ///
+    /// To use \c check() to specify a user-defined assertion in a regex, use the
+    /// following syntax:
+    ///
+    /** \code
+        sregex s = (_d >> _d)[check( XXX )]; // XXX is a custom assertion
+        \endcode
+    */
+    ///
+    /// The assertion is evaluated with a \c sub_match\<\> object that delineates
+    /// what part of the string matched the sub-expression to which the assertion
+    /// was attached.
+    ///
+    /// \c check() can be used with an ordinary predicate that takes a
+    /// \c sub_match\<\> object as follows:
+    ///
+    /** \code
+        // A predicate that is true IFF a sub-match is
+        // either 3 or 6 characters long.
+        struct three_or_six
+        {
+            bool operator()(ssub_match const &sub) const
+            {
+                return sub.length() == 3 || sub.length() == 6;
+            }
+        };
+
+        // match words of 3 characters or 6 characters.
+        sregex rx = (bow >> +_w >> eow)[ check(three_or_six()) ] ;
+        \endcode
+    */
+    ///
+    /// Alternately, \c check() can be used to define inline custom
+    /// assertions with the same syntax as is used to define semantic
+    /// actions. The following code is equivalent to above:
+    ///
+    /** \code
+        // match words of 3 characters or 6 characters.
+        sregex rx = (bow >> +_w >> eow)[ check(length(_)==3 || length(_)==6) ] ;
+        \endcode
+    */
+    ///
+    /// Within a custom assertion, \c _ is a placeholder for the \c sub_match\<\>
+    /// That delineates the part of the string matched by the sub-expression to
+    /// which the custom assertion was attached.
+#ifdef BOOST_XPRESSIVE_DOXYGEN_INVOKED // A hack so Doxygen emits something more meaningful.
+    template<typename T>
+    detail::unspecified check(T const &t);
+#else
+    proto::terminal<detail::check_tag>::type const check = {{}};
+#endif
+
+    /// \brief For binding local variables to placeholders in semantic actions when
+    /// constructing a \c regex_iterator or a \c regex_token_iterator.
+    ///
+    /// \param args A set of argument bindings, where each argument binding is an assignment
+    /// expression, the left hand side of which must be an instance of \c placeholder\<X\>
+    /// for some \c X, and the right hand side is an lvalue of type \c X.
+    ///
+    /// \c xpressive::let() serves the same purpose as <tt>match_results::let()</tt>;
+    /// that is, it binds a placeholder to a local value. The purpose is to allow a
+    /// regex with semantic actions to be defined that refers to objects that do not yet exist.
+    /// Rather than referring directly to an object, a semantic action can refer to a placeholder,
+    /// and the value of the placeholder can be specified later with a <em>let expression</em>.
+    /// The <em>let expression</em> created with \c let() is passed to the constructor of either
+    /// \c regex_iterator or \c regex_token_iterator.
+    ///
+    /// See the section \RefSect{user_s_guide.semantic_actions_and_user_defined_assertions.referring_to_non_local_variables, "Referring to Non-Local Variables"}
+    /// in the Users' Guide for more discussion.
+    ///
+    /// \em Example:
+    ///
+    /**
+        \code
+        // Define a placeholder for a map object:
+        placeholder<std::map<std::string, int> > _map;
+
+        // Match a word and an integer, separated by =>,
+        // and then stuff the result into a std::map<>
+        sregex pair = ( (s1= +_w) >> "=>" >> (s2= +_d) )
+            [ _map[s1] = as<int>(s2) ];
+
+        // The string to parse
+        std::string str("aaa=>1 bbb=>23 ccc=>456");
+
+        // Here is the actual map to fill in:
+        std::map<std::string, int> result;
+
+        // Create a regex_iterator to find all the matches
+        sregex_iterator it(str.begin(), str.end(), pair, let(_map=result));
+        sregex_iterator end;
+
+        // step through all the matches, and fill in
+        // the result map
+        while(it != end)
+            ++it;
+
+        std::cout << result["aaa"] << '\n';
+        std::cout << result["bbb"] << '\n';
+        std::cout << result["ccc"] << '\n';
+        \endcode
+    */
+    ///
+    /// The above code displays:
+    ///
+    /** \code{.txt}
+        1
+        23
+        456
+        \endcode
+    */
+#ifdef BOOST_XPRESSIVE_DOXYGEN_INVOKED // A hack so Doxygen emits something more meaningful.
+    template<typename...ArgBindings>
+    detail::unspecified let(ArgBindings const &...args);
+#else
+    detail::let_<proto::terminal<detail::let_tag>::type> const let = {{{}}};
+#endif
+
+    /// \brief For defining a placeholder to stand in for a variable a semantic action.
+    ///
+    /// Use \c placeholder\<\> to define a placeholder for use in semantic actions to stand
+    /// in for real objects. The use of placeholders allows regular expressions with actions
+    /// to be defined once and reused in many contexts to read and write from objects which
+    /// were not available when the regex was defined.
+    ///
+    /// \tparam T The type of the object for which this placeholder stands in.
+    /// \tparam I An optional identifier that can be used to distinguish this placeholder
+    ///           from others that may be used in the same semantic action that happen
+    ///           to have the same type.
+    ///
+    /// You can use \c placeholder\<\> by creating an object of type \c placeholder\<T\>
+    /// and using that object in a semantic action exactly as you intend an object of
+    /// type \c T to be used.
+    ///
+    /**
+        \code
+        placeholder<int> _i;
+        placeholder<double> _d;
+
+        sregex rex = ( some >> regex >> here )
+            [ ++_i, _d *= _d ];
+        \endcode
+    */
+    ///
+    /// Then, when doing a pattern match with either \c regex_search(),
+    /// \c regex_match() or \c regex_replace(), pass a \c match_results\<\> object that
+    /// contains bindings for the placeholders used in the regex object's semantic actions.
+    /// You can create the bindings by calling \c match_results::let as follows:
+    ///
+    /**
+        \code
+        int i = 0;
+        double d = 3.14;
+
+        smatch what;
+        what.let(_i = i)
+            .let(_d = d);
+
+        if(regex_match("some string", rex, what))
+           // i and d mutated here
+        \endcode
+    */
+    ///
+    /// If a semantic action executes that contains an unbound placeholder, a exception of
+    /// type \c regex_error is thrown.
+    ///
+    /// See the discussion for \c xpressive::let() and the
+    /// \RefSect{user_s_guide.semantic_actions_and_user_defined_assertions.referring_to_non_local_variables, "Referring to Non-Local Variables"}
+    /// section in the Users' Guide for more information.
+    ///
+    /// <em>Example:</em>
+    ///
+    /**
+        \code
+        // Define a placeholder for a map object:
+        placeholder<std::map<std::string, int> > _map;
+
+        // Match a word and an integer, separated by =>,
+        // and then stuff the result into a std::map<>
+        sregex pair = ( (s1= +_w) >> "=>" >> (s2= +_d) )
+            [ _map[s1] = as<int>(s2) ];
+
+        // Match one or more word/integer pairs, separated
+        // by whitespace.
+        sregex rx = pair >> *(+_s >> pair);
+
+        // The string to parse
+        std::string str("aaa=>1 bbb=>23 ccc=>456");
+
+        // Here is the actual map to fill in:
+        std::map<std::string, int> result;
+
+        // Bind the _map placeholder to the actual map
+        smatch what;
+        what.let( _map = result );
+
+        // Execute the match and fill in result map
+        if(regex_match(str, what, rx))
+        {
+            std::cout << result["aaa"] << '\n';
+            std::cout << result["bbb"] << '\n';
+            std::cout << result["ccc"] << '\n';
+        }
+        \endcode
+    */
+#ifdef BOOST_XPRESSIVE_DOXYGEN_INVOKED // A hack so Doxygen emits something more meaningful.
+    template<typename T, int I = 0>
+    struct placeholder
+    {
+        /// \param t The object to associate with this placeholder
+        /// \return An object of unspecified type that records the association of \c t
+        /// with \c *this.
+        detail::unspecified operator=(T &t) const;
+        /// \overload
+        detail::unspecified operator=(T const &t) const;
+    };
+#else
+    template<typename T, int I, typename Dummy>
+    struct placeholder
+    {
+        typedef placeholder<T, I, Dummy> this_type;
+        typedef
+            typename proto::terminal<detail::action_arg<T, mpl::int_<I> > >::type
+        action_arg_type;
+
+        BOOST_PROTO_EXTENDS(action_arg_type, this_type, proto::default_domain)
+    };
+#endif
+
+    /// \brief A lazy funtion for constructing objects objects of the specified type.
+    /// \tparam T The type of object to construct.
+    /// \param args The arguments to the constructor.
+    /// \return A lazy object that, when evaluated, returns <tt>T(xs...)</tt>, where
+    ///         <tt>xs...</tt> is the result of evaluating the lazy arguments
+    ///         <tt>args...</tt>.
+#ifdef BOOST_XPRESSIVE_DOXYGEN_INVOKED // A hack so Doxygen emits something more meaningful.
+    template<typename T, typename ...Args>
+    detail::unspecified construct(Args const &...args);
+#else
+/// INTERNAL ONLY
+#define BOOST_PROTO_LOCAL_MACRO(N, typename_A, A_const_ref, A_const_ref_a, a)                       \
+    template<typename X2_0 BOOST_PP_COMMA_IF(N) typename_A(N)>                                      \
+    typename detail::make_function::impl<                                                           \
+        op::construct<X2_0> const                                                                   \
+        BOOST_PP_COMMA_IF(N) A_const_ref(N)                                                         \
+    >::result_type const                                                                            \
+    construct(A_const_ref_a(N))                                                                     \
+    {                                                                                               \
+        return detail::make_function::impl<                                                         \
+            op::construct<X2_0> const                                                               \
+            BOOST_PP_COMMA_IF(N) A_const_ref(N)                                                     \
+        >()((op::construct<X2_0>()) BOOST_PP_COMMA_IF(N) a(N));                                     \
+    }                                                                                               \
+                                                                                                    \
+    template<typename X2_0 BOOST_PP_COMMA_IF(N) typename_A(N)>                                      \
+    typename detail::make_function::impl<                                                           \
+        op::throw_<X2_0> const                                                                      \
+        BOOST_PP_COMMA_IF(N) A_const_ref(N)                                                         \
+    >::result_type const                                                                            \
+    throw_(A_const_ref_a(N))                                                                        \
+    {                                                                                               \
+        return detail::make_function::impl<                                                         \
+            op::throw_<X2_0> const                                                                  \
+            BOOST_PP_COMMA_IF(N) A_const_ref(N)                                                     \
+        >()((op::throw_<X2_0>()) BOOST_PP_COMMA_IF(N) a(N));                                        \
+    }                                                                                               \
+    /**/
+
+    #define BOOST_PROTO_LOCAL_a         BOOST_PROTO_a                               ///< INTERNAL ONLY
+    #define BOOST_PROTO_LOCAL_LIMITS    (0, BOOST_PP_DEC(BOOST_PROTO_MAX_ARITY))    ///< INTERNAL ONLY
+    #include BOOST_PROTO_LOCAL_ITERATE()
+#endif
+
+    namespace detail
+    {
+        inline void ignore_unused_regex_actions()
+        {
+            detail::ignore_unused(xpressive::at);
+            detail::ignore_unused(xpressive::push);
+            detail::ignore_unused(xpressive::push_back);
+            detail::ignore_unused(xpressive::push_front);
+            detail::ignore_unused(xpressive::pop);
+            detail::ignore_unused(xpressive::pop_back);
+            detail::ignore_unused(xpressive::pop_front);
+            detail::ignore_unused(xpressive::top);
+            detail::ignore_unused(xpressive::back);
+            detail::ignore_unused(xpressive::front);
+            detail::ignore_unused(xpressive::first);
+            detail::ignore_unused(xpressive::second);
+            detail::ignore_unused(xpressive::matched);
+            detail::ignore_unused(xpressive::length);
+            detail::ignore_unused(xpressive::str);
+            detail::ignore_unused(xpressive::insert);
+            detail::ignore_unused(xpressive::make_pair);
+            detail::ignore_unused(xpressive::unwrap_reference);
+            detail::ignore_unused(xpressive::check);
+            detail::ignore_unused(xpressive::let);
+        }
+
+        struct mark_nbr
+        {
+            BOOST_PROTO_CALLABLE()
+            typedef int result_type;
+
+            int operator()(mark_placeholder m) const
+            {
+                return m.mark_number_;
+            }
+        };
+
+        struct ReplaceAlgo
+          : proto::or_<
+                proto::when<
+                    proto::terminal<mark_placeholder>
+                  , op::at(proto::_data, proto::call<mark_nbr(proto::_value)>)
+                >
+              , proto::when<
+                    proto::terminal<any_matcher>
+                  , op::at(proto::_data, proto::size_t<0>)
+                >
+              , proto::when<
+                    proto::terminal<reference_wrapper<proto::_> >
+                  , op::unwrap_reference(proto::_value)
+                >
+              , proto::_default<ReplaceAlgo>
+            >
+        {};
+    }
+}}
+
+#if BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+#endif // BOOST_XPRESSIVE_ACTIONS_HPP_EAN_03_22_2007

--- a/inst/include/boost/xpressive/regex_compiler.hpp
+++ b/inst/include/boost/xpressive/regex_compiler.hpp
@@ -1,0 +1,759 @@
+///////////////////////////////////////////////////////////////////////////////
+/// \file regex_compiler.hpp
+/// Contains the definition of regex_compiler, a factory for building regex objects
+/// from strings.
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_REGEX_COMPILER_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_REGEX_COMPILER_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <map>
+#include <boost/config.hpp>
+#include <boost/assert.hpp>
+#include <boost/next_prior.hpp>
+#include <boost/range/begin.hpp>
+#include <boost/range/end.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/throw_exception.hpp>
+#include <boost/type_traits/is_same.hpp>
+#include <boost/type_traits/is_pointer.hpp>
+#include <boost/utility/enable_if.hpp>
+#include <boost/iterator/iterator_traits.hpp>
+#include <boost/xpressive/basic_regex.hpp>
+#include <boost/xpressive/detail/dynamic/parser.hpp>
+#include <boost/xpressive/detail/dynamic/parse_charset.hpp>
+#include <boost/xpressive/detail/dynamic/parser_enum.hpp>
+#include <boost/xpressive/detail/dynamic/parser_traits.hpp>
+#include <boost/xpressive/detail/core/linker.hpp>
+#include <boost/xpressive/detail/core/optimize.hpp>
+
+namespace boost { namespace xpressive
+{
+
+///////////////////////////////////////////////////////////////////////////////
+// regex_compiler
+//
+/// \brief Class template regex_compiler is a factory for building basic_regex objects from a string.
+///
+/// Class template regex_compiler is used to construct a basic_regex object from a string. The string
+/// should contain a valid regular expression. You can imbue a regex_compiler object with a locale,
+/// after which all basic_regex objects created with that regex_compiler object will use that locale.
+/// After creating a regex_compiler object, and optionally imbueing it with a locale, you can call the
+/// compile() method to construct a basic_regex object, passing it the string representing the regular
+/// expression. You can call compile() multiple times on the same regex_compiler object. Two basic_regex
+/// objects compiled from the same string will have different regex_id's.
+template<typename BidiIter, typename RegexTraits, typename CompilerTraits>
+struct regex_compiler
+{
+    typedef BidiIter iterator_type;
+    typedef typename iterator_value<BidiIter>::type char_type;
+    typedef regex_constants::syntax_option_type flag_type;
+    typedef RegexTraits traits_type;
+    typedef typename traits_type::string_type string_type;
+    typedef typename traits_type::locale_type locale_type;
+    typedef typename traits_type::char_class_type char_class_type;
+
+    explicit regex_compiler(RegexTraits const &traits = RegexTraits())
+      : mark_count_(0)
+      , hidden_mark_count_(0)
+      , traits_(traits)
+      , upper_(0)
+      , self_()
+      , rules_()
+    {
+        this->upper_ = lookup_classname(this->rxtraits(), "upper");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // imbue
+    /// Specify the locale to be used by a regex_compiler.
+    ///
+    /// \param loc The locale that this regex_compiler should use.
+    /// \return The previous locale.
+    locale_type imbue(locale_type loc)
+    {
+        locale_type oldloc = this->traits_.imbue(loc);
+        this->upper_ = lookup_classname(this->rxtraits(), "upper");
+        return oldloc;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // getloc
+    /// Get the locale used by a regex_compiler.
+    ///
+    /// \return The locale used by this regex_compiler.
+    locale_type getloc() const
+    {
+        return this->traits_.getloc();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // compile
+    /// Builds a basic_regex object from a range of characters.
+    ///
+    /// \param  begin The beginning of a range of characters representing the
+    ///         regular expression to compile.
+    /// \param  end The end of a range of characters representing the
+    ///         regular expression to compile.
+    /// \param  flags Optional bitmask that determines how the pat string is
+    ///         interpreted. (See syntax_option_type.)
+    /// \return A basic_regex object corresponding to the regular expression
+    ///         represented by the character range.
+    /// \pre    InputIter is a model of the InputIterator concept.
+    /// \pre    [begin,end) is a valid range.
+    /// \pre    The range of characters specified by [begin,end) contains a
+    ///         valid string-based representation of a regular expression.
+    /// \throw  regex_error when the range of characters has invalid regular
+    ///         expression syntax.
+    template<typename InputIter>
+    basic_regex<BidiIter>
+    compile(InputIter begin, InputIter end, flag_type flags = regex_constants::ECMAScript)
+    {
+        typedef typename iterator_category<InputIter>::type category;
+        return this->compile_(begin, end, flags, category());
+    }
+
+    /// \overload
+    ///
+    template<typename InputRange>
+    typename disable_if<is_pointer<InputRange>, basic_regex<BidiIter> >::type
+    compile(InputRange const &pat, flag_type flags = regex_constants::ECMAScript)
+    {
+        return this->compile(boost::begin(pat), boost::end(pat), flags);
+    }
+
+    /// \overload
+    ///
+    basic_regex<BidiIter>
+    compile(char_type const *begin, flag_type flags = regex_constants::ECMAScript)
+    {
+        BOOST_ASSERT(0 != begin);
+        char_type const *end = begin + std::char_traits<char_type>::length(begin);
+        return this->compile(begin, end, flags);
+    }
+
+    /// \overload
+    ///
+    basic_regex<BidiIter> compile(char_type const *begin, std::size_t size, flag_type flags)
+    {
+        BOOST_ASSERT(0 != begin);
+        char_type const *end = begin + size;
+        return this->compile(begin, end, flags);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // operator[]
+    /// Return a reference to the named regular expression. If no such named
+    /// regular expression exists, create a new regular expression and return
+    /// a reference to it.
+    ///
+    /// \param  name A std::string containing the name of the regular expression.
+    /// \pre    The string is not empty.
+    /// \throw  bad_alloc on allocation failure.
+    basic_regex<BidiIter> &operator [](string_type const &name)
+    {
+        BOOST_ASSERT(!name.empty());
+        return this->rules_[name];
+    }
+
+    /// \overload
+    ///
+    basic_regex<BidiIter> const &operator [](string_type const &name) const
+    {
+        BOOST_ASSERT(!name.empty());
+        return this->rules_[name];
+    }
+
+private:
+
+    typedef detail::escape_value<char_type, char_class_type> escape_value;
+    typedef detail::alternate_matcher<detail::alternates_vector<BidiIter>, RegexTraits> alternate_matcher;
+
+    ///////////////////////////////////////////////////////////////////////////
+    // compile_
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    basic_regex<BidiIter> compile_(FwdIter begin, FwdIter end, flag_type flags, std::forward_iterator_tag)
+    {
+        BOOST_MPL_ASSERT((is_same<char_type, typename iterator_value<FwdIter>::type>));
+        using namespace regex_constants;
+        this->reset();
+        this->traits_.flags(flags);
+
+        basic_regex<BidiIter> rextmp, *prex = &rextmp;
+        FwdIter tmp = begin;
+
+        // Check if this regex is a named rule:
+        string_type name;
+        if(token_group_begin == this->traits_.get_token(tmp, end) &&
+           BOOST_XPR_ENSURE_(tmp != end, error_paren, "mismatched parenthesis") &&
+           token_rule_assign == this->traits_.get_group_type(tmp, end, name))
+        {
+            begin = tmp;
+            BOOST_XPR_ENSURE_
+            (
+                begin != end && token_group_end == this->traits_.get_token(begin, end)
+              , error_paren
+              , "mismatched parenthesis"
+            );
+            prex = &this->rules_[name];
+        }
+
+        this->self_ = detail::core_access<BidiIter>::get_regex_impl(*prex);
+
+        // at the top level, a regex is a sequence of alternates
+        detail::sequence<BidiIter> seq = this->parse_alternates(begin, end);
+        BOOST_XPR_ENSURE_(begin == end, error_paren, "mismatched parenthesis");
+
+        // terminate the sequence
+        seq += detail::make_dynamic<BidiIter>(detail::end_matcher());
+
+        // bundle the regex information into a regex_impl object
+        detail::common_compile(seq.xpr().matchable(), *this->self_, this->rxtraits());
+
+        this->self_->traits_ = new detail::traits_holder<RegexTraits>(this->rxtraits());
+        this->self_->mark_count_ = this->mark_count_;
+        this->self_->hidden_mark_count_ = this->hidden_mark_count_;
+
+        // References changed, update dependencies.
+        this->self_->tracking_update();
+        this->self_.reset();
+        return *prex;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // compile_
+    /// INTERNAL ONLY
+    template<typename InputIter>
+    basic_regex<BidiIter> compile_(InputIter begin, InputIter end, flag_type flags, std::input_iterator_tag)
+    {
+        string_type pat(begin, end);
+        return this->compile_(boost::begin(pat), boost::end(pat), flags, std::forward_iterator_tag());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // reset
+    /// INTERNAL ONLY
+    void reset()
+    {
+        this->mark_count_ = 0;
+        this->hidden_mark_count_ = 0;
+        this->traits_.flags(regex_constants::ECMAScript);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // regex_traits
+    /// INTERNAL ONLY
+    traits_type &rxtraits()
+    {
+        return this->traits_.traits();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // regex_traits
+    /// INTERNAL ONLY
+    traits_type const &rxtraits() const
+    {
+        return this->traits_.traits();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_alternates
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    detail::sequence<BidiIter> parse_alternates(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        int count = 0;
+        FwdIter tmp = begin;
+        detail::sequence<BidiIter> seq;
+
+        do switch(++count)
+        {
+        case 1:
+            seq = this->parse_sequence(tmp, end);
+            break;
+        case 2:
+            seq = detail::make_dynamic<BidiIter>(alternate_matcher()) | seq;
+            BOOST_FALLTHROUGH;
+        default:
+            seq |= this->parse_sequence(tmp, end);
+        }
+        while((begin = tmp) != end && token_alternate == this->traits_.get_token(tmp, end));
+
+        return seq;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_group
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    detail::sequence<BidiIter> parse_group(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        int mark_nbr = 0;
+        bool keeper = false;
+        bool lookahead = false;
+        bool lookbehind = false;
+        bool negative = false;
+        string_type name;
+
+        detail::sequence<BidiIter> seq, seq_end;
+        FwdIter tmp = FwdIter();
+
+        syntax_option_type old_flags = this->traits_.flags();
+
+        switch(this->traits_.get_group_type(begin, end, name))
+        {
+        case token_no_mark:
+            // Don't process empty groups like (?:) or (?i)
+            // BUGBUG this doesn't handle the degenerate (?:)+ correctly
+            if(token_group_end == this->traits_.get_token(tmp = begin, end))
+            {
+                return this->parse_atom(begin = tmp, end);
+            }
+            break;
+
+        case token_negative_lookahead:
+            negative = true;
+            BOOST_FALLTHROUGH;
+        case token_positive_lookahead:
+            lookahead = true;
+            break;
+
+        case token_negative_lookbehind:
+            negative = true;
+            BOOST_FALLTHROUGH;
+        case token_positive_lookbehind:
+            lookbehind = true;
+            break;
+
+        case token_independent_sub_expression:
+            keeper = true;
+            break;
+
+        case token_comment:
+            while(BOOST_XPR_ENSURE_(begin != end, error_paren, "mismatched parenthesis"))
+            {
+                switch(this->traits_.get_token(begin, end))
+                {
+                case token_group_end:
+                    return this->parse_atom(begin, end);
+                case token_escape:
+                    BOOST_XPR_ENSURE_(begin != end, error_escape, "incomplete escape sequence");
+                    BOOST_FALLTHROUGH;
+                case token_literal:
+                    ++begin;
+                    break;
+                default:
+                    break;
+                }
+            }
+            break;
+
+        case token_recurse:
+            BOOST_XPR_ENSURE_
+            (
+                begin != end && token_group_end == this->traits_.get_token(begin, end)
+              , error_paren
+              , "mismatched parenthesis"
+            );
+            return detail::make_dynamic<BidiIter>(detail::regex_byref_matcher<BidiIter>(this->self_));
+
+        case token_rule_assign:
+            BOOST_THROW_EXCEPTION(
+                regex_error(error_badrule, "rule assignments must be at the front of the regex")
+            );
+            break;
+
+        case token_rule_ref:
+            {
+                typedef detail::core_access<BidiIter> access;
+                BOOST_XPR_ENSURE_
+                (
+                    begin != end && token_group_end == this->traits_.get_token(begin, end)
+                  , error_paren
+                  , "mismatched parenthesis"
+                );
+                basic_regex<BidiIter> &rex = this->rules_[name];
+                shared_ptr<detail::regex_impl<BidiIter> > impl = access::get_regex_impl(rex);
+                this->self_->track_reference(*impl);
+                return detail::make_dynamic<BidiIter>(detail::regex_byref_matcher<BidiIter>(impl));
+            }
+
+        case token_named_mark:
+            mark_nbr = static_cast<int>(++this->mark_count_);
+            for(std::size_t i = 0; i < this->self_->named_marks_.size(); ++i)
+            {
+                BOOST_XPR_ENSURE_(this->self_->named_marks_[i].name_ != name, error_badmark, "named mark already exists");
+            }
+            this->self_->named_marks_.push_back(detail::named_mark<char_type>(name, this->mark_count_));
+            seq = detail::make_dynamic<BidiIter>(detail::mark_begin_matcher(mark_nbr));
+            seq_end = detail::make_dynamic<BidiIter>(detail::mark_end_matcher(mark_nbr));
+            break;
+
+        case token_named_mark_ref:
+            BOOST_XPR_ENSURE_
+            (
+                begin != end && token_group_end == this->traits_.get_token(begin, end)
+              , error_paren
+              , "mismatched parenthesis"
+            );
+            for(std::size_t i = 0; i < this->self_->named_marks_.size(); ++i)
+            {
+                if(this->self_->named_marks_[i].name_ == name)
+                {
+                    mark_nbr = static_cast<int>(this->self_->named_marks_[i].mark_nbr_);
+                    return detail::make_backref_xpression<BidiIter>
+                    (
+                        mark_nbr, this->traits_.flags(), this->rxtraits()
+                    );
+                }
+            }
+            BOOST_THROW_EXCEPTION(regex_error(error_badmark, "invalid named back-reference"));
+            break;
+
+        default:
+            mark_nbr = static_cast<int>(++this->mark_count_);
+            seq = detail::make_dynamic<BidiIter>(detail::mark_begin_matcher(mark_nbr));
+            seq_end = detail::make_dynamic<BidiIter>(detail::mark_end_matcher(mark_nbr));
+            break;
+        }
+
+        // alternates
+        seq += this->parse_alternates(begin, end);
+        seq += seq_end;
+        BOOST_XPR_ENSURE_
+        (
+            begin != end && token_group_end == this->traits_.get_token(begin, end)
+          , error_paren
+          , "mismatched parenthesis"
+        );
+
+        typedef detail::shared_matchable<BidiIter> xpr_type;
+        if(lookahead)
+        {
+            seq += detail::make_independent_end_xpression<BidiIter>(seq.pure());
+            detail::lookahead_matcher<xpr_type> lam(seq.xpr(), negative, seq.pure());
+            seq = detail::make_dynamic<BidiIter>(lam);
+        }
+        else if(lookbehind)
+        {
+            seq += detail::make_independent_end_xpression<BidiIter>(seq.pure());
+            detail::lookbehind_matcher<xpr_type> lbm(seq.xpr(), seq.width().value(), negative, seq.pure());
+            seq = detail::make_dynamic<BidiIter>(lbm);
+        }
+        else if(keeper) // independent sub-expression
+        {
+            seq += detail::make_independent_end_xpression<BidiIter>(seq.pure());
+            detail::keeper_matcher<xpr_type> km(seq.xpr(), seq.pure());
+            seq = detail::make_dynamic<BidiIter>(km);
+        }
+
+        // restore the modifiers
+        this->traits_.flags(old_flags);
+        return seq;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_charset
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    detail::sequence<BidiIter> parse_charset(FwdIter &begin, FwdIter end)
+    {
+        detail::compound_charset<traits_type> chset;
+
+        // call out to a helper to actually parse the character set
+        detail::parse_charset(begin, end, chset, this->traits_);
+
+        return detail::make_charset_xpression<BidiIter>
+        (
+            chset
+          , this->rxtraits()
+          , this->traits_.flags()
+        );
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_atom
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    detail::sequence<BidiIter> parse_atom(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        escape_value esc = { 0, 0, 0, detail::escape_char };
+        FwdIter old_begin = begin;
+
+        switch(this->traits_.get_token(begin, end))
+        {
+        case token_literal:
+            return detail::make_literal_xpression<BidiIter>
+            (
+                this->parse_literal(begin, end), this->traits_.flags(), this->rxtraits()
+            );
+
+        case token_any:
+            return detail::make_any_xpression<BidiIter>(this->traits_.flags(), this->rxtraits());
+
+        case token_assert_begin_sequence:
+            return detail::make_dynamic<BidiIter>(detail::assert_bos_matcher());
+
+        case token_assert_end_sequence:
+            return detail::make_dynamic<BidiIter>(detail::assert_eos_matcher());
+
+        case token_assert_begin_line:
+            return detail::make_assert_begin_line<BidiIter>(this->traits_.flags(), this->rxtraits());
+
+        case token_assert_end_line:
+            return detail::make_assert_end_line<BidiIter>(this->traits_.flags(), this->rxtraits());
+
+        case token_assert_word_boundary:
+            return detail::make_assert_word<BidiIter>(detail::word_boundary<mpl::true_>(), this->rxtraits());
+
+        case token_assert_not_word_boundary:
+            return detail::make_assert_word<BidiIter>(detail::word_boundary<mpl::false_>(), this->rxtraits());
+
+        case token_assert_word_begin:
+            return detail::make_assert_word<BidiIter>(detail::word_begin(), this->rxtraits());
+
+        case token_assert_word_end:
+            return detail::make_assert_word<BidiIter>(detail::word_end(), this->rxtraits());
+
+        case token_escape:
+            esc = this->parse_escape(begin, end);
+            switch(esc.type_)
+            {
+            case detail::escape_mark:
+                return detail::make_backref_xpression<BidiIter>
+                (
+                    esc.mark_nbr_, this->traits_.flags(), this->rxtraits()
+                );
+            case detail::escape_char:
+                return detail::make_char_xpression<BidiIter>
+                (
+                    esc.ch_, this->traits_.flags(), this->rxtraits()
+                );
+            case detail::escape_class:
+                return detail::make_posix_charset_xpression<BidiIter>
+                (
+                    esc.class_
+                  , this->is_upper_(*begin++)
+                  , this->traits_.flags()
+                  , this->rxtraits()
+                );
+            }
+
+        case token_group_begin:
+            return this->parse_group(begin, end);
+
+        case token_charset_begin:
+            return this->parse_charset(begin, end);
+
+        case token_invalid_quantifier:
+            BOOST_THROW_EXCEPTION(regex_error(error_badrepeat, "quantifier not expected"));
+            break;
+
+        case token_quote_meta_begin:
+            return detail::make_literal_xpression<BidiIter>
+            (
+                this->parse_quote_meta(begin, end), this->traits_.flags(), this->rxtraits()
+            );
+
+        case token_quote_meta_end:
+            BOOST_THROW_EXCEPTION(
+                regex_error(
+                    error_escape
+                  , "found quote-meta end without corresponding quote-meta begin"
+                )
+            );
+            break;
+
+        case token_end_of_pattern:
+            break;
+
+        default:
+            begin = old_begin;
+            break;
+        }
+
+        return detail::sequence<BidiIter>();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_quant
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    detail::sequence<BidiIter> parse_quant(FwdIter &begin, FwdIter end)
+    {
+        BOOST_ASSERT(begin != end);
+        detail::quant_spec spec = { 0, 0, false, &this->hidden_mark_count_ };
+        detail::sequence<BidiIter> seq = this->parse_atom(begin, end);
+
+        // BUGBUG this doesn't handle the degenerate (?:)+ correctly
+        if(!seq.empty() && begin != end && detail::quant_none != seq.quant())
+        {
+            if(this->traits_.get_quant_spec(begin, end, spec))
+            {
+                BOOST_ASSERT(spec.min_ <= spec.max_);
+
+                if(0 == spec.max_) // quant {0,0} is degenerate -- matches nothing.
+                {
+                    seq = this->parse_quant(begin, end);
+                }
+                else
+                {
+                    seq.repeat(spec);
+                }
+            }
+        }
+
+        return seq;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_sequence
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    detail::sequence<BidiIter> parse_sequence(FwdIter &begin, FwdIter end)
+    {
+        detail::sequence<BidiIter> seq;
+
+        while(begin != end)
+        {
+            detail::sequence<BidiIter> seq_quant = this->parse_quant(begin, end);
+
+            // did we find a quantified atom?
+            if(seq_quant.empty())
+                break;
+
+            // chain it to the end of the xpression sequence
+            seq += seq_quant;
+        }
+
+        return seq;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_literal
+    //  scan ahead looking for char literals to be globbed together into a string literal
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    string_type parse_literal(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        BOOST_ASSERT(begin != end);
+        BOOST_ASSERT(token_literal == this->traits_.get_token(begin, end));
+        escape_value esc = { 0, 0, 0, detail::escape_char };
+        string_type literal(1, *begin);
+
+        for(FwdIter prev = begin, tmp = ++begin; begin != end; prev = begin, begin = tmp)
+        {
+            detail::quant_spec spec = { 0, 0, false, &this->hidden_mark_count_ };
+            if(this->traits_.get_quant_spec(tmp, end, spec))
+            {
+                if(literal.size() != 1)
+                {
+                    begin = prev;
+                    literal.erase(boost::prior(literal.end()));
+                }
+                return literal;
+            }
+            else switch(this->traits_.get_token(tmp, end))
+            {
+            case token_escape:
+                esc = this->parse_escape(tmp, end);
+                if(detail::escape_char != esc.type_) return literal;
+                literal.insert(literal.end(), esc.ch_);
+                break;
+            case token_literal:
+                literal.insert(literal.end(), *tmp++);
+                break;
+            default:
+                return literal;
+            }
+        }
+
+        return literal;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // parse_quote_meta
+    //  scan ahead looking for char literals to be globbed together into a string literal
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    string_type parse_quote_meta(FwdIter &begin, FwdIter end)
+    {
+        using namespace regex_constants;
+        FwdIter old_begin = begin, old_end;
+        while(end != (old_end = begin))
+        {
+            switch(this->traits_.get_token(begin, end))
+            {
+            case token_quote_meta_end:
+                return string_type(old_begin, old_end);
+            case token_escape:
+                BOOST_XPR_ENSURE_(begin != end, error_escape, "incomplete escape sequence");
+                BOOST_FALLTHROUGH;
+            case token_invalid_quantifier:
+            case token_literal:
+                ++begin;
+                break;
+            default:
+                break;
+            }
+        }
+        return string_type(old_begin, begin);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////
+    // parse_escape
+    /// INTERNAL ONLY
+    template<typename FwdIter>
+    escape_value parse_escape(FwdIter &begin, FwdIter end)
+    {
+        BOOST_XPR_ENSURE_(begin != end, regex_constants::error_escape, "incomplete escape sequence");
+
+        // first, check to see if this can be a backreference
+        if(0 < this->rxtraits().value(*begin, 10))
+        {
+            // Parse at most 3 decimal digits.
+            FwdIter tmp = begin;
+            int mark_nbr = detail::toi(tmp, end, this->rxtraits(), 10, 999);
+
+            // If the resulting number could conceivably be a backref, then it is.
+            if(10 > mark_nbr || mark_nbr <= static_cast<int>(this->mark_count_))
+            {
+                begin = tmp;
+                escape_value esc = {0, mark_nbr, 0, detail::escape_mark};
+                return esc;
+            }
+        }
+
+        // Not a backreference, defer to the parse_escape helper
+        return detail::parse_escape(begin, end, this->traits_);
+    }
+
+    bool is_upper_(char_type ch) const
+    {
+        return 0 != this->upper_ && this->rxtraits().isctype(ch, this->upper_);
+    }
+
+    std::size_t mark_count_;
+    std::size_t hidden_mark_count_;
+    CompilerTraits traits_;
+    typename RegexTraits::char_class_type upper_;
+    shared_ptr<detail::regex_impl<BidiIter> > self_;
+    std::map<string_type, basic_regex<BidiIter> > rules_;
+};
+
+}} // namespace boost::xpressive
+
+#endif

--- a/inst/include/boost/xpressive/xpressive.hpp
+++ b/inst/include/boost/xpressive/xpressive.hpp
@@ -1,0 +1,21 @@
+///////////////////////////////////////////////////////////////////////////////
+/// \file xpressive.hpp
+/// Includes all of xpressive including support for both static and
+/// dynamic regular expressions.
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/xpressive/xpressive_static.hpp>
+#include <boost/xpressive/xpressive_dynamic.hpp>
+
+#endif

--- a/inst/include/boost/xpressive/xpressive_dynamic.hpp
+++ b/inst/include/boost/xpressive/xpressive_dynamic.hpp
@@ -1,0 +1,25 @@
+///////////////////////////////////////////////////////////////////////////////
+/// \file xpressive_dynamic.hpp
+/// Includes everything you need to write and use dynamic regular expressions.
+//
+//  Copyright 2008 Eric Niebler. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_XPRESSIVE_DYNAMIC_HPP_EAN_10_04_2005
+#define BOOST_XPRESSIVE_DYNAMIC_HPP_EAN_10_04_2005
+
+// MS compatible compilers support #pragma once
+#if defined(_MSC_VER)
+# pragma once
+#endif
+
+#include <boost/xpressive/regex_compiler.hpp>
+#include <boost/xpressive/basic_regex.hpp>
+#include <boost/xpressive/sub_match.hpp>
+#include <boost/xpressive/match_results.hpp>
+#include <boost/xpressive/regex_algorithms.hpp>
+#include <boost/xpressive/regex_iterator.hpp>
+#include <boost/xpressive/regex_token_iterator.hpp>
+
+#endif

--- a/local/scripts/CreateBoost.sh
+++ b/local/scripts/CreateBoost.sh
@@ -13,7 +13,7 @@ pkgdir="${HOME}/git/bh"
 boosttargz="boost_1_60_0.tar.gz"
 ## -- current package version and date (and other metadata as needed)
 version="1.60.0-0"
-date="2015-12-24"
+date="2016-2-20"
 
 
 
@@ -121,7 +121,7 @@ bcp --boost=${boostroot}  ${boostlibs}  ${pkgincl}   > /dev/null  2>&1
 # Plus phoenix (cf [github] issue ticket #19)
 boostextras="filesystem spirit foreach algorithm iostreams \
             dynamic_bitset heap any circular_buffer geometry fusion graph \
-            multiprcecision phoenix"
+            multiprcecision phoenix bimap"
 
 bcp --boost=${boostroot}  ${boostextras}   ${pkgincl}   > /dev/null   2>&1
 

--- a/man/BH-package.Rd
+++ b/man/BH-package.Rd
@@ -16,7 +16,7 @@
 Package: \tab BH\cr
 Type: \tab Package\cr
 Version: \tab 1.60.0-0\cr
-Date: \tab 2015-12-24\cr
+Date: \tab 2016-2-20\cr
 License: \tab BSL-1.0\cr
 }
   Boost provides free peer-reviewed portable C++ source


### PR DESCRIPTION
Previously only a subset of the bimap functionality was included, presumably because it was needed by other included components. Notably most of the bimap container adapters were absent, so you could not use anything but basic bimaps.

I basically downloaded  boost_1_60_0.tar.gz and ran `local/scripts/CreateBoost.sh` with bimap added in `boostextras` and an updated date. If there is anything else needed please let me know.