### PR TITLE
include icl headers

### DIFF
--- a/inst/include/boost/icl/associative_element_container.hpp
+++ b/inst/include/boost/icl/associative_element_container.hpp
@@ -1,0 +1,20 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_ASSOCIATIVE_ELEMENT_CONTAINER_HPP_JOFA_101023
+#define BOOST_ICL_ASSOCIATIVE_ELEMENT_CONTAINER_HPP_JOFA_101023
+
+#include <boost/icl/detail/map_algo.hpp>
+#include <boost/icl/concept/comparable.hpp>
+#include <boost/icl/concept/container.hpp>
+#include <boost/icl/concept/element_set.hpp>
+#include <boost/icl/concept/element_map.hpp>
+#include <boost/icl/concept/element_associator.hpp>
+
+#endif
+
+

--- a/inst/include/boost/icl/associative_interval_container.hpp
+++ b/inst/include/boost/icl/associative_interval_container.hpp
@@ -1,0 +1,23 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_ASSOCIATIVE_INTERVAL_CONTAINER_HPP_JOFA_101023
+#define BOOST_ICL_ASSOCIATIVE_INTERVAL_CONTAINER_HPP_JOFA_101023
+
+#include <boost/icl/impl_config.hpp>
+#include <boost/icl/concept/comparable.hpp>
+#include <boost/icl/concept/joinable.hpp>
+#include <boost/icl/concept/container.hpp>
+#include <boost/icl/concept/interval_associator_base.hpp>
+#include <boost/icl/concept/interval_set.hpp>
+#include <boost/icl/concept/interval_map.hpp>
+#include <boost/icl/concept/interval_associator.hpp>
+#include <boost/icl/iterator.hpp>
+
+#endif
+
+

--- a/inst/include/boost/icl/closed_interval.hpp
+++ b/inst/include/boost/icl/closed_interval.hpp
@@ -1,0 +1,118 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CLOSED_INTERVAL_HPP_JOFA_100324
+#define BOOST_ICL_CLOSED_INTERVAL_HPP_JOFA_100324
+
+#include <boost/icl/detail/concept_check.hpp>
+#include <boost/icl/concept/interval.hpp>
+#include <boost/icl/type_traits/value_size.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+
+template <class DomainT, 
+          ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)>
+class closed_interval
+{
+public:
+    typedef closed_interval<DomainT,Compare> type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor; yields an empty interval <tt>[0,0)</tt>. */
+    closed_interval() 
+        : _lwb(unit_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
+    }
+
+    //NOTE: Compiler generated copy constructor is used
+
+    /** Constructor for a closed singleton interval <tt>[val,val]</tt> */
+    explicit closed_interval(const DomainT& val)
+        : _lwb(val), _upb(val)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((!icl::is_continuous<DomainT>::value));
+    }
+
+    /** Interval from <tt>low</tt> to <tt>up</tt> with bounds <tt>bounds</tt> */
+    closed_interval(const DomainT& low, const DomainT& up) :
+        _lwb(low), _upb(up)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    DomainT lower()const{ return _lwb; }
+    DomainT upper()const{ return _upb; }
+
+    DomainT first()const{ return _lwb; }
+    DomainT last() const{ return _upb; }
+
+private:
+    DomainT _lwb;
+    DomainT _upb;
+};
+
+
+//==============================================================================
+//=T closed_interval -> concept intervals
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct interval_traits< icl::closed_interval<DomainT, Compare> >
+{
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef icl::closed_interval<DomainT, Compare> interval_type;
+
+    static interval_type construct(const domain_type& lo, const domain_type& up)
+    {
+        return interval_type(lo, up);
+    }
+
+    static domain_type lower(const interval_type& inter_val){ return inter_val.lower(); };
+    static domain_type upper(const interval_type& inter_val){ return inter_val.upper(); };
+};
+
+//==============================================================================
+//= Type traits
+//==============================================================================
+template <class DomainT, ICL_COMPARE Compare> 
+struct interval_bound_type< closed_interval<DomainT,Compare> >
+{
+    typedef interval_bound_type type;
+    BOOST_STATIC_CONSTANT(bound_type, value = interval_bounds::static_closed);
+};
+
+template <class DomainT, ICL_COMPARE Compare>
+struct type_to_string<icl::closed_interval<DomainT,Compare> >
+{
+    static std::string apply()
+    { return "[I]<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+template<class DomainT> 
+struct value_size<icl::closed_interval<DomainT> >
+{
+    static std::size_t apply(const icl::closed_interval<DomainT>&) 
+    { return 2; }
+};
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/concept/comparable.hpp
+++ b/inst/include/boost/icl/concept/comparable.hpp
@@ -1,0 +1,45 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_COMPARABLE_HPP_JOFA_100921
+#define BOOST_ICL_CONCEPT_COMPARABLE_HPP_JOFA_100921
+
+#include <boost/utility/enable_if.hpp>
+#include <boost/icl/type_traits/is_icl_container.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= Equivalences and Orderings<Comparable>
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_icl_container<Type>, bool>::type
+operator != (const Type& left, const Type& right)
+{ return !(left == right); }
+
+template<class Type>
+inline typename enable_if<is_icl_container<Type>, bool>::type
+operator > (const Type& left, const Type& right)
+{ return right < left; }
+
+/** Partial ordering which is induced by Compare */
+template<class Type>
+inline typename enable_if<is_icl_container<Type>, bool>::type
+operator <= (const Type& left, const Type& right)
+{ return !(left > right); }
+
+template<class Type>
+inline typename enable_if<is_icl_container<Type>, bool>::type
+operator >= (const Type& left, const Type& right)
+{ return !(left < right); }
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/container.hpp
+++ b/inst/include/boost/icl/concept/container.hpp
@@ -1,0 +1,87 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_CONTAINER_HPP_JOFA_100923
+#define BOOST_ICL_CONCEPT_CONTAINER_HPP_JOFA_100923
+
+#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/icl/type_traits/is_container.hpp>
+#include <boost/icl/type_traits/is_icl_container.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= Emptieness
+//==============================================================================
+
+/** Tests if the container is empty. 
+    Complexity: constant. */
+template<class Type>
+typename enable_if<is_container<Type>, bool>::type
+is_empty(const Type& object)
+{
+    return object.begin()==object.end();
+}
+
+
+/** All content of the container is dropped. 
+    Complexity: linear. */
+template<class Type>
+typename enable_if<is_container<Type>, void>::type
+clear(Type& object)
+{
+    object.erase(object.begin(), object.end());
+}
+
+//==============================================================================
+//= Size
+//==============================================================================
+
+template<class Type> 
+typename enable_if<mpl::and_< is_container<Type>
+                            , mpl::not_<is_icl_container<Type> > >
+                  , std::size_t>::type
+iterative_size(const Type& object)
+{ 
+    return object.size(); 
+}
+
+//==============================================================================
+//= Swap
+//==============================================================================
+
+template<class Type>
+typename enable_if<is_container<Type>, void>::type
+swap(Type& left, Type& right)
+{
+    left.swap(right);
+}
+
+//==============================================================================
+//= Iteration
+//==============================================================================
+
+template<class Type>
+typename enable_if<is_container<Type>, typename Type::iterator>::type
+cyclic_prior(Type& object, typename Type::iterator it_)
+{ return it_ == object.begin() ? object.end() : --it_; }
+
+template<class Type>
+typename enable_if<is_container<Type>, typename Type::const_iterator>::type
+cyclic_prior(const Type& object, typename Type::const_iterator it_)
+{ return it_ == object.begin() ? object.end() : --it_; }
+
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/element_associator.hpp
+++ b/inst/include/boost/icl/concept/element_associator.hpp
@@ -1,0 +1,506 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_ELEMENT_ASSOCIATOR_HPP_JOFA_100921
+#define BOOST_ICL_CONCEPT_ELEMENT_ASSOCIATOR_HPP_JOFA_100921
+
+#include <boost/config.hpp>
+#include <boost/icl/type_traits/is_associative_element_container.hpp>
+#include <boost/icl/type_traits/is_key_container_of.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/detail/subset_comparer.hpp>
+#include <boost/icl/concept/element_set.hpp>
+#include <boost/icl/concept/element_map.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= Size
+//==============================================================================
+template<class Type> 
+typename enable_if<is_element_container<Type>, std::size_t>::type
+iterative_size(const Type& object)
+{ 
+    return object.size(); 
+}
+
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, typename Type::size_type>::type
+size(const Type& object)
+{ 
+    return icl::iterative_size(object); 
+}
+
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, typename Type::size_type>::type
+cardinality(const Type& object)
+{ 
+    return icl::iterative_size(object); 
+}
+
+
+//==============================================================================
+//= Containedness<ElementSet|ElementMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- bool within(c P&, c T&) T:{s}|{m} P:{e}|{i} fragment_types|key_types
+//------------------------------------------------------------------------------
+/** Checks if a key is in the associative container */
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, bool>::type
+within(const typename Type::key_type& key, const Type& super)
+{ 
+    return !(super.find(key) == super.end()); 
+}
+
+//------------------------------------------------------------------------------
+//- bool within(c P&, c T&) T:{s}|{m} P:{s'} fragment_types|key_types
+//------------------------------------------------------------------------------
+template<class SubT, class SuperT>
+typename enable_if<mpl::and_< is_associative_element_container<SuperT> 
+                            , is_key_container_of<SubT, SuperT> >,
+                   bool>::type
+within(const SubT& sub, const SuperT& super)
+{
+    if(icl::is_empty(sub))                return true;
+    if(icl::is_empty(super))              return false;
+    if(icl::size(super) < icl::size(sub)) return false;
+
+    typename SubT::const_iterator common_lwb_;
+    typename SubT::const_iterator common_upb_;
+    if(!Set::common_range(common_lwb_, common_upb_, sub, super))
+        return false;
+
+    typename SubT::const_iterator sub_ = sub.begin();
+    typename SuperT::const_iterator super_;
+    while(sub_ != sub.end())
+    {
+        super_ = super.find(key_value<SubT>(sub_));
+        if(super_ == super.end()) 
+            return false;
+        else if(!co_equal(sub_, super_, &sub, &super))
+            return false;
+
+        ++sub_;
+    }
+    return true;
+}
+
+//------------------------------------------------------------------------------
+//- bool contains(c T&, c P&) T:{s}|{m} P:{e}|{i} fragment_types|key_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, bool>::type
+contains(const Type& super, const typename Type::key_type& key)
+{ 
+    return icl::within(key, super); 
+}
+
+//------------------------------------------------------------------------------
+//- bool contains(c T&, c P&) T:{s}|{m} P:{s'} fragment_types|key_types
+//------------------------------------------------------------------------------
+template<class SubT, class SuperT>
+typename enable_if<mpl::and_< is_associative_element_container<SuperT>
+                            , is_key_container_of<SubT, SuperT> >,
+                   bool>::type
+contains(const SuperT& super, const SubT& sub)
+{ 
+    return icl::within(sub, super); 
+}
+
+//==============================================================================
+//= Equivalences and Orderings
+//==============================================================================
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4996) //'std::equal': Function call with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct. To disable this warning, use -D_SCL_SECURE_NO_WARNINGS. See documentation on how to use Visual C++ 'Checked Iterators'
+#endif                        // I do guarantee here that I am using the parameters correctly :)
+
+/** Standard equality, which is lexicographical equality of the sets
+    as sequences, that are given by their Compare order. */
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, bool>::type
+operator == (const Type& left, const Type& right)
+{
+    return left.size() == right.size() 
+        && std::equal(left.begin(), left.end(), right.begin());
+}
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, bool>::type
+is_element_equal(const Type& left, const Type& right)
+{ return left == right; }
+
+
+/* Strict weak less ordering which is given by the Compare order */
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, bool>::type
+operator < (const Type& left, const Type& right)
+{
+    return std::lexicographical_compare(
+        left.begin(), left.end(), right.begin(), right.end(), 
+        typename Type::element_compare()
+        );
+}
+
+template<class LeftT, class RightT>
+typename enable_if<is_concept_equivalent<is_element_container,LeftT, RightT>, 
+                   int>::type
+inclusion_compare(const LeftT& left, const RightT& right)
+{
+    return Set::subset_compare(left, right, 
+                               left.begin(), left.end(),
+                               right.begin(), right.end());
+}
+
+//==============================================================================
+//= Addition
+//==============================================================================
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator += (Type& object, const typename Type::value_type& operand) 
+{ 
+    return icl::add(object, operand); 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator + (Type object, const typename Type::value_type& operand) 
+{ 
+    return object += operand; 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator + (const typename Type::value_type& operand, Type object) 
+{ 
+    return object += operand; 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator += (Type& object, const Type& operand) 
+{ 
+    if(&object == &operand)
+        return object;
+
+    typename Type::iterator prior_ = object.end();
+    ICL_const_FORALL(typename Type, it_, operand)
+        prior_ = icl::add(object, prior_, *it_);
+
+    return object;
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator + (Type object, const Type& operand) 
+{ 
+    return object += operand; 
+}
+
+//==============================================================================
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator |= (Type& object, const typename Type::value_type& operand) 
+{ 
+    return icl::add(object, operand); 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator | (Type object, const typename Type::value_type& operand) 
+{ 
+    return object += operand; 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator | (const typename Type::value_type& operand, Type object) 
+{ 
+    return object += operand; 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator |= (Type& object, const Type& operand) 
+{ 
+    return object += operand; 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator | (Type object, const Type& operand) 
+{ 
+    return object += operand; 
+}
+
+
+//==============================================================================
+//= Insertion
+//==============================================================================
+//------------------------------------------------------------------------------
+//- V insert(T&, c P&) T:{s}|{m} P:{e}|{b} fragment_type
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, 
+                   std::pair<typename Type::iterator,bool> >::type
+insert(Type& object, const typename Type::value_type& operand)
+{
+    return object.insert(operand);
+}
+
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, 
+                   typename Type::iterator>::type
+insert(Type& object, typename Type::iterator      prior, 
+               const typename Type::value_type& operand)
+{
+    return object.insert(prior, operand);
+}
+
+//------------------------------------------------------------------------------
+//- T insert(T&, c T&) T:{s m}  map fragment_type
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, Type>::type&
+insert(Type& object, const Type& addend)
+{
+    typedef typename Type::iterator iterator;
+
+    iterator prior_ = object.end();
+    ICL_const_FORALL(typename Type, elem_, addend) 
+        icl::insert(object, prior_, *elem_);
+
+    return object; 
+}
+
+
+//==============================================================================
+//= Erasure
+//==============================================================================
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, typename Type::size_type>::type
+erase(Type& object, const typename Type::key_type& key_value)
+{
+    typedef typename Type::size_type size_type;
+    typename Type::iterator it_ = object.find(key_value);
+    if(it_ != object.end())
+    {
+        object.erase(it_);
+        return unit_element<size_type>::value();
+    }
+    return identity_element<size_type>::value();
+}
+
+template<class Type>
+typename enable_if<is_associative_element_container<Type>, Type>::type&
+erase(Type& object, const Type& erasure)
+{
+    ICL_const_FORALL(typename Type, elem_, erasure) 
+        icl::erase(object, *elem_); 
+
+    return object; 
+}
+
+
+
+//==============================================================================
+//= Subtraction<ElementSet|ElementMap>
+//==============================================================================
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator -= (Type& object, const typename Type::value_type& operand) 
+{ 
+    return icl::subtract(object, operand); 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator - (Type object, const typename Type::value_type& operand) 
+{ 
+    return object -= operand; 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator -= (Type& object, const Type& subtrahend) 
+{ 
+    ICL_const_FORALL(typename Type, it_, subtrahend)
+        icl::subtract(object, *it_);
+
+    return object; 
+}
+
+template <class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator - (Type object, const Type& subtrahend) 
+{ 
+    return object -= subtrahend; 
+}
+
+
+//==============================================================================
+//= Intersection
+//==============================================================================
+//------------------------------------------------------------------------------
+//- void add_intersection(T&, c T&, c P&) T:{s}{m} P:{e}{e} key_type 
+//------------------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, void>::type
+add_intersection(Type& section, const Type&              object, 
+                       const typename Type::key_type& operand)
+{
+    typedef typename Type::const_iterator const_iterator;
+    const_iterator it_ = object.find(operand);
+    if(it_ != object.end()) 
+        icl::add(section, *it_);
+}
+
+//------------------------------------------------------------------------------
+//- void add_intersection(T&, c T&, c P&) T:{s}{m} P:{s}{s} set key_type 
+//------------------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, void>::type
+add_intersection(Type& section, const Type& object, 
+                 const typename key_container_type_of<Type>::type& operand)
+{
+    typedef typename key_container_type_of<Type>::type key_container_type;
+    typedef typename key_container_type::const_iterator const_iterator;
+    const_iterator common_lwb_, common_upb_;
+    if(!Set::common_range(common_lwb_, common_upb_, operand, object))
+        return;
+
+    const_iterator sec_ = common_lwb_;
+    while(sec_ != common_upb_)
+        add_intersection(section, object, *sec_++);
+}
+
+//------------------------------------------------------------------------------
+//- Intersection<ElementMap|ElementSet> 
+//------------------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator &= (Type& object, const typename Type::key_type& operand)
+{ 
+    Type section;
+    add_intersection(section, object, operand);
+    object.swap(section);
+    return object;
+}
+
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator & (Type object, const typename Type::key_type& operand)
+{
+    return object &= operand;
+}
+
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator & (const typename Type::key_type& operand, Type object)
+{
+    return object &= operand;
+}
+
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+operator &= (Type& object, const typename key_container_type_of<Type>::type& operand)
+{ 
+    Type section;
+    add_intersection(section, object, operand);
+    object.swap(section);
+    return object;
+}
+
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator & (Type object, const Type& operand)
+{
+    return object &= operand;
+}
+//------------------------------------------------------------------------------
+
+template<class Type, class CoType>
+inline typename enable_if<is_associative_element_container<Type>, bool>::type
+disjoint(const Type& left, const Type& right)
+{
+    return !intersects(left, right);
+}
+
+//==============================================================================
+//= Symmetric difference<ElementSet|ElementMap>
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator ^ (Type object, const typename Type::value_type& operand)
+{
+    return icl::flip(object, operand);
+}
+
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator ^ (const typename Type::value_type& operand, Type object)
+{
+    return icl::flip(object, operand);
+}
+
+template<class Type>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type
+operator ^ (Type object, const Type& operand)
+{
+    return object ^= operand; 
+}
+
+
+//==============================================================================
+//= Manipulation by predicates
+//==============================================================================
+template<class Type, class Predicate>
+typename enable_if<is_associative_element_container<Type>, Type>::type&
+erase_if(const Predicate& pred, Type& object)
+{
+    typename Type::iterator it_ = object.begin();
+    while(it_ != object.end())
+        if(pred(*it_))
+            icl::erase(object, it_++); 
+        else ++it_;
+    return object;
+}
+
+template<class Type, class Predicate>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+add_if(const Predicate& pred, Type& object, const Type& src)
+{
+    typename Type::const_iterator it_ = src.begin();
+    while(it_ != src.end())
+        if(pred(*it_)) 
+            icl::add(object, *it_++); 
+    
+    return object;
+}
+
+template<class Type, class Predicate>
+inline typename enable_if<is_associative_element_container<Type>, Type>::type&
+assign_if(const Predicate& pred, Type& object, const Type& src)
+{
+    icl::clear(object);
+    return add_if(object, src, pred);
+}
+
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/element_map.hpp
+++ b/inst/include/boost/icl/concept/element_map.hpp
@@ -1,0 +1,481 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_ELEMENT_MAP_HPP_JOFA_100921
+#define BOOST_ICL_CONCEPT_ELEMENT_MAP_HPP_JOFA_100921
+
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/icl/detail/on_absorbtion.hpp>
+#include <boost/icl/type_traits/unit_element.hpp>
+#include <boost/icl/type_traits/is_total.hpp>
+#include <boost/icl/type_traits/absorbs_identities.hpp>
+#include <boost/icl/type_traits/is_associative_element_container.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+
+#include <boost/icl/concept/map_value.hpp>
+#include <boost/icl/detail/map_algo.hpp>
+
+
+namespace boost{ namespace icl
+{
+
+//NOTE: Some forward declarations are needed by some compilers.
+template<class Type, class Predicate>
+typename enable_if<is_associative_element_container<Type>, Type>::type&
+erase_if(const Predicate& pred, Type& object);
+
+
+//==============================================================================
+//= Containedness<ElementMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- bool within(c P&, c T&) T:{m} P:{b} fragment_types
+//------------------------------------------------------------------------------
+/** Checks if a key-value pair is in the map */
+template<class Type>
+typename enable_if<is_element_map<Type>, bool>::type
+within(const typename Type::element_type& value_pair, const Type& super)
+{ 
+    typedef typename Type::const_iterator const_iterator;
+    const_iterator found_ = super.find(value_pair.first);
+    return found_ != super.end() && (*found_).second == value_pair.second;
+}
+
+//------------------------------------------------------------------------------
+//- bool contains(c T&, c P&) T:{m} P:{b} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_element_map<Type>, bool>::type
+contains(const Type& super, const typename Type::element_type& value_pair)
+{
+    return icl::within(value_pair, super);
+}
+
+//==============================================================================
+//= Equivalences and Orderings<ElementMap>
+//==============================================================================
+
+/** Protonic equality is equality on all elements that do not carry an identity element as content. */
+template<class Type>
+inline typename enable_if<is_element_map<Type>, bool>::type
+is_distinct_equal(const Type& lhs, const Type& rhs)
+{
+    return Map::lexicographical_distinct_equal(lhs, rhs);
+}
+
+//==============================================================================
+//= Addition<ElementMap>
+//==============================================================================
+/** \c add inserts \c value_pair into the map if it's key does 
+    not exist in the map.    
+    If \c value_pairs's key value exists in the map, it's data
+    value is added to the data value already found in the map. */
+template <class Type>
+typename enable_if<is_element_map<Type>, Type>::type&
+add(Type& object, const typename Type::value_type& value_pair)
+{
+    return object.add(value_pair); 
+}
+
+/** \c add add \c value_pair into the map using \c prior as a hint to
+    insert \c value_pair after the position \c prior is pointing to. */
+template <class Type>
+typename enable_if<is_element_map<Type>, typename Type::iterator>::type
+add(Type& object, typename Type::iterator prior, 
+    const typename Type::value_type& value_pair) 
+{ 
+    return object.add(prior, value_pair); 
+}
+
+//==============================================================================
+//= Erasure
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& erase(T&, c P&) T:{m} P:{b} fragment_type
+//------------------------------------------------------------------------------
+template <class Type>
+typename enable_if<is_element_map<Type>, typename Type::size_type>::type
+erase(Type& object, const typename Type::element_type& value_pair)
+{
+    typedef typename Type::size_type             size_type;
+    typedef typename Type::iterator              iterator;
+    typedef typename Type::on_identity_absorbtion on_identity_absorbtion;
+
+    if(on_identity_absorbtion::is_absorbable(value_pair.second)) 
+        return identity_element<size_type>::value();
+
+    iterator it_ = object.find(value_pair.first);
+    if(it_ != object.end() && value_pair.second == (*it_).second)
+    {
+        object.erase(it_);
+        return unit_element<size_type>::value();
+    }
+
+    return identity_element<size_type>::value();
+}
+
+template<class Type>
+typename enable_if<is_element_map<Type>, Type>::type&
+erase(Type& object, const typename Type::set_type& erasure)
+{
+    typedef typename Type::set_type set_type;
+    ICL_const_FORALL(typename set_type, elem_, erasure) 
+        icl::erase(object, *elem_); 
+
+    return object; 
+}
+
+//==============================================================================
+//= Subtraction
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{m} P:{b} fragment_type
+//------------------------------------------------------------------------------
+template <class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type&
+subtract(Type& object, const typename Type::element_type& operand) 
+{ 
+    return object.subtract(operand); 
+}
+
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{m} P:{e} key_type
+//------------------------------------------------------------------------------
+template <class Type>
+typename enable_if<is_element_map<Type>, Type>::type&
+subtract(Type& object, const typename Type::domain_type& key_value)
+{
+    return icl::erase(object, key_value);
+}
+
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{m} P:{s} set key_type 
+//------------------------------------------------------------------------------
+template <class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type&
+operator -= (Type& object, const typename Type::set_type& operand) 
+{ 
+    typedef typename Type::set_type           set_type;
+    typedef typename set_type::const_iterator co_iterator;
+    typedef typename Type::iterator           iterator;
+
+    co_iterator common_lwb_, common_upb_;
+    if(!Set::common_range(common_lwb_, common_upb_, operand, object))
+        return object;
+
+    co_iterator it_ = common_lwb_;
+    iterator    common_;
+
+    while(it_ != common_upb_)
+        object.erase(*it_++);
+
+    return object;
+}
+
+template <class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type
+operator - (Type object, const typename Type::set_type& subtrahend) 
+{ 
+    return object -= subtrahend; 
+}
+
+//==============================================================================
+//= Selective Update<ElementMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& set_at(T&, c P&) T:{m} P:{b}
+//------------------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type&
+set_at(Type& object, const typename Type::element_type& operand)
+{
+    typedef typename Type::iterator         iterator;
+    typedef typename Type::codomain_combine codomain_combine;
+    typedef on_absorbtion<Type,codomain_combine,absorbs_identities<Type>::value>
+                                            on_identity_absorbtion;
+
+    if(!on_identity_absorbtion::is_absorbable(operand.second))
+    {
+        std::pair<iterator,bool> insertion = object.insert(operand);
+        if(!insertion.second)
+            insertion->second = operand.second;
+    }
+    return object;
+}
+
+
+//==============================================================================
+//= Intersection
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_element_map<Type>, void>::type
+add_intersection(Type& section, const Type&               object, 
+                       const typename Type::element_type& operand)
+{
+    object.add_intersection(section, operand);
+}
+
+template<class Type>
+inline typename enable_if<is_element_map<Type>, void>::type
+add_intersection(Type& section, const Type& object, const Type& operand)
+{
+    ICL_const_FORALL(typename Type, it_, operand) 
+        icl::add_intersection(section, object, *it_); 
+}
+
+//------------------------------------------------------------------------------
+//- T& op &=(T&, c P&) T:{m} P:{b m} fragment_types
+//------------------------------------------------------------------------------
+
+template<class Type>
+inline typename enable_if<mpl::and_<is_element_map<Type>, is_total<Type> >, Type>::type&
+operator &=(Type& object, const typename Type::element_type& operand)
+{
+    object.add(operand);
+    return object;
+}
+
+template<class Type>
+inline typename enable_if<mpl::and_<is_element_map<Type>, mpl::not_<is_total<Type> > >, Type>::type&
+operator &=(Type& object, const typename Type::element_type& operand)
+{
+    Type section;
+    icl::add_intersection(section, object, operand);
+    object.swap(section);
+    return object; 
+}
+
+template<class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type
+operator & (Type object, const typename Type::element_type& operand)
+{
+    return object &= operand;
+}
+
+template<class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type
+operator & (const typename Type::element_type& operand, Type object)
+{
+    return object &= operand;
+}
+
+
+template<class Type>
+inline typename enable_if<mpl::and_<is_element_map<Type>, is_total<Type> >, Type>::type&
+operator &=(Type& object, const Type& operand)
+{
+    object += operand; 
+    return object;
+}
+
+template<class Type>
+inline typename enable_if<mpl::and_<is_element_map<Type>, mpl::not_<is_total<Type> > >, Type>::type&
+operator &=(Type& object, const Type& operand)
+{
+    Type section;
+    icl::add_intersection(section, object, operand);
+    object.swap(section);
+    return object; 
+}
+
+template<class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type
+operator & (Type object, const typename Type::key_object_type& operand)
+{
+    return object &= operand;
+}
+
+template<class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type
+operator & (const typename Type::key_object_type& operand, Type object)
+{
+    return object &= operand;
+}
+
+//==============================================================================
+//= Intersection<ElementMap> bool intersects(x,y)
+//==============================================================================
+template<class Type, class CoType>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , is_total<Type>      > 
+                         , bool>::type
+intersects(const Type&, const CoType&)
+{
+    return true;
+}
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , mpl::not_<is_total<Type> > > 
+                         , bool>::type
+intersects(const Type& object, const typename Type::domain_type& operand)
+{
+    return icl::contains(object, operand);
+}
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , mpl::not_<is_total<Type> > > 
+                         , bool>::type
+intersects(const Type& object, const typename Type::set_type& operand)
+{
+    if(object.iterative_size() < operand.iterative_size())
+        return Map::intersects(object, operand);
+    else
+        return Map::intersects(operand, object);
+}
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , mpl::not_<is_total<Type> > > 
+                         , bool>::type
+intersects(const Type& object, const typename Type::element_type& operand)
+{
+    Type intersection;
+    icl::add_intersection(intersection, object, operand);
+    return !intersection.empty();
+}
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , mpl::not_<is_total<Type> > > 
+                         , bool>::type
+intersects(const Type& object, const Type& operand)
+{
+    if(object.iterative_size() < operand.iterative_size())
+        return Map::intersects(object, operand);
+    else
+        return Map::intersects(operand, object);
+}
+
+//==============================================================================
+//= Symmetric difference
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_element_map<Type>, Type>::type&
+flip(Type& object, const typename Type::element_type& operand)
+{
+    return object.flip(operand);
+}
+
+template<class Type, class CoType>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , is_total<Type>       
+                                    , absorbs_identities<Type> > 
+                         , Type>::type&
+operator ^= (Type& object, const CoType&)
+{
+    icl::clear(object);
+    return object;
+}
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , is_total<Type>       
+                                    , mpl::not_<absorbs_identities<Type> > > 
+                         , Type>::type&
+operator ^= (Type& object, const typename Type::element_type& operand)
+{
+    return object.flip(operand);
+}
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , is_total<Type>       
+                                    , mpl::not_<absorbs_identities<Type> > > 
+                         , Type>::type&
+operator ^= (Type& object, const Type& operand)
+{
+    ICL_const_FORALL(typename Type, it_, operand)
+        icl::flip(object, *it_);
+
+    ICL_FORALL(typename Type, it2_, object)
+        (*it2_).second = identity_element<typename Type::codomain_type>::value();
+
+    return object;
+}
+
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , mpl::not_<is_total<Type> > > 
+                         , Type>::type&
+operator ^= (Type& object, const typename Type::element_type& operand)
+{
+    return icl::flip(object, operand);
+}
+
+template<class Type>
+inline typename enable_if< mpl::and_< is_element_map<Type>
+                                    , mpl::not_<is_total<Type> > > 
+                         , Type>::type&
+operator ^= (Type& object, const Type& operand)
+{
+    typedef typename Type::const_iterator const_iterator;
+    const_iterator it_ = operand.begin();
+    while(it_ != operand.end())
+        icl::flip(object, *it_++);
+
+    return object;
+}
+
+
+//==============================================================================
+//= Set selection
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_element_map<Type>, 
+                          typename Type::set_type>::type&
+domain(typename Type::set_type& domain_set, const Type& object)
+{
+    typename Type::set_type::iterator prior_ = domain_set.end();
+    typename Type::const_iterator it_ = object.begin();
+    while(it_ != object.end())
+        prior_ = domain_set.insert(prior_, (*it_++).first);
+
+    return domain_set;
+}
+
+//==============================================================================
+//= Neutron absorbtion
+//==============================================================================
+template<class Type>
+inline typename enable_if<mpl::and_< is_element_map<Type>
+                                   , absorbs_identities<Type> >, Type>::type&
+absorb_identities(Type& object)
+{
+    typedef typename Type::element_type element_type;
+    return icl::erase_if(content_is_identity_element<element_type>(), object);
+}
+
+template<class Type>
+inline typename enable_if<mpl::and_< is_element_map<Type>
+                                   , mpl::not_<absorbs_identities<Type> > >
+                         , Type>::type&
+absorb_identities(Type&){}
+
+//==============================================================================
+//= Streaming<ElementMap>
+//==============================================================================
+template<class CharType, class CharTraits, class Type>
+inline typename enable_if<is_element_map<Type>, std::basic_ostream<CharType, CharTraits> >::type&
+operator << (std::basic_ostream<CharType, CharTraits>& stream, const Type& object)
+{
+    stream << "{";
+    ICL_const_FORALL(typename Type, it, object)
+        stream << "(" << it->first << "->" << it->second << ")";
+
+    return stream << "}";
+}
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/element_set.hpp
+++ b/inst/include/boost/icl/concept/element_set.hpp
@@ -1,0 +1,134 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_ELEMENT_SET_HPP_JOFA_100921
+#define BOOST_ICL_CONCEPT_ELEMENT_SET_HPP_JOFA_100921
+
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/concept/set_value.hpp>
+#include <boost/icl/detail/std_set.hpp>
+#include <boost/icl/detail/set_algo.hpp>
+
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= Addition<ElementSet>
+//==============================================================================
+/** \c add inserts \c operand into the map if it's key does 
+    not exist in the map.    
+    If \c operands's key value exists in the map, it's data
+    value is added to the data value already found in the map. */
+template <class Type>
+typename enable_if<is_element_set<Type>, Type>::type&
+add(Type& object, const typename Type::value_type& operand)
+{
+    object.insert(operand); 
+    return object;
+}
+
+/** \c add add \c operand into the map using \c prior as a hint to
+    insert \c operand after the position \c prior is pointing to. */
+template <class Type>
+typename enable_if<is_element_set<Type>, typename Type::iterator>::type
+add(Type& object, typename Type::iterator prior, 
+    const typename Type::value_type& operand) 
+{ 
+    return object.insert(prior, operand); 
+}
+
+//==============================================================================
+//= Subtraction
+//==============================================================================
+/** If the \c operand's key value is in the map, it's data value is
+    subtraced from the data value stored in the map. */
+template<class Type>
+typename enable_if<is_element_set<Type>, Type>::type&
+subtract(Type& object, const typename Type::value_type& operand)
+{
+    object.erase(operand);
+    return object;
+}
+
+
+//==============================================================================
+//= Intersection
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_element_set<Type>, bool>::type
+intersects(const Type& object, const typename Type::key_type& operand)
+{
+    return !(object.find(operand) == object.end()); 
+}
+
+template<class Type>
+inline typename enable_if<is_element_set<Type>, bool>::type
+intersects(const Type& object, const Type& operand)
+{
+    if(iterative_size(object) < iterative_size(operand))
+        return Set::intersects(object, operand);
+    else
+        return Set::intersects(operand, object);
+}
+
+//==============================================================================
+//= Symmetric difference
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_element_set<Type>, Type>::type&
+flip(Type& object, const typename Type::value_type& operand)
+{
+    typedef typename Type::iterator iterator;
+    std::pair<iterator,bool> insertion = object.insert(operand);
+    if(!insertion.second)
+        object.erase(insertion.first);
+
+    return object;
+}
+
+template<class Type>
+inline typename enable_if<is_element_set<Type>, Type>::type&
+operator ^= (Type& object, const typename Type::element_type& operand)
+{
+    return icl::flip(object, operand); 
+}
+
+/** Symmetric subtract map \c x2 and \c *this.
+    So \c *this becomes the symmetric difference of \c *this and \c x2 */
+template<class Type>
+inline typename enable_if<is_element_set<Type>, Type>::type&
+operator ^= (Type& object, const Type& operand)
+{
+    typedef typename Type::const_iterator const_iterator;
+    const_iterator it_ = operand.begin();
+    while(it_ != operand.end())
+        icl::flip(object, *it_++);
+
+    return object;
+}
+
+//==============================================================================
+//= Streaming<ElementSet>
+//==============================================================================
+template<class CharType, class CharTraits, class Type>
+inline typename enable_if<is_element_set<Type>, std::basic_ostream<CharType, CharTraits> >::type&
+operator << (std::basic_ostream<CharType, CharTraits>& stream, const Type& object)
+{
+    stream << "{";
+    ICL_const_FORALL(typename Type, it, object)
+        stream << (*it) << " ";
+
+    return stream << "}";
+}
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/element_set_value.hpp
+++ b/inst/include/boost/icl/concept/element_set_value.hpp
@@ -1,0 +1,31 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_ELEMENT_SET_VALUE_HPP_JOFA_100924
+#define BOOST_ICL_CONCEPT_ELEMENT_SET_VALUE_HPP_JOFA_100924
+
+#include <boost/icl/type_traits/is_element_container.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= AlgoUnifiers<Set>
+//==============================================================================
+template<class Type, class Iterator>
+inline typename enable_if<is_element_set<Type>, const typename Type::key_type>::type&
+co_value(Iterator it_)
+{
+    return *it_;
+}
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/interval.hpp
+++ b/inst/include/boost/icl/concept/interval.hpp
@@ -1,0 +1,1477 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_INTERVAL_HPP_JOFA_100323
+#define BOOST_ICL_CONCEPT_INTERVAL_HPP_JOFA_100323
+
+#include <boost/assert.hpp> 
+#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/icl/detail/design_config.hpp>
+#include <boost/icl/type_traits/unit_element.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/infinity.hpp>
+#include <boost/icl/type_traits/succ_pred.hpp>
+#include <boost/icl/type_traits/is_numeric.hpp>
+#include <boost/icl/type_traits/is_discrete.hpp>
+#include <boost/icl/type_traits/is_continuous.hpp>
+#include <boost/icl/type_traits/is_asymmetric_interval.hpp>
+#include <boost/icl/type_traits/is_discrete_interval.hpp>
+#include <boost/icl/type_traits/is_continuous_interval.hpp>
+
+#include <boost/icl/concept/interval_bounds.hpp>
+#include <boost/icl/interval_traits.hpp>
+#include <boost/icl/dynamic_interval_traits.hpp>
+
+
+namespace boost{namespace icl
+{
+
+//==============================================================================
+//= Ordering
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_interval<Type>, bool>::type
+domain_less(const typename interval_traits<Type>::domain_type& left, 
+            const typename interval_traits<Type>::domain_type& right)
+{
+    return typename interval_traits<Type>::domain_compare()(left, right);
+}
+
+template<class Type>
+inline typename enable_if<is_interval<Type>, bool>::type
+domain_less_equal(const typename interval_traits<Type>::domain_type& left, 
+                  const typename interval_traits<Type>::domain_type& right)
+{
+    return !(typename interval_traits<Type>::domain_compare()(right, left));
+}
+
+template<class Type>
+inline typename enable_if<is_interval<Type>, bool>::type
+domain_equal(const typename interval_traits<Type>::domain_type& left, 
+             const typename interval_traits<Type>::domain_type& right)
+{
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    return !(domain_compare()(left, right)) && !(domain_compare()(right, left));
+}
+
+template<class Type>
+inline typename enable_if< is_interval<Type>
+                         , typename interval_traits<Type>::domain_type>::type
+domain_next(const typename interval_traits<Type>::domain_type value) 
+{
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    return icl::successor<domain_type,domain_compare>::apply(value);
+}
+
+template<class Type>
+inline typename enable_if< is_interval<Type>
+                         , typename interval_traits<Type>::domain_type>::type
+domain_prior(const typename interval_traits<Type>::domain_type value) 
+{
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    return icl::predecessor<domain_type,domain_compare>::apply(value);
+}
+
+//==============================================================================
+//= Construct<Interval> singleton
+//==============================================================================
+template<class Type>
+typename enable_if
+<
+    mpl::and_< is_static_right_open<Type>
+             , is_discrete<typename interval_traits<Type>::domain_type> >
+  , Type
+>::type
+singleton(const typename interval_traits<Type>::domain_type& value)
+{
+    //ASSERT: This always creates an interval with exactly one element
+    return interval_traits<Type>::construct(value, domain_next<Type>(value));
+}
+
+template<class Type>
+typename enable_if
+<
+    mpl::and_< is_static_left_open<Type>
+             , is_discrete<typename interval_traits<Type>::domain_type> >
+  , Type
+>::type
+singleton(const typename interval_traits<Type>::domain_type& value)
+{
+    //ASSERT: This always creates an interval with exactly one element
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_less_than(value) )); 
+
+    return interval_traits<Type>::construct(domain_prior<Type>(value), value);
+}
+
+template<class Type>
+typename enable_if<is_discrete_static_open<Type>, Type>::type
+singleton(const typename interval_traits<Type>::domain_type& value)
+{
+    //ASSERT: This always creates an interval with exactly one element
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_less_than(value))); 
+
+    return interval_traits<Type>::construct( domain_prior<Type>(value)
+                                           , domain_next<Type>(value));
+}
+
+template<class Type>
+typename enable_if<is_discrete_static_closed<Type>, Type>::type
+singleton(const typename interval_traits<Type>::domain_type& value)
+{
+    //ASSERT: This always creates an interval with exactly one element
+    return interval_traits<Type>::construct(value, value);
+}
+
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, Type>::type
+singleton(const typename interval_traits<Type>::domain_type& value)
+{
+    return dynamic_interval_traits<Type>::construct(value, value, interval_bounds::closed());
+}
+
+namespace detail
+{
+
+//==============================================================================
+//= Construct<Interval> unit_trail == generalized singleton
+// The smallest interval on an incrementable (and decrementable) type that can 
+// be constructed using ++ and -- and such that it contains a given value.
+// If 'Type' is discrete, 'unit_trail' and 'singleton' are identical. So we 
+// can view 'unit_trail' as a generalized singleton for static intervals of 
+// continuous types.
+//==============================================================================
+template<class Type>
+typename enable_if
+<
+    mpl::and_< is_static_right_open<Type>
+             , boost::detail::is_incrementable<typename interval_traits<Type>::domain_type> >
+  , Type
+>::type
+unit_trail(const typename interval_traits<Type>::domain_type& value)
+{
+    return interval_traits<Type>::construct(value, domain_next<Type>(value));
+}
+
+template<class Type>
+typename enable_if
+<
+    mpl::and_< is_static_left_open<Type>
+             , boost::detail::is_incrementable<typename interval_traits<Type>::domain_type> >
+  , Type
+>::type
+unit_trail(const typename interval_traits<Type>::domain_type& value)
+{
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_less_than(value) )); 
+
+    return interval_traits<Type>::construct(domain_prior<Type>(value), value);
+}
+
+template<class Type>
+typename enable_if
+<
+    mpl::and_< is_static_open<Type>
+             , is_discrete<typename interval_traits<Type>::domain_type> >
+  , Type
+>::type
+unit_trail(const typename interval_traits<Type>::domain_type& value)
+{
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_less_than(value))); 
+
+    return interval_traits<Type>::construct( domain_prior<Type>(value)
+                                           ,  domain_next<Type>(value));
+}
+
+template<class Type>
+typename enable_if
+<
+    mpl::and_< is_static_closed<Type>
+             , is_discrete<typename interval_traits<Type>::domain_type> >
+  , Type
+>::type
+unit_trail(const typename interval_traits<Type>::domain_type& value)
+{
+    return interval_traits<Type>::construct(value, value);
+}
+
+//NOTE: statically bounded closed or open intervals of continuous domain types
+// are NOT supported by ICL. They can not be used with interval containers
+// consistently.
+
+
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, Type>::type
+unit_trail(const typename interval_traits<Type>::domain_type& value)
+{
+    return dynamic_interval_traits<Type>::construct(value, value, interval_bounds::closed());
+}
+
+} //namespace detail
+
+//==============================================================================
+//= Construct<Interval> multon
+//==============================================================================
+template<class Type>
+typename enable_if<has_static_bounds<Type>, Type>::type
+construct(const typename interval_traits<Type>::domain_type& low,
+          const typename interval_traits<Type>::domain_type& up  )
+{
+    return interval_traits<Type>::construct(low, up);
+}
+
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, Type>::type
+construct(const typename interval_traits<Type>::domain_type& low,
+          const typename interval_traits<Type>::domain_type& up,
+          interval_bounds bounds = interval_bounds::right_open())
+{
+    return dynamic_interval_traits<Type>::construct(low, up, bounds);
+}
+
+
+//- construct form bounded values ----------------------------------------------
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, Type>::type
+construct(const typename Type::bounded_domain_type& low,
+          const typename Type::bounded_domain_type& up)
+{
+    return dynamic_interval_traits<Type>::construct_bounded(low, up);
+}
+
+template<class Type>
+typename enable_if<is_interval<Type>, Type>::type
+span(const typename interval_traits<Type>::domain_type& left,
+     const typename interval_traits<Type>::domain_type& right)
+{
+    if(interval_traits<Type>::domain_compare()(left,right))
+        return construct<Type>(left, right);
+    else
+        return construct<Type>(right, left);
+}
+
+
+//==============================================================================
+template<class Type>
+typename enable_if<is_static_right_open<Type>, Type>::type
+hull(const typename interval_traits<Type>::domain_type& left,
+     const typename interval_traits<Type>::domain_type& right)
+{
+    if(interval_traits<Type>::domain_compare()(left,right))
+        return construct<Type>(left, domain_next<Type>(right));
+    else
+        return construct<Type>(right, domain_next<Type>(left));
+}
+
+template<class Type>
+typename enable_if<is_static_left_open<Type>, Type>::type
+hull(const typename interval_traits<Type>::domain_type& left,
+     const typename interval_traits<Type>::domain_type& right)
+{
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    if(interval_traits<Type>::domain_compare()(left,right))
+    {
+        BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_less_than(left) )); 
+        return construct<Type>(domain_prior<Type>(left), right);
+    }
+    else
+    {
+        BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_less_than(right) )); 
+        return construct<Type>(domain_prior<Type>(right), left);
+    }
+}
+
+template<class Type>
+typename enable_if<is_static_closed<Type>, Type>::type
+hull(const typename interval_traits<Type>::domain_type& left,
+     const typename interval_traits<Type>::domain_type& right)
+{
+    if(interval_traits<Type>::domain_compare()(left,right))
+        return construct<Type>(left, right);
+    else
+        return construct<Type>(right, left);
+}
+
+template<class Type>
+typename enable_if<is_static_open<Type>, Type>::type
+hull(const typename interval_traits<Type>::domain_type& left,
+     const typename interval_traits<Type>::domain_type& right)
+{
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    if(interval_traits<Type>::domain_compare()(left,right))
+    {
+        BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_less_than(left) )); 
+        return construct<Type>( domain_prior<Type>(left)
+                              ,  domain_next<Type>(right));
+    }
+    else
+    {
+        BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                     ::is_less_than(right) )); 
+        return construct<Type>( domain_prior<Type>(right)
+                              ,  domain_next<Type>(left));
+    }
+}
+
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, Type>::type
+hull(const typename interval_traits<Type>::domain_type& left,
+     const typename interval_traits<Type>::domain_type& right)
+{
+    if(interval_traits<Type>::domain_compare()(left,right))
+        return construct<Type>(left, right, interval_bounds::closed());
+    else
+        return construct<Type>(right, left, interval_bounds::closed());
+}
+
+//==============================================================================
+//= Selection
+//==============================================================================
+
+template<class Type>
+inline typename enable_if<is_interval<Type>, 
+                          typename interval_traits<Type>::domain_type>::type
+lower(const Type& object)
+{ 
+    return interval_traits<Type>::lower(object);
+}
+
+template<class Type>
+inline typename enable_if<is_interval<Type>, 
+                          typename interval_traits<Type>::domain_type>::type
+upper(const Type& object)
+{ 
+    return interval_traits<Type>::upper(object);
+}
+
+
+//- first ----------------------------------------------------------------------
+template<class Type>
+inline typename 
+enable_if< mpl::or_<is_static_right_open<Type>, is_static_closed<Type> >
+         , typename interval_traits<Type>::domain_type>::type
+first(const Type& object)
+{ 
+    return lower(object);
+}
+
+template<class Type>
+inline typename 
+enable_if< mpl::and_< mpl::or_<is_static_left_open<Type>, is_static_open<Type> >
+                    , is_discrete<typename interval_traits<Type>::domain_type> >
+         , typename interval_traits<Type>::domain_type>::type
+first(const Type& object)
+{ 
+    return domain_next<Type>(lower(object));
+}
+
+template<class Type>
+inline typename enable_if<is_discrete_interval<Type>, 
+                          typename interval_traits<Type>::domain_type>::type
+first(const Type& object)
+{ 
+    return is_left_closed(object.bounds()) ? 
+                                 lower(object) : 
+               domain_next<Type>(lower(object));
+}
+
+//- last -----------------------------------------------------------------------
+template<class Type>
+inline typename 
+enable_if< mpl::or_<is_static_left_open<Type>, is_static_closed<Type> >
+         , typename interval_traits<Type>::domain_type>::type
+last(const Type& object)
+{ 
+    return upper(object);
+}
+
+template<class Type>
+inline typename 
+enable_if< mpl::and_< mpl::or_<is_static_right_open<Type>, is_static_open<Type> >
+                    , is_discrete<typename interval_traits<Type>::domain_type>  >
+         , typename interval_traits<Type>::domain_type>::type
+last(const Type& object)
+{ 
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_less_than(upper(object)) )); 
+    return domain_prior<Type>(upper(object));
+}
+
+template<class Type>
+inline typename enable_if<is_discrete_interval<Type>, 
+                          typename interval_traits<Type>::domain_type>::type
+last(const Type& object)
+{ 
+    typedef typename interval_traits<Type>::domain_type    domain_type;
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+    BOOST_ASSERT((numeric_minimum<domain_type, domain_compare, is_numeric<domain_type>::value>
+                                 ::is_less_than_or(upper(object), is_right_closed(object.bounds())) )); 
+    return is_right_closed(object.bounds()) ? 
+                                  upper(object) : 
+               domain_prior<Type>(upper(object));
+}
+
+//- last_next ------------------------------------------------------------------
+template<class Type>
+inline typename 
+enable_if< mpl::and_< mpl::or_<is_static_left_open<Type>, is_static_closed<Type> >
+                    , is_discrete<typename interval_traits<Type>::domain_type>  >
+         , typename interval_traits<Type>::domain_type>::type
+last_next(const Type& object)
+{ 
+    return domain_next<Type>(upper(object));
+}
+
+template<class Type>
+inline typename 
+enable_if< mpl::and_< mpl::or_<is_static_right_open<Type>, is_static_open<Type> >
+                    , is_discrete<typename interval_traits<Type>::domain_type>  >
+         , typename interval_traits<Type>::domain_type>::type
+last_next(const Type& object)
+{ 
+    //CL typedef typename interval_traits<Type>::domain_type domain_type;
+    return upper(object); // NOTE: last_next is implemented to avoid calling pred(object)
+}                         // For unsigned integral types this may cause underflow.
+
+template<class Type>
+inline typename enable_if<is_discrete_interval<Type>, 
+                          typename interval_traits<Type>::domain_type>::type
+last_next(const Type& object)
+{ 
+    return is_right_closed(object.bounds()) ? 
+               domain_next<Type>(upper(object)): 
+                                 upper(object) ;
+}
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, 
+                   typename Type::bounded_domain_type>::type
+bounded_lower(const Type& object)
+{ 
+    return typename 
+        Type::bounded_domain_type(lower(object), object.bounds().left()); 
+}
+
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, 
+                   typename Type::bounded_domain_type>::type
+reverse_bounded_lower(const Type& object)
+{ 
+    return typename 
+        Type::bounded_domain_type(lower(object), 
+                                  object.bounds().reverse_left()); 
+}
+
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, 
+                   typename Type::bounded_domain_type>::type
+bounded_upper(const Type& object)
+{ 
+    return typename 
+        Type::bounded_domain_type(upper(object), 
+                                  object.bounds().right()); 
+}
+
+template<class Type>
+typename enable_if<has_dynamic_bounds<Type>, 
+                   typename Type::bounded_domain_type>::type
+reverse_bounded_upper(const Type& object)
+{ 
+    return typename 
+        Type::bounded_domain_type(upper(object), 
+                                  object.bounds().reverse_right()); 
+}
+
+//- bounds ---------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<has_dynamic_bounds<Type>, interval_bounds>::type
+bounds(const Type& object)
+{
+    return object.bounds();
+}
+
+template<class Type>
+inline typename enable_if<has_static_bounds<Type>, interval_bounds>::type
+bounds(const Type&)
+{
+    return interval_bounds(interval_bound_type<Type>::value);
+}
+
+
+//==============================================================================
+//= Emptieness
+//==============================================================================
+/** Is the interval empty? */
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
+is_empty(const Type& object)
+{ 
+    return domain_less_equal<Type>(upper(object), lower(object)); 
+}
+
+template<class Type>
+typename boost::enable_if<is_static_closed<Type>, bool>::type
+is_empty(const Type& object)
+{ 
+    return domain_less<Type>(upper(object), lower(object)); 
+}
+
+template<class Type>
+typename boost::enable_if<is_static_open<Type>, bool>::type
+is_empty(const Type& object)
+{ 
+    return domain_less_equal<Type>(upper(object),                   lower(object) ) 
+        || domain_less_equal<Type>(upper(object), domain_next<Type>(lower(object)));
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+is_empty(const Type& object)
+{ 
+    if(object.bounds() == interval_bounds::closed())
+        return domain_less<Type>(upper(object), lower(object)); 
+    else if(object.bounds() == interval_bounds::open())
+        return domain_less_equal<Type>(upper(object),                   lower(object) )
+            || domain_less_equal<Type>(upper(object), domain_next<Type>(lower(object)));
+    else
+        return domain_less_equal<Type>(upper(object), lower(object)); 
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+is_empty(const Type& object)
+{
+    return     domain_less<Type>(upper(object), lower(object))
+        || (   domain_equal<Type>(upper(object), lower(object))
+            && object.bounds() != interval_bounds::closed()    );
+}
+
+//==============================================================================
+//= Orderings, containedness (non empty)
+//==============================================================================
+namespace non_empty
+{
+
+    template<class Type>
+    inline typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    { 
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return domain_less_equal<Type>(upper(left), lower(right)); 
+    }
+
+    template<class Type>
+    inline typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    { 
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return domain_less<Type>(last(left), first(right)); 
+    }
+
+    template<class Type>
+    inline typename boost::
+    enable_if<has_symmetric_bounds<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    { 
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return domain_less<Type>(last(left), first(right)); 
+    }
+
+    template<class Type>
+    inline typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+    exclusive_less(const Type& left, const Type& right)
+    { 
+        BOOST_ASSERT(!(icl::is_empty(left) || icl::is_empty(right)));
+        return     domain_less <Type>(upper(left), lower(right))
+            || (   domain_equal<Type>(upper(left), lower(right))
+                && inner_bounds(left,right) != interval_bounds::open() );
+    }
+
+    template<class Type>
+    inline typename boost::enable_if<is_interval<Type>, bool>::type
+    contains(const Type& super, const Type& sub)
+    { 
+        return lower_less_equal(super,sub) && upper_less_equal(sub,super);
+    }
+
+
+} //namespace non_empty
+
+
+//- contains -------------------------------------------------------------------
+template<class Type>
+inline typename boost::enable_if<is_interval<Type>, bool>::type
+contains(const Type& super, const Type& sub)
+{ 
+    return icl::is_empty(sub) || non_empty::contains(super, sub);
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_static<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return domain_less_equal<Type>(icl::first(super), element                  ) 
+        && domain_less_equal<Type>(                   element, icl::last(super));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_left_open<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return domain_less      <Type>(icl::lower(super), element                   ) 
+        && domain_less_equal<Type>(                   element, icl::upper(super));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_right_open<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return domain_less_equal<Type>(icl::lower(super), element                   ) 
+        && domain_less      <Type>(                   element, icl::upper(super));
+}
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, bool>::type
+contains(const Type& super, const typename interval_traits<Type>::domain_type& element)
+{
+    return
+        (is_left_closed(super.bounds())  
+            ? domain_less_equal<Type>(lower(super), element) 
+            :       domain_less<Type>(lower(super), element))
+    &&
+        (is_right_closed(super.bounds()) 
+            ? domain_less_equal<Type>(element, upper(super)) 
+            :       domain_less<Type>(element, upper(super)));
+}
+
+//- within ---------------------------------------------------------------------
+template<class Type>
+inline typename boost::enable_if<is_interval<Type>, bool>::type
+within(const Type& sub, const Type& super)
+{ 
+    return contains(super,sub);
+}
+
+
+//==============================================================================
+//= Equivalences and Orderings
+//==============================================================================
+//- exclusive_less -------------------------------------------------------------
+/** Maximal element of <tt>left</tt> is less than the minimal element of 
+    <tt>right</tt> */
+template<class Type>
+inline typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
+exclusive_less(const Type& left, const Type& right)
+{ 
+    return icl::is_empty(left) || icl::is_empty(right)
+        || domain_less_equal<Type>(upper(left), lower(right)); 
+}
+
+template<class Type>
+inline typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+exclusive_less(const Type& left, const Type& right)
+{ 
+    return icl::is_empty(left) || icl::is_empty(right)
+        || domain_less<Type>(last(left), first(right)); 
+}
+
+template<class Type>
+inline typename boost::
+enable_if<has_symmetric_bounds<Type>, bool>::type
+exclusive_less(const Type& left, const Type& right)
+{ 
+    return icl::is_empty(left) || icl::is_empty(right)
+        || domain_less<Type>(last(left), first(right)); 
+}
+
+template<class Type>
+inline typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+exclusive_less(const Type& left, const Type& right)
+{ 
+    return     icl::is_empty(left) || icl::is_empty(right)
+        ||     domain_less<Type>(upper(left), lower(right))
+        || (   domain_equal<Type>(upper(left), lower(right))
+            && inner_bounds(left,right) != interval_bounds::open() );
+}
+
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<has_static_bounds<Type>, bool>::type
+lower_less(const Type& left, const Type& right)
+{
+    return domain_less<Type>(lower(left), lower(right));
+}
+    
+template<class Type>
+typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+lower_less(const Type& left, const Type& right)
+{
+    return domain_less<Type>(first(left), first(right));
+}
+    
+template<class Type>
+typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+lower_less(const Type& left, const Type& right)
+{
+    if(left_bounds(left,right) == interval_bounds::right_open())  //'[(' == 10
+        return domain_less_equal<Type>(lower(left), lower(right));
+    else 
+        return domain_less<Type>(lower(left), lower(right));
+}
+    
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<has_static_bounds<Type>, bool>::type
+upper_less(const Type& left, const Type& right)
+{
+    return domain_less<Type>(upper(left), upper(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+upper_less(const Type& left, const Type& right)
+{
+    return domain_less<Type>(last(left), last(right));
+}
+    
+template<class Type>
+typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+upper_less(const Type& left, const Type& right)
+{
+    if(right_bounds(left,right) == interval_bounds::left_open())
+        return domain_less_equal<Type>(upper(left), upper(right));
+    else
+        return domain_less<Type>(upper(left), upper(right));
+}
+    
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, 
+                          typename Type::bounded_domain_type   >::type
+lower_min(const Type& left, const Type& right)
+{
+    return lower_less(left, right) ? bounded_lower(left) : bounded_lower(right);
+}
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, 
+                          typename Type::bounded_domain_type   >::type
+lower_max(const Type& left, const Type& right)
+{
+    return lower_less(left, right) ? bounded_lower(right) : bounded_lower(left);
+}
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, 
+                          typename Type::bounded_domain_type   >::type
+upper_max(const Type& left, const Type& right)
+{
+    return upper_less(left, right) ? bounded_upper(right) : bounded_upper(left);
+}
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, 
+                          typename Type::bounded_domain_type   >::type
+upper_min(const Type& left, const Type& right)
+{
+    return upper_less(left, right) ? bounded_upper(left) : bounded_upper(right);
+}
+
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
+lower_equal(const Type& left, const Type& right)
+{
+    return domain_equal<Type>(lower(left), lower(right));
+}
+
+template<class Type>
+typename boost::enable_if<has_symmetric_bounds<Type>, bool>::type
+lower_equal(const Type& left, const Type& right)
+{
+    return domain_equal<Type>(first(left), first(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+lower_equal(const Type& left, const Type& right)
+{
+    return domain_equal<Type>(first(left), first(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+lower_equal(const Type& left, const Type& right)
+{
+    return (left.bounds().left()==right.bounds().left())
+        && domain_equal<Type>(lower(left), lower(right));
+}
+
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
+upper_equal(const Type& left, const Type& right)
+{
+    return domain_equal<Type>(upper(left), upper(right));
+}
+
+template<class Type>
+typename boost::enable_if<has_symmetric_bounds<Type>, bool>::type
+upper_equal(const Type& left, const Type& right)
+{
+    return domain_equal<Type>(last(left), last(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+upper_equal(const Type& left, const Type& right)
+{
+    return domain_equal<Type>(last(left), last(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+upper_equal(const Type& left, const Type& right)
+{
+    return (left.bounds().right()==right.bounds().right())
+        && domain_equal<Type>(upper(left), upper(right));
+}
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+lower_less_equal(const Type& left, const Type& right)
+{
+    return lower_less(left,right) || lower_equal(left,right);
+}
+
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+upper_less_equal(const Type& left, const Type& right)
+{
+    return upper_less(left,right) || upper_equal(left,right);
+}
+
+
+//- operator == ----------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+operator == (const Type& left, const Type& right)
+{
+    return (icl::is_empty(left) && icl::is_empty(right)) 
+        || (lower_equal(left,right) && upper_equal(left,right));
+}
+
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+operator != (const Type& left, const Type& right)
+{
+    return !(left == right);
+}
+
+//- operator < -----------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+operator < (const Type& left, const Type& right)
+{
+    if(icl::is_empty(left)) 
+        return !icl::is_empty(right);
+    else 
+        return lower_less(left,right) 
+            || (lower_equal(left,right) && upper_less(left,right)); 
+}
+
+template<class Type>
+inline typename boost::enable_if<is_interval<Type>, bool>::type
+operator > (const Type& left, const Type& right)
+{
+    return right < left;
+}
+
+
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, bool>::type
+touches(const Type& left, const Type& right)
+{ 
+    return domain_equal<Type>(upper(left), lower(right)); 
+}
+
+template<class Type>
+typename boost::enable_if<has_symmetric_bounds<Type>, bool>::type
+touches(const Type& left, const Type& right)
+{ 
+    return domain_equal<Type>(last_next(left), first(right)); 
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_interval<Type>, bool>::type
+touches(const Type& left, const Type& right)
+{
+    return domain_equal<Type>(domain_next<Type>(last(left)), first(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_interval<Type>, bool>::type
+touches(const Type& left, const Type& right)
+{
+    return is_complementary(inner_bounds(left,right))
+        && domain_equal<Type>(upper(left), lower(right));
+}
+
+
+//==============================================================================
+//= Size
+//==============================================================================
+//- cardinality ----------------------------------------------------------------
+
+template<class Type>
+typename boost::enable_if<is_continuous_interval<Type>, 
+    typename size_type_of<interval_traits<Type> >::type>::type
+cardinality(const Type& object)
+{
+    typedef typename size_type_of<interval_traits<Type> >::type SizeT;
+    if(icl::is_empty(object))
+        return icl::identity_element<SizeT>::value();
+    else if(   object.bounds() == interval_bounds::closed() 
+            && domain_equal<Type>(lower(object), upper(object)))
+        return icl::unit_element<SizeT>::value();
+    else 
+        return icl::infinity<SizeT>::value();
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_interval<Type>, 
+    typename size_type_of<interval_traits<Type> >::type>::type
+cardinality(const Type& object)
+{
+    typedef typename size_type_of<interval_traits<Type> >::type SizeT;
+    return icl::is_empty(object) ? identity_element<SizeT>::value()
+                                 : static_cast<SizeT>(last_next(object) - first(object));
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_asymmetric<Type>, 
+    typename size_type_of<interval_traits<Type> >::type>::type
+cardinality(const Type& object)
+{
+    typedef typename size_type_of<interval_traits<Type> >::type SizeT;
+    if(icl::is_empty(object))
+        return icl::identity_element<SizeT>::value();
+    else 
+        return icl::infinity<SizeT>::value();
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_asymmetric<Type>, 
+    typename size_type_of<interval_traits<Type> >::type>::type
+cardinality(const Type& object)
+{
+    typedef typename size_type_of<interval_traits<Type> >::type SizeT;
+    return icl::is_empty(object) ? identity_element<SizeT>::value()
+                                 : static_cast<SizeT>(last_next(object) - first(object));
+}
+
+template<class Type>
+typename boost::enable_if<has_symmetric_bounds<Type>, 
+    typename size_type_of<interval_traits<Type> >::type>::type
+cardinality(const Type& object)
+{
+    typedef typename size_type_of<interval_traits<Type> >::type SizeT;
+    return icl::is_empty(object) ? identity_element<SizeT>::value()
+                                 : static_cast<SizeT>(last_next(object) - first(object));
+}
+
+
+
+//- size -----------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_interval<Type>, 
+    typename size_type_of<interval_traits<Type> >::type>::type
+size(const Type& object)
+{
+    return cardinality(object);
+}
+
+//- length ---------------------------------------------------------------------
+template<class Type>
+inline typename boost::enable_if<is_continuous_interval<Type>, 
+    typename difference_type_of<interval_traits<Type> >::type>::type
+length(const Type& object)
+{
+    typedef typename difference_type_of<interval_traits<Type> >::type DiffT;
+    return icl::is_empty(object) ? identity_element<DiffT>::value()
+                                 : upper(object) - lower(object);
+}
+
+template<class Type>
+inline typename boost::enable_if<is_discrete_interval<Type>, 
+    typename difference_type_of<interval_traits<Type> >::type>::type
+length(const Type& object)
+{
+    typedef typename difference_type_of<interval_traits<Type> >::type DiffT;
+    return icl::is_empty(object) ? identity_element<DiffT>::value()
+                                 : last_next(object) - first(object);
+}
+
+template<class Type>
+typename boost::enable_if<is_continuous_asymmetric<Type>, 
+    typename difference_type_of<interval_traits<Type> >::type>::type
+length(const Type& object)
+{
+    typedef typename difference_type_of<interval_traits<Type> >::type DiffT;
+    return icl::is_empty(object) ? identity_element<DiffT>::value()
+                                 : upper(object) - lower(object);
+}
+
+template<class Type>
+inline typename boost::enable_if<is_discrete_static<Type>, 
+    typename difference_type_of<interval_traits<Type> >::type>::type
+length(const Type& object)
+{
+    typedef typename difference_type_of<interval_traits<Type> >::type DiffT;
+    return icl::is_empty(object) ? identity_element<DiffT>::value()
+                                 : last_next(object) - first(object);
+}
+
+//- iterative_size -------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_interval<Type>, 
+    typename size_type_of<interval_traits<Type> >::type>::type
+iterative_size(const Type&)
+{
+    return 2;
+}
+
+
+//==============================================================================
+//= Addition
+//==============================================================================
+//- hull -----------------------------------------------------------------------
+/** \c hull returns the smallest interval containing \c left and \c right. */
+template<class Type>
+typename boost::enable_if<has_static_bounds<Type>, Type>::type
+hull(Type left, const Type& right)
+{
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+
+    if(icl::is_empty(right))
+        return left;
+    else if(icl::is_empty(left))
+        return right;
+
+    return 
+        construct<Type>
+        (
+            (std::min)(lower(left), lower(right), domain_compare()), 
+            (std::max)(upper(left), upper(right), domain_compare())
+        );
+}
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, Type>::type
+hull(Type left, const Type& right)
+{
+    if(icl::is_empty(right))
+        return left;
+    else if(icl::is_empty(left))
+        return right;
+
+    return  dynamic_interval_traits<Type>::construct_bounded
+            (
+                lower_min(left, right), 
+                upper_max(left, right)
+            );
+}
+
+//==============================================================================
+//= Subtraction
+//==============================================================================
+//- left_subtract --------------------------------------------------------------
+/** subtract \c left_minuend from the \c right interval on it's left side. 
+    Return the difference: The part of \c right right of \c left_minuend.
+\code
+right_over = right - left_minuend; //on the left.
+...      d) : right
+... c)      : left_minuend
+     [c  d) : right_over
+\endcode
+*/
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, Type>::type
+left_subtract(Type right, const Type& left_minuend)
+{
+    if(exclusive_less(left_minuend, right))
+        return right; 
+
+    return construct<Type>(upper(left_minuend), upper(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_static_closed<Type>, Type>::type
+left_subtract(Type right, const Type& left_minuend)
+{
+    if(exclusive_less(left_minuend, right))
+        return right; 
+    else if(upper_less_equal(right, left_minuend))
+        return identity_element<Type>::value();
+
+    return construct<Type>(domain_next<Type>(upper(left_minuend)), upper(right));
+}
+
+template<class Type>
+typename boost::enable_if<is_static_open<Type>, Type>::type
+left_subtract(Type right, const Type& left_minuend)
+{
+    if(exclusive_less(left_minuend, right))
+        return right; 
+
+    return construct<Type>(domain_prior<Type>(upper(left_minuend)), upper(right));
+}
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, Type>::type
+left_subtract(Type right, const Type& left_minuend)
+{
+    if(exclusive_less(left_minuend, right))
+        return right; 
+    return  dynamic_interval_traits<Type>::construct_bounded
+            ( reverse_bounded_upper(left_minuend), bounded_upper(right) );
+}
+
+
+//- right_subtract -------------------------------------------------------------
+/** subtract \c right_minuend from the \c left interval on it's right side. 
+    Return the difference: The part of \c left left of \c right_minuend.
+\code
+left_over = left - right_minuend; //on the right side.
+[a      ...  : left
+     [b ...  : right_minuend
+[a  b)       : left_over
+\endcode
+*/
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, Type>::type
+right_subtract(Type left, const Type& right_minuend)
+{
+    if(exclusive_less(left, right_minuend))
+        return left; 
+    return construct<Type>(lower(left), lower(right_minuend));
+}
+
+template<class Type>
+typename boost::enable_if<is_static_closed<Type>, Type>::type
+right_subtract(Type left, const Type& right_minuend)
+{
+    if(exclusive_less(left, right_minuend))
+        return left;
+    else if(lower_less_equal(right_minuend, left))
+        return identity_element<Type>::value();
+
+    return construct<Type>(lower(left), domain_prior<Type>(lower(right_minuend)));
+}
+
+template<class Type>
+typename boost::enable_if<is_static_open<Type>, Type>::type
+right_subtract(Type left, const Type& right_minuend)
+{
+    if(exclusive_less(left, right_minuend))
+        return left;
+
+    return construct<Type>(lower(left), domain_next<Type>(lower(right_minuend)));
+}
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, Type>::type
+right_subtract(Type left, const Type& right_minuend)
+{
+    if(exclusive_less(left, right_minuend))
+        return left; 
+
+    return  dynamic_interval_traits<Type>::construct_bounded
+            ( bounded_lower(left), reverse_bounded_lower(right_minuend) );
+}
+
+//==============================================================================
+//= Intersection
+//==============================================================================
+//- operator & -----------------------------------------------------------------
+/** Returns the intersection of \c left and \c right interval. */
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, Type>::type
+operator & (Type left, const Type& right)
+{
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return identity_element<Type>::value();
+    else
+        return
+        construct<Type>
+        (
+            (std::max)(icl::lower(left), icl::lower(right), domain_compare()),
+            (std::min)(icl::upper(left), icl::upper(right), domain_compare())
+        );
+}
+
+template<class Type>
+typename boost::enable_if<has_symmetric_bounds<Type>, Type>::type
+operator & (Type left, const Type& right)
+{
+    typedef typename interval_traits<Type>::domain_compare domain_compare;
+
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return identity_element<Type>::value();
+    else
+        return
+        construct<Type>
+        (
+            (std::max)(icl::lower(left), icl::lower(right), domain_compare()),
+            (std::min)(icl::upper(left), icl::upper(right), domain_compare())
+        );
+}
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, Type>::type
+operator & (Type left, const Type& right)
+{
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return identity_element<Type>::value();
+    else 
+        return  dynamic_interval_traits<Type>::construct_bounded
+                (
+                    lower_max(left, right), 
+                    upper_min(left, right) 
+                );
+}
+
+
+//- intersects -----------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+intersects(const Type& left, const Type& right)
+{ 
+    return !(   icl::is_empty(left) || icl::is_empty(right) 
+             || exclusive_less(left,right) || exclusive_less(right,left)); 
+}
+
+//- disjoint -------------------------------------------------------------------
+template<class Type>
+typename boost::enable_if<is_interval<Type>, bool>::type
+disjoint(const Type& left, const Type& right)
+{ 
+    return icl::is_empty(left) || icl::is_empty(right) 
+        || exclusive_less(left,right) || exclusive_less(right,left); 
+}
+
+//==============================================================================
+//= Complement
+//==============================================================================
+
+template<class Type>
+typename boost::enable_if<is_asymmetric_interval<Type>, Type>::type
+inner_complement(const Type& left, const Type& right)
+{
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return  identity_element<Type>::value();
+    else if(exclusive_less(left, right))
+        return construct<Type>(upper(left), lower(right));
+    else if(exclusive_less(right, left))
+        return construct<Type>(upper(right), lower(left));
+    else
+        return identity_element<Type>::value();
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_static_closed<Type>, Type>::type
+inner_complement(const Type& left, const Type& right)
+{
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return  identity_element<Type>::value();
+    else if(exclusive_less(left, right))
+        return construct<Type>(domain_next<Type>(upper(left)), domain_prior<Type>(lower(right)));
+    else if(exclusive_less(right, left))
+        return construct<Type>(domain_next<Type>(upper(right)), domain_prior<Type>(lower(left)));
+    else
+        return identity_element<Type>::value();
+}
+
+template<class Type>
+typename boost::enable_if<is_discrete_static_open<Type>, Type>::type
+inner_complement(const Type& left, const Type& right)
+{
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return  identity_element<Type>::value();
+    else if(exclusive_less(left, right))
+        return construct<Type>(last(left), first(right));
+    else if(exclusive_less(right, left))
+        return construct<Type>(last(right), first(left));
+    else
+        return identity_element<Type>::value();
+}
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, Type>::type
+inner_complement(const Type& left, const Type& right)
+{
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return  identity_element<Type>::value();
+    else if(exclusive_less(left, right))
+        return right_subtract(left_subtract(hull(left, right), left), right);
+    else if(exclusive_less(right, left))
+        return right_subtract(left_subtract(hull(right, left), right), left);
+    else
+        return identity_element<Type>::value();
+}
+
+template<class Type>
+inline typename boost::enable_if<is_interval<Type>, Type>::type
+between(const Type& left, const Type& right)
+{ 
+    return inner_complement(left, right);
+}
+
+
+
+//==============================================================================
+//= Distance
+//==============================================================================
+template<class Type>
+typename boost::
+enable_if< mpl::and_< is_interval<Type>
+                    , has_difference<typename interval_traits<Type>::domain_type>
+                    , is_discrete<typename interval_traits<Type>::domain_type>        
+                    >
+         , typename difference_type_of<interval_traits<Type> >::type>::type
+distance(const Type& x1, const Type& x2)
+{
+    typedef typename difference_type_of<interval_traits<Type> >::type difference_type;
+
+    if(icl::is_empty(x1) || icl::is_empty(x2))
+        return icl::identity_element<difference_type>::value();
+    else if(domain_less<Type>(last(x1), first(x2)))
+        return static_cast<difference_type>(icl::pred(first(x2) - last(x1)));
+    else if(domain_less<Type>(last(x2), first(x1)))
+        return static_cast<difference_type>(icl::pred(first(x1) - last(x2)));
+    else
+        return icl::identity_element<difference_type>::value();
+}
+
+template<class Type>
+typename boost::
+enable_if< mpl::and_< is_interval<Type>
+                    , has_difference<typename interval_traits<Type>::domain_type>
+                    , is_continuous<typename interval_traits<Type>::domain_type>        
+                    >
+         , typename difference_type_of<interval_traits<Type> >::type>::type
+distance(const Type& x1, const Type& x2)
+{
+    typedef typename difference_type_of<interval_traits<Type> >::type DiffT;
+
+    if(icl::is_empty(x1) || icl::is_empty(x2))
+        return icl::identity_element<DiffT>::value();
+    else if(domain_less<Type>(upper(x1), lower(x2)))
+        return lower(x2) - upper(x1);
+    else if(domain_less<Type>(upper(x2), lower(x1)))
+        return lower(x1) - upper(x2);
+    else
+        return icl::identity_element<DiffT>::value();
+}
+
+//==============================================================================
+//= Streaming, representation
+//==============================================================================
+template<class Type>
+typename boost::
+    enable_if< mpl::or_< is_static_left_open<Type>
+                       , is_static_open<Type>    >, std::string>::type
+left_bracket(const Type&) { return "("; }
+
+template<class Type>
+typename boost::
+    enable_if< mpl::or_< is_static_right_open<Type>
+                       , is_static_closed<Type>   >, std::string>::type
+left_bracket(const Type&) { return "["; }
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, std::string>::type
+left_bracket(const Type& object) 
+{ 
+    return left_bracket(object.bounds()); 
+}
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename boost::
+    enable_if< mpl::or_< is_static_right_open<Type>
+                       , is_static_open<Type>     >, std::string>::type
+right_bracket(const Type&) { return ")"; }
+
+template<class Type>
+typename boost::
+    enable_if< mpl::or_< is_static_left_open<Type>
+                       , is_static_closed<Type>    >, std::string>::type
+right_bracket(const Type&) { return "]"; }
+
+template<class Type>
+typename boost::enable_if<has_dynamic_bounds<Type>, std::string>::type
+right_bracket(const Type& object) 
+{ 
+    return right_bracket(object.bounds()); 
+}
+
+//------------------------------------------------------------------------------
+template<class CharType, class CharTraits, class Type>
+typename boost::enable_if<is_interval<Type>, 
+                          std::basic_ostream<CharType, CharTraits> >::type&
+operator << (std::basic_ostream<CharType, CharTraits> &stream, Type const& object)
+{
+    if(boost::icl::is_empty(object))
+        return stream << left_bracket<Type>(object) << right_bracket<Type>(object); 
+    else
+        return stream << left_bracket<Type>(object) 
+                      << interval_traits<Type>::lower(object) 
+                      << "," 
+                      << interval_traits<Type>::upper(object) 
+                      << right_bracket<Type>(object) ;
+}
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/concept/interval_associator.hpp
+++ b/inst/include/boost/icl/concept/interval_associator.hpp
@@ -1,0 +1,1211 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_INTERVAL_ASSOCIATOR_HPP_JOFA_100920
+#define BOOST_ICL_CONCEPT_INTERVAL_ASSOCIATOR_HPP_JOFA_100920
+
+#include <boost/icl/type_traits/domain_type_of.hpp>
+#include <boost/icl/type_traits/interval_type_of.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/detail/set_algo.hpp>
+#include <boost/icl/detail/map_algo.hpp>
+#include <boost/icl/detail/interval_set_algo.hpp>
+#include <boost/icl/detail/interval_map_algo.hpp>
+#include <boost/icl/concept/interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= Containedness<IntervalSet|IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- bool within(c T&, c P&) T={Set,Map} P={e i b p S M}
+//------------------------------------------------------------------------------
+template<class SubT, class SuperT>
+typename enable_if<is_interval_container<SuperT>, bool>::type 
+within(const SubT& sub, const SuperT& super)
+{
+    return icl::contains(super, sub); 
+}
+
+//==============================================================================
+//= Equivalences and Orderings<IntervalSet|IntervalMap>
+//==============================================================================
+template<class Type>
+inline typename enable_if<is_interval_container<Type>, bool>::type
+operator == (const Type& left, const Type& right)
+{
+    return Set::lexicographical_equal(left, right);
+}
+
+template<class Type>
+inline typename enable_if<is_interval_container<Type>, bool>::type
+operator < (const Type& left, const Type& right)
+{
+    typedef typename Type::segment_compare segment_compare;
+    return std::lexicographical_compare(
+        left.begin(), left.end(), right.begin(), right.end(), 
+        segment_compare()
+        );
+}
+
+/** Returns true, if \c left and \c right contain the same elements. 
+    Complexity: linear. */
+template<class LeftT, class RightT>
+typename enable_if<is_intra_combinable<LeftT, RightT>, bool>::type
+is_element_equal(const LeftT& left, const RightT& right)
+{
+    return Interval_Set::is_element_equal(left, right);
+}
+
+/** Returns true, if \c left is lexicographically less than \c right. 
+    Intervals are interpreted as sequence of elements.
+    Complexity: linear. */
+template<class LeftT, class RightT>
+typename enable_if<is_intra_combinable<LeftT, RightT>, bool>::type
+is_element_less(const LeftT& left, const RightT& right)
+{
+    return Interval_Set::is_element_less(left, right);
+}
+
+/** Returns true, if \c left is lexicographically greater than \c right. 
+    Intervals are interpreted as sequence of elements.
+    Complexity: linear. */
+template<class LeftT, class RightT>
+typename enable_if<is_intra_combinable<LeftT, RightT>, bool>::type
+is_element_greater(const LeftT& left, const RightT& right)
+{
+    return Interval_Set::is_element_greater(left, right);
+}
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+typename enable_if<is_inter_combinable<LeftT, RightT>, int>::type
+inclusion_compare(const LeftT& left, const RightT& right)
+{
+    return Interval_Set::subset_compare(left, right, 
+                                        left.begin(), left.end(),
+                                        right.begin(), right.end());
+}
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+typename enable_if< is_concept_compatible<is_interval_map, LeftT, RightT>,
+                    bool >::type
+is_distinct_equal(const LeftT& left, const RightT& right)
+{
+    return Map::lexicographical_distinct_equal(left, right);
+}
+
+//==============================================================================
+//= Size<IntervalSet|IntervalMap>
+//==============================================================================
+template<class Type> 
+typename enable_if<is_interval_container<Type>, std::size_t>::type
+iterative_size(const Type& object)
+{ 
+    return object.iterative_size(); 
+}
+
+template<class Type>
+typename enable_if
+< mpl::and_< is_interval_container<Type>
+           , is_discrete<typename Type::domain_type> >
+, typename Type::size_type
+>::type
+cardinality(const Type& object)
+{
+    typedef typename Type::size_type size_type;
+    //CL typedef typename Type::interval_type interval_type;
+
+    size_type size = identity_element<size_type>::value();
+    ICL_const_FORALL(typename Type, it, object)
+        size += icl::cardinality(key_value<Type>(it));
+    return size;
+
+}
+
+template<class Type>
+typename enable_if
+< mpl::and_< is_interval_container<Type>
+           , mpl::not_<is_discrete<typename Type::domain_type> > >
+, typename Type::size_type
+>::type
+cardinality(const Type& object)
+{
+    typedef typename Type::size_type size_type;
+    //CL typedef typename Type::interval_type interval_type;
+
+    size_type size = identity_element<size_type>::value();
+    size_type interval_size;
+    ICL_const_FORALL(typename Type, it, object)
+    {
+        interval_size = icl::cardinality(key_value<Type>(it));
+        if(interval_size == icl::infinity<size_type>::value())
+            return interval_size;
+        else
+            size += interval_size;
+    }
+    return size;
+}
+
+template<class Type>
+inline typename enable_if<is_interval_container<Type>, typename Type::size_type>::type
+size(const Type& object)
+{
+    return icl::cardinality(object);
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, typename Type::difference_type>::type
+length(const Type& object)
+{
+    typedef typename Type::difference_type difference_type;
+    typedef typename Type::const_iterator  const_iterator;
+    difference_type length = identity_element<difference_type>::value();
+    const_iterator it_ = object.begin();
+
+    while(it_ != object.end())
+        length += icl::length(key_value<Type>(it_++));
+    return length;
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, std::size_t>::type
+interval_count(const Type& object)
+{
+    return icl::iterative_size(object);
+}
+
+
+template<class Type>
+typename enable_if< is_interval_container<Type> 
+                  , typename Type::difference_type >::type
+distance(const Type& object)
+{
+    typedef typename Type::difference_type DiffT;
+    typedef typename Type::const_iterator const_iterator;
+    const_iterator it_ = object.begin(), pred_;
+    DiffT dist = identity_element<DiffT>::value();
+
+    if(it_ != object.end())
+        pred_ = it_++;
+
+    while(it_ != object.end())
+        dist += icl::distance(key_value<Type>(pred_++), key_value<Type>(it_++));
+    
+    return dist;
+}
+
+//==============================================================================
+//= Range<IntervalSet|IntervalMap>
+//==============================================================================
+template<class Type>
+typename enable_if<is_interval_container<Type>, 
+                   typename Type::interval_type>::type
+hull(const Type& object)
+{
+    return 
+        icl::is_empty(object) 
+            ? identity_element<typename Type::interval_type>::value()
+            : icl::hull( key_value<Type>(object.begin()), 
+                         key_value<Type>(object.rbegin()) );
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, 
+                   typename domain_type_of<Type>::type>::type
+lower(const Type& object)
+{
+    typedef typename domain_type_of<Type>::type DomainT;
+    return 
+        icl::is_empty(object) 
+            ? unit_element<DomainT>::value()
+            : icl::lower( key_value<Type>(object.begin()) );
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, 
+                   typename domain_type_of<Type>::type>::type
+upper(const Type& object)
+{
+    typedef typename domain_type_of<Type>::type DomainT;
+    return 
+        icl::is_empty(object) 
+            ? identity_element<DomainT>::value()
+            : icl::upper( key_value<Type>(object.rbegin()) );
+}
+
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if
+< mpl::and_< is_interval_container<Type>
+           , is_discrete<typename domain_type_of<Type>::type> > 
+, typename domain_type_of<Type>::type>::type
+first(const Type& object)
+{
+    typedef typename domain_type_of<Type>::type DomainT;
+    return 
+        icl::is_empty(object) 
+            ? unit_element<DomainT>::value()
+            : icl::first( key_value<Type>(object.begin()) );
+}
+
+template<class Type>
+typename enable_if
+< mpl::and_< is_interval_container<Type>
+           , is_discrete<typename domain_type_of<Type>::type> >
+, typename domain_type_of<Type>::type>::type
+last(const Type& object)
+{
+    typedef typename domain_type_of<Type>::type DomainT;
+    return 
+        icl::is_empty(object) 
+            ? identity_element<DomainT>::value()
+            : icl::last( key_value<Type>(object.rbegin()) );
+}
+
+
+//==============================================================================
+//= Addition<IntervalSet|IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& op +=(T&, c P&) T:{S}|{M} P:{e i}|{b p}
+//------------------------------------------------------------------------------
+/* \par \b Requires: \c OperandT is an addable derivative type of \c Type. 
+    \b Effects: \c operand is added to \c object.
+    \par \b Returns: A reference to \c object.
+    \b Complexity:
+\code
+                  \ OperandT:                    
+                   \         element     segment 
+Type:
+       interval container    O(log n)     O(n)   
+
+             interval_set               amortized
+    spearate_interval_set                O(log n) 
+
+n = object.interval_count()
+\endcode
+
+For the addition of \b elements or \b segments
+complexity is \b logarithmic or \b linear respectively.
+For \c interval_sets and \c separate_interval_sets addition of segments
+is \b amortized \b logarithmic.
+*/
+template<class Type, class OperandT>
+typename enable_if<is_intra_derivative<Type, OperandT>, Type>::type&
+operator += (Type& object, const OperandT& operand)
+{ 
+    return icl::add(object, operand); 
+}
+
+
+//------------------------------------------------------------------------------
+//- T& op +=(T&, c P&) T:{S}|{M} P:{S'}|{M'}
+//------------------------------------------------------------------------------
+/** \par \b Requires: \c OperandT is an interval container addable to \c Type. 
+    \b Effects: \c operand is added to \c object.
+    \par \b Returns: A reference to \c object.
+    \b Complexity: loglinear */
+template<class Type, class OperandT>
+typename enable_if<is_intra_combinable<Type, OperandT>, Type>::type&
+operator += (Type& object, const OperandT& operand)
+{
+    typename Type::iterator prior_ = object.end();
+    ICL_const_FORALL(typename OperandT, elem_, operand) 
+        prior_ = icl::add(object, prior_, *elem_); 
+
+    return object; 
+}
+
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op + (T, c P&) T:{S}|{M} P:{e i S}|{b p M}
+//------------------------------------------------------------------------------
+/** \par \b Requires: \c object and \c operand are addable.
+    \b Effects: \c operand is added to \c object.
+    \par \b Efficieny: There is one additional copy of 
+    \c Type \c object compared to inplace \c operator \c += */
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator + (Type object, const OperandT& operand)
+{
+    return object += operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator + (const Type& object, const OperandT& operand)
+{
+    Type temp = object;
+    return boost::move(temp += operand); 
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator + (Type&& object, const OperandT& operand)
+{
+    return boost::move(object += operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op + (c P&, T) T:{S}|{M} P:{e i S'}|{b p M'}
+//------------------------------------------------------------------------------
+/** \par \b Requires: \c object and \c operand are addable.
+    \b Effects: \c operand is added to \c object.
+    \par \b Efficieny: There is one additional copy of 
+    \c Type \c object compared to inplace \c operator \c += */
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator + (const OperandT& operand, Type object)
+{
+    return object += operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator + (const OperandT& operand, const Type& object)
+{
+    Type temp = object;
+    return boost::move(temp += operand);
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator + (const OperandT& operand, Type&& object)
+{
+    return boost::move(object += operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op + (T, c P&) T:{S}|{M} P:{S}|{M}
+//------------------------------------------------------------------------------
+/** \par \b Requires: \c object and \c operand are addable.
+    \b Effects: \c operand is added to \c object.
+    \par \b Efficieny: There is one additional copy of 
+    \c Type \c object compared to inplace \c operator \c += */
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator + (Type object, const Type& operand)
+{
+    return object += operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator + (const Type& object, const Type& operand)
+{
+    Type temp = object;
+    return boost::move(temp += operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator + (Type&& object, const Type& operand)
+{
+    return boost::move(object += operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator + (const Type& operand, Type&& object)
+{
+    return boost::move(object += operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator + (Type&& object, Type&& operand)
+{
+    return boost::move(object += operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+//------------------------------------------------------------------------------
+//- Addition |=, | 
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+//- T& op |=(c P&) T:{S}|{M} P:{e i}|{b p}
+//------------------------------------------------------------------------------
+/** \par \b Requires: Types \c Type and \c OperandT are addable.
+    \par \b Effects: \c operand is added to \c object.
+    \par \b Returns: A reference to \c object.
+    \b Complexity:
+\code
+                  \ OperandT:                      interval
+                   \         element     segment   container
+Type:
+       interval container    O(log n)     O(n)     O(m log(n+m))
+
+             interval_set               amortized
+    spearate_interval_set                O(log n) 
+
+n = object.interval_count()
+m = operand.interval_count()
+\endcode
+
+For the addition of \b elements, \b segments and \b interval \b containers
+complexity is \b logarithmic, \b linear and \b loglinear respectively.
+For \c interval_sets and \c separate_interval_sets addition of segments
+is \b amortized \b logarithmic.
+*/
+template<class Type, class OperandT>
+typename enable_if<is_right_intra_combinable<Type, OperandT>, Type>::type&
+operator |= (Type& object, const OperandT& operand)
+{ 
+    return object += operand; 
+}
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op | (T, c P&) T:{S}|{M} P:{e i S}|{b p M}
+//------------------------------------------------------------------------------
+/** \par \b Requires: \c object and \c operand are addable.
+    \b Effects: \c operand is added to \c object.
+    \par \b Efficieny: There is one additional copy of 
+    \c Type \c object compared to inplace \c operator \c |= */
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator | (Type object, const OperandT& operand)
+{
+    return object += operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator | (const Type& object, const OperandT& operand)
+{
+    Type temp = object;
+    return boost::move(temp += operand); 
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator | (Type&& object, const OperandT& operand)
+{
+    return boost::move(object += operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op | (T, c P&) T:{S}|{M} P:{S}|{M}
+//------------------------------------------------------------------------------
+/** \par \b Requires: \c object and \c operand are addable.
+    \b Effects: \c operand is added to \c object.
+    \par \b Efficieny: There is one additional copy of 
+    \c Type \c object compared to inplace \c operator \c |= */
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator | (const OperandT& operand, Type object)
+{
+    return object += operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator | (const OperandT& operand, const Type& object)
+{
+    Type temp = object;
+    return boost::move(temp += operand);
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator | (const OperandT& operand, Type&& object)
+{
+    return boost::move(object += operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op | (T, c P&) T:{S}|{M} P:{S}|{M}
+//------------------------------------------------------------------------------
+/** \par \b Requires: \c object and \c operand are addable.
+    \b Effects: \c operand is added to \c object.
+    \par \b Efficieny: There is one additional copy of 
+    \c Type \c object compared to inplace \c operator \c |= */
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator | (Type object, const Type& operand)
+{
+    return object += operand; 
+}
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator | (const Type& object, const Type& operand)
+{
+    Type temp = object;
+    return boost::move(temp += operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator | (Type&& object, const Type& operand)
+{
+    return boost::move(object += operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator | (const Type& operand, Type&& object)
+{
+    return boost::move(object += operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator | (Type&& object, Type&& operand)
+{
+    return boost::move(object += operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+
+//==============================================================================
+//= Insertion<IntervalSet|IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& insert(T&, c P&) T:{S}|{M} P:{S'}|{M'}
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_intra_combinable<Type, OperandT>, Type>::type&
+insert(Type& object, const OperandT& operand)
+{
+    typename Type::iterator prior_ = object.end();
+    ICL_const_FORALL(typename OperandT, elem_, operand) 
+        insert(object, prior_, *elem_); 
+
+    return object; 
+}
+
+//==============================================================================
+//= Erasure<IntervalSet|IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& erase(T&, c P&) T:{S}|{M} P:{S'}|{S' M'}
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<combines_right_to_interval_container<Type, OperandT>,
+                   Type>::type&
+erase(Type& object, const OperandT& operand)
+{
+    typedef typename OperandT::const_iterator const_iterator;
+
+    if(icl::is_empty(operand))
+        return object;
+
+    const_iterator common_lwb, common_upb;
+    if(!Set::common_range(common_lwb, common_upb, operand, object))
+        return object;
+
+    const_iterator it_ = common_lwb;
+    while(it_ != common_upb)
+        icl::erase(object, *it_++);
+
+    return object; 
+}
+
+//==============================================================================
+//= Subtraction<IntervalSet|IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& op -= (c P&) T:{M} P:{M'} 
+//------------------------------------------------------------------------------
+/** \par \b Requires: Types \c Type and \c OperandT are subtractable.
+    \par \b Effects: \c operand is subtracted from \c object.
+    \par \b Returns: A reference to \c object.
+    \b Complexity:
+\code
+                  \ OperandT:                      interval
+                   \         element    segment    container
+Type:
+       interval container    O(log n)     O(n)     O(m log(n+m))
+
+                                       amortized
+            interval_sets               O(log n) 
+
+n = object.interval_count()
+m = operand.interval_count()
+\endcode
+
+For the subtraction of \em elements, \b segments and \b interval \b containers
+complexity is \b logarithmic, \b linear and \b loglinear respectively.
+For interval sets subtraction of segments
+is \b amortized \b logarithmic.
+*/
+template<class Type, class OperandT>
+typename enable_if<is_concept_compatible<is_interval_map, Type, OperandT>, 
+                   Type>::type& 
+operator -=(Type& object, const OperandT& operand)
+{
+    ICL_const_FORALL(typename OperandT, elem_, operand) 
+        icl::subtract(object, *elem_);
+
+    return object; 
+}
+
+//------------------------------------------------------------------------------
+//- T& op -= (c P&) T:{S}|{M} P:{e i}|{b p} 
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_intra_derivative<Type, OperandT>, Type>::type&
+operator -= (Type& object, const OperandT& operand)
+{ 
+    return icl::subtract(object, operand); 
+}
+
+//------------------------------------------------------------------------------
+//- T& op -= (c P&) T:{M} P:{e i} 
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_cross_derivative<Type, OperandT>, Type>::type&
+operator -= (Type& object, const OperandT& operand)
+{ 
+    return icl::erase(object, operand); 
+}
+
+//------------------------------------------------------------------------------
+//- T& op -= (c P&) T:{S M} P:{S'}
+//------------------------------------------------------------------------------
+template<class Type, class IntervalSetT>
+typename enable_if<combines_right_to_interval_set<Type, IntervalSetT>,
+                   Type>::type&
+operator -= (Type& object, const IntervalSetT& operand)
+{
+    return erase(object, operand);
+}
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op - (T, c P&) T:{S}|{M} P:{e i S'}|{e i b p S' M'} 
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_right_inter_combinable<Type, OperandT>, Type>::type
+operator - (Type object, const OperandT& operand)
+{
+    return object -= operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_right_inter_combinable<Type, OperandT>, Type>::type
+operator - (const Type& object, const OperandT& operand)
+{
+    Type temp = object;
+    return boost::move(temp -= operand); 
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_right_inter_combinable<Type, OperandT>, Type>::type
+operator - (Type&& object, const OperandT& operand)
+{
+    return boost::move(object -= operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+//==============================================================================
+//= Intersection<IntervalSet|IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- void add_intersection(T&, c T&, c P&) T:{S M} P:{S'}
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<mpl::and_<is_interval_set<Type>, 
+                             combines_right_to_interval_set<Type, OperandT> >,
+                   void>::type
+add_intersection(Type& section, const Type& object, const OperandT& operand)
+{
+    typedef typename OperandT::const_iterator const_iterator;
+
+    if(operand.empty())
+        return;
+
+    const_iterator common_lwb, common_upb;
+    if(!Set::common_range(common_lwb, common_upb, operand, object))
+        return;
+
+    const_iterator it_ = common_lwb;
+    while(it_ != common_upb)
+        icl::add_intersection(section, object, key_value<OperandT>(it_++));
+}
+
+//------------------------------------------------------------------------------
+//- T& op &=(T&, c P&) T:{S}|{M} P:{e i S'}|{e i b p S' M'}
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_right_inter_combinable<Type, OperandT>, Type>::type&
+operator &= (Type& object, const OperandT& operand)
+{
+    Type intersection;
+    add_intersection(intersection, object, operand);
+    object.swap(intersection);
+    return object;
+}
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op & (T, c P&) T:{S}|{M} P:{e i S'}|{e i b p S' M'} S<S' M<M' <:coarser
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_binary_inter_combinable<Type, OperandT>, Type>::type
+operator & (Type object, const OperandT& operand)
+{
+    return object &= operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_inter_combinable<Type, OperandT>, Type>::type
+operator & (const Type& object, const OperandT& operand)
+{
+    Type temp = object;
+    return boost::move(temp &= operand); 
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_inter_combinable<Type, OperandT>, Type>::type
+operator & (Type&& object, const OperandT& operand)
+{
+    return boost::move(object &= operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op & (c P&, T) T:{S}|{M} P:{e i S'}|{e i b p S' M'} S<S' M<M' <:coarser
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_binary_inter_combinable<Type, OperandT>, Type>::type
+operator & (const OperandT& operand, Type object)
+{
+    return object &= operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_inter_combinable<Type, OperandT>, Type>::type
+operator & (const OperandT& operand, const Type& object)
+{
+    Type temp = object;
+    return boost::move(temp &= operand);
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_inter_combinable<Type, OperandT>, Type>::type
+operator & (const OperandT& operand, Type&& object)
+{
+    return boost::move(object &= operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op & (T, c T&) T:{S M}
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator & (Type object, const Type& operand)
+{
+    return object &= operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator & (const Type& object, const Type& operand)
+{
+    Type temp = object;
+    return boost::move(temp &= operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator & (Type&& object, const Type& operand)
+{
+    return boost::move(object &= operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator & (const Type& operand, Type&& object)
+{
+    return boost::move(object &= operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator & (Type&& object, Type&& operand)
+{
+    return boost::move(object &= operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+//------------------------------------------------------------------------------
+//- intersects<IntervalSet|IntervalMap>
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+//- bool intersects(c T&, c P&) T:{S}|{M} P:{e i}
+//------------------------------------------------------------------------------
+template<class Type, class CoType>
+typename enable_if<mpl::and_< is_interval_container<Type>
+                            , boost::is_same<CoType, typename domain_type_of<Type>::type> >, 
+                   bool>::type
+intersects(const Type& left, const CoType& right)
+{
+    return icl::contains(left, right); 
+}
+
+template<class Type, class CoType>
+typename enable_if<mpl::and_< is_interval_container<Type>
+                            , boost::is_same<CoType, typename interval_type_of<Type>::type> >, 
+                   bool>::type
+intersects(const Type& left, const CoType& right)
+{
+    return icl::find(left, right) != left.end();
+}
+
+
+template<class LeftT, class RightT>
+typename enable_if< mpl::and_< is_intra_combinable<LeftT, RightT> 
+                             , mpl::or_<is_total<LeftT>, is_total<RightT> > >
+                  , bool>::type
+intersects(const LeftT&, const RightT&)
+{
+    return true;
+}
+
+template<class LeftT, class RightT>
+typename enable_if< mpl::and_< is_intra_combinable<LeftT, RightT> 
+                             , mpl::not_<mpl::or_< is_total<LeftT>
+                                                 , is_total<RightT> > > >
+                  , bool>::type
+intersects(const LeftT& left, const RightT& right)
+{
+    typedef typename RightT::const_iterator const_iterator;
+    LeftT intersection;
+
+    const_iterator right_common_lower_, right_common_upper_;
+    if(!Set::common_range(right_common_lower_, right_common_upper_, right, left))
+        return false;
+
+    const_iterator it_ = right_common_lower_;
+    while(it_ != right_common_upper_)
+    {
+        icl::add_intersection(intersection, left, *it_++);
+        if(!icl::is_empty(intersection))
+            return true;
+    }
+    return false; 
+}
+
+template<class LeftT, class RightT>
+typename enable_if<is_cross_combinable<LeftT, RightT>, bool>::type
+intersects(const LeftT& left, const RightT& right)
+{
+    typedef typename RightT::const_iterator const_iterator;
+    LeftT intersection;
+
+    if(icl::is_empty(left) || icl::is_empty(right))
+        return false;
+
+    const_iterator right_common_lower_, right_common_upper_;
+    if(!Set::common_range(right_common_lower_, right_common_upper_, right, left))
+        return false;
+
+    typename RightT::const_iterator it_ = right_common_lower_;
+    while(it_ != right_common_upper_)
+    {
+        icl::add_intersection(intersection, left, key_value<RightT>(it_++));
+        if(!icl::is_empty(intersection))
+            return true;
+    }
+
+    return false; 
+}
+
+/** \b Returns true, if \c left and \c right have no common elements.
+    Intervals are interpreted as sequence of elements.
+    \b Complexity: loglinear, if \c left and \c right are interval containers. */
+template<class LeftT, class RightT>
+typename enable_if<is_inter_combinable<LeftT, RightT>, bool>::type
+disjoint(const LeftT& left, const RightT& right)
+{
+    return !intersects(left, right);
+}
+
+/** \b Returns true, if \c left and \c right have no common elements.
+    Intervals are interpreted as sequence of elements.
+    \b Complexity: logarithmic, if \c AssociateT is an element type \c Type::element_type. 
+    linear, if \c AssociateT is a segment type \c Type::segment_type. */
+template<class Type, class AssociateT>
+typename enable_if<is_inter_derivative<Type, AssociateT>, bool>::type
+disjoint(const Type& left, const AssociateT& right)
+{
+    return !intersects(left,right);
+}
+
+
+//==============================================================================
+//= Symmetric difference<IntervalSet|IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- Symmetric difference ^=, ^
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+//- T& op ^=(T&, c P&) T:{S}|{M} P:{S'}|{M'}
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_intra_combinable<Type, OperandT>, Type>::type&
+operator ^= (Type& object, const OperandT& operand)
+{ 
+    return icl::flip(object, operand); 
+}
+
+//------------------------------------------------------------------------------
+//- T& op ^=(T&, c P&) T:{S}|{M} P:{e i}|{b p}
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_intra_derivative<Type, OperandT>, Type>::type&
+operator ^= (Type& object, const OperandT& operand)
+{ 
+    return icl::flip(object, operand); 
+}
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op ^ (T, c P&) T:{S}|{M} P:{e i S'}|{b p M'} S<S' M<M' <:coarser
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator ^ (Type object, const OperandT& operand)
+{
+    return object ^= operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator ^ (const Type& object, const OperandT& operand)
+{
+    Type temp = object;
+    return boost::move(temp ^= operand); 
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator ^ (Type&& object, const OperandT& operand)
+{
+    return boost::move(object ^= operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op ^ (c P&, T) T:{S}|{M} P:{e i S'}|{b p M'} S<S' M<M' <:coarser
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator ^ (const OperandT& operand, Type object)
+{
+    return object ^= operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator ^ (const OperandT& operand, const Type& object)
+{
+    Type temp = object;
+    return boost::move(temp ^= operand);
+}
+
+template<class Type, class OperandT>
+typename enable_if<is_binary_intra_combinable<Type, OperandT>, Type>::type
+operator ^ (const OperandT& operand, Type&& object)
+{
+    return boost::move(object ^= operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+#ifdef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//------------------------------------------------------------------------------
+//- T op ^ (T, c T&) T:{S M}
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator ^ (typename Type::overloadable_type object, const Type& operand)
+{
+    return object ^= operand; 
+}
+
+#else //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator ^ (const Type& object, const Type& operand)
+{
+    Type temp = object;
+    return boost::move(temp ^= operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator ^ (Type&& object, const Type& operand)
+{
+    return boost::move(object ^= operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator ^ (const Type& operand, Type&& object)
+{
+    return boost::move(object ^= operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type
+operator ^ (Type&& object, Type&& operand)
+{
+    return boost::move(object ^= operand); 
+}
+
+#endif //BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+//==========================================================================
+//= Element Iteration <IntervalSet|IntervalMap>
+//==========================================================================
+//--------------------------------------------------------------------------
+//- Forward
+//--------------------------------------------------------------------------
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_iterator>::type
+elements_begin(Type& object)
+{
+    return typename Type::element_iterator(object.begin());
+}
+
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_iterator>::type
+elements_end(Type& object)
+{ 
+    return typename Type::element_iterator(object.end()); 
+}
+
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_const_iterator>::type
+elements_begin(const Type& object)
+{ 
+    return typename Type::element_const_iterator(object.begin());
+}
+
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_const_iterator>::type
+elements_end(const Type& object)
+{ 
+    return typename Type::element_const_iterator(object.end());
+}
+
+//--------------------------------------------------------------------------
+//- Reverse
+//--------------------------------------------------------------------------
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_reverse_iterator>::type
+elements_rbegin(Type& object)
+{
+    return typename Type::element_reverse_iterator(object.rbegin());
+}
+
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_reverse_iterator>::type
+elements_rend(Type& object)
+{ 
+    return typename Type::element_reverse_iterator(object.rend());
+}
+
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_const_reverse_iterator>::type
+elements_rbegin(const Type& object)
+{ 
+    return typename Type::element_const_reverse_iterator(object.rbegin());
+}
+
+template<class Type>
+typename enable_if
+<mpl::and_< is_interval_container<Type> 
+          , mpl::not_<is_continuous_interval<typename Type::interval_type> > >,
+typename Type::element_const_reverse_iterator>::type
+elements_rend(const Type& object)
+{ 
+    return typename Type::element_const_reverse_iterator(object.rend());
+}
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/interval_associator_base.hpp
+++ b/inst/include/boost/icl/concept/interval_associator_base.hpp
@@ -1,0 +1,149 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2011-2011: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_INTERVAL_ASSOCIATOR_BASE_HPP_JOFA_110301
+#define BOOST_ICL_CONCEPT_INTERVAL_ASSOCIATOR_BASE_HPP_JOFA_110301
+
+#include <boost/icl/type_traits/domain_type_of.hpp>
+#include <boost/icl/type_traits/interval_type_of.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/concept/set_value.hpp>
+#include <boost/icl/concept/map_value.hpp>
+#include <boost/icl/concept/interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= Selection<IntervalSet|IntervalMap>
+//==============================================================================
+template<class Type> inline
+typename enable_if<mpl::and_< is_interval_container<Type>
+                            , is_discrete<typename domain_type_of<Type>::type> 
+                            > 
+                   , typename Type::const_iterator>::type
+find(const Type& object, const typename domain_type_of<Type>::type& key_val)
+{
+    //CL typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::interval_type  interval_type;
+    return object.find(icl::detail::unit_trail<interval_type>(key_val));
+}
+
+template<class Type> inline
+typename enable_if<mpl::and_< is_interval_container<Type>
+                            , is_continuous<typename domain_type_of<Type>::type> 
+                            , has_dynamic_bounds<typename interval_type_of<Type>::type> 
+                            > 
+                   , typename Type::const_iterator>::type
+find(const Type& object, const typename domain_type_of<Type>::type& key_val)
+{
+    //CL typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::interval_type  interval_type;
+    return object.find(icl::singleton<interval_type>(key_val));
+}
+
+template<class Type> inline
+typename enable_if<mpl::and_< is_interval_container<Type>
+                            , is_continuous<typename domain_type_of<Type>::type> 
+                            , is_static_right_open<typename interval_type_of<Type>::type> 
+                            , boost::detail::is_incrementable<typename domain_type_of<Type>::type>
+                            > 
+                   , typename Type::const_iterator>::type
+find(const Type& object, const typename domain_type_of<Type>::type& key_val)
+{
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::interval_type  interval_type;
+    const_iterator first_collision = object.lower_bound(icl::detail::unit_trail<interval_type>(key_val));
+    // A part of the unit_trail(key_value)-interval may be found in the container, that
+    // does not contain key_value. Therefore we have to check for its existence:
+    return (  first_collision == object.end() 
+           || icl::contains(key_value<Type>(first_collision), key_val) ) 
+            ? first_collision 
+            : object.end();
+}
+
+template<class Type> inline
+typename enable_if<mpl::and_< is_interval_container<Type>
+                            , is_continuous<typename domain_type_of<Type>::type> 
+                            , is_static_left_open<typename interval_type_of<Type>::type> 
+                            , boost::detail::is_incrementable<typename domain_type_of<Type>::type>
+                            > 
+                   , typename Type::const_iterator>::type
+find(const Type& object, const typename domain_type_of<Type>::type& key_val)
+{
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::interval_type  interval_type;
+    const_iterator last_collision = object.upper_bound(icl::detail::unit_trail<interval_type>(key_val));
+    if(last_collision != object.begin())
+        --last_collision;
+    // A part of the unit_trail(key_value)-interval may be found in the container, that
+    // does not contain key_value. Therefore we have to check for its existence:
+    return (  last_collision == object.end() 
+           || icl::contains(key_value<Type>(last_collision), key_val) ) 
+            ? last_collision 
+            : object.end();
+}
+
+// NOTE: find(object, key) won't compile if key is of continuous type that does
+// not implement in(de)crementation (e.g. std::string).
+
+template<class Type> inline
+typename enable_if< is_interval_container<Type>
+                  , typename Type::const_iterator>::type
+find(const Type& object, const typename interval_type_of<Type>::type& inter_val)
+{
+    return object.find(inter_val);
+}
+
+//==============================================================================
+//= Morphisms
+//==============================================================================
+template<class Type>
+typename enable_if<is_interval_container<Type>, Type>::type&
+join(Type& object)
+{
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+
+    iterator it_ = object.begin();
+    if(it_ == object.end()) 
+        return object;
+
+    iterator next_ = it_; next_++;
+
+    while(next_ != object.end())
+    {
+        if( segmental::is_joinable<Type>(it_, next_) )
+        {
+            iterator fst_mem = it_;  // hold the first member
+            
+            // Go on while touching members are found
+            it_++; next_++;
+            while(     next_ != object.end()
+                    && segmental::is_joinable<Type>(it_, next_) )
+            { it_++; next_++; }
+
+            // finally we arrive at the end of a sequence of joinable intervals
+            // and it points to the last member of that sequence
+            const_cast<interval_type&>(key_value<Type>(it_)) 
+                = hull(key_value<Type>(it_), key_value<Type>(fst_mem));
+            object.erase(fst_mem, it_);
+
+            it_++; next_=it_; 
+            if(next_!=object.end())
+                next_++;
+        }
+        else { it_++; next_++; }
+    }
+    return object;
+}
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/interval_bounds.hpp
+++ b/inst/include/boost/icl/concept/interval_bounds.hpp
@@ -1,0 +1,157 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_INTERVAL_BOUNDS_HPP_JOFA_100927
+#define BOOST_ICL_CONCEPT_INTERVAL_BOUNDS_HPP_JOFA_100927
+
+#include <boost/icl/interval_bounds.hpp>
+#include <boost/icl/type_traits/is_discrete.hpp>
+#include <boost/icl/type_traits/is_numeric.hpp>
+
+namespace boost{namespace icl
+{
+
+inline interval_bounds left(interval_bounds x1)
+{ return interval_bounds(x1._bits & interval_bounds::_left); }
+
+inline interval_bounds right(interval_bounds x1)
+{ return interval_bounds(x1._bits & interval_bounds::_right); }
+
+inline interval_bounds all(interval_bounds x1)
+{ return interval_bounds(x1._bits & interval_bounds::_all); }
+
+inline bool operator == (const interval_bounds x1, const interval_bounds x2)
+{ return x1._bits == x2._bits; }
+
+inline bool operator != (const interval_bounds x1, const interval_bounds x2)
+{ return x1._bits != x2._bits; }
+
+inline interval_bounds operator & (interval_bounds x1, interval_bounds x2)
+{ return interval_bounds(x1._bits & x2._bits); }
+
+inline interval_bounds operator | (interval_bounds x1, interval_bounds x2)
+{ return interval_bounds(x1._bits | x2._bits); }
+
+// left shift (multiplies by 2^shift)
+inline interval_bounds operator << (interval_bounds bounds, unsigned int shift)
+{ return interval_bounds(bounds._bits << shift); }
+
+// right shift (divides by 2^shift)
+inline interval_bounds operator >> (interval_bounds bounds, unsigned int shift)
+{ return interval_bounds(bounds._bits >> shift); }
+
+inline interval_bounds operator ~ (interval_bounds x1)
+{ return all(interval_bounds(~(x1._bits))); }
+
+inline interval_bounds outer_bounds(interval_bounds x1, interval_bounds x2)
+{ return left(x1) | right(x2); }
+
+inline interval_bounds inner_bounds(interval_bounds x1, interval_bounds x2)
+{ return interval_bounds(x1.reverse_right() | x2.reverse_left()); }
+
+inline interval_bounds left_bounds(interval_bounds x1, interval_bounds x2)
+{ return left(x1) | (left(x2) >> 1); }
+
+inline interval_bounds right_bounds(interval_bounds x1, interval_bounds x2)
+{ return (right(x1) <<1 ) | right(x2); }
+
+inline interval_bounds left_subtract_bounds(interval_bounds x1, interval_bounds x2)
+{ return right(x1) | ~(right(x2) << 1); }
+
+inline interval_bounds right_subtract_bounds(interval_bounds x1, interval_bounds x2)
+{ return left(x1) | ~(left(x2) >> 1); }
+
+inline bool is_complementary(interval_bounds x1)
+{ return x1 == interval_bounds::right_open() || x1 == interval_bounds::left_open(); }
+
+inline bool is_left_closed(interval_bounds bounds)
+{ return bounds.left().bits()==2; }
+
+inline bool is_right_closed(interval_bounds bounds)
+{ return bounds.right().bits()==1; }
+
+inline std::string left_bracket(interval_bounds bounds)
+{ return is_left_closed(bounds) ? "[" : "("; }
+
+inline std::string right_bracket(interval_bounds bounds)
+{ return is_right_closed(bounds) ? "]" : ")"; }
+
+template <class Type>
+inline typename enable_if<is_discrete<Type>, Type>::type
+shift_lower(interval_bounds decl, interval_bounds repr, const Type& low)
+{
+    if(is_left_closed(decl) && !is_left_closed(repr))
+        return icl::pred(low);
+    else if(!is_left_closed(decl) && is_left_closed(repr)) 
+        return icl::succ(low);
+    else 
+        return low;
+}
+
+template <class Type>
+inline typename enable_if<is_discrete<Type>, Type>::type
+shift_upper(interval_bounds decl, interval_bounds repr, const Type& up)
+{
+    if(!is_right_closed(decl) && is_right_closed(repr))
+        return icl::pred(up);
+    else if(is_right_closed(decl) && !is_right_closed(repr)) 
+        return icl::succ(up);
+    else 
+        return up;
+}
+
+template<class CharType, class CharTraits>
+std::basic_ostream<CharType, CharTraits>& operator <<
+  (std::basic_ostream<CharType, CharTraits> &stream, 
+   interval_bounds const& object)
+{
+    return stream << left_bracket(object) << right_bracket(object);
+}
+
+
+
+template<class IntervalT>
+inline typename 
+boost::enable_if<has_dynamic_bounds<IntervalT>, interval_bounds>::type
+outer_bounds(const IntervalT& x1, const IntervalT& x2)
+{ return outer_bounds(x1.bounds(), x2.bounds()); }
+
+template<class IntervalT>
+inline typename 
+boost::enable_if<has_dynamic_bounds<IntervalT>, interval_bounds>::type
+inner_bounds(const IntervalT& x1, const IntervalT& x2)
+{ return inner_bounds(x1.bounds(), x2.bounds()); }
+
+template<class IntervalT>
+inline typename 
+boost::enable_if<has_dynamic_bounds<IntervalT>, interval_bounds>::type
+left_bounds(const IntervalT& x1, const IntervalT& x2)
+{ return left_bounds(x1.bounds(), x2.bounds()); }
+
+template<class IntervalT>
+inline typename 
+boost::enable_if<has_dynamic_bounds<IntervalT>, interval_bounds>::type
+right_bounds(const IntervalT& x1, const IntervalT& x2)
+{ return right_bounds(x1.bounds(), x2.bounds()); }
+
+template<class IntervalT>
+inline typename 
+boost::enable_if<has_dynamic_bounds<IntervalT>, interval_bounds>::type
+left_subtract_bounds(const IntervalT& x1, const IntervalT& x2)
+{ return left_subtract_bounds(x1.bounds(), x2.bounds()); }
+
+template<class IntervalT>
+inline typename 
+boost::enable_if<has_dynamic_bounds<IntervalT>, interval_bounds>::type
+right_subtract_bounds(const IntervalT& x1, const IntervalT& x2)
+{ return right_subtract_bounds(x1.bounds(), x2.bounds()); }
+
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/concept/interval_map.hpp
+++ b/inst/include/boost/icl/concept/interval_map.hpp
@@ -1,0 +1,677 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_INTERVAL_MAP_HPP_JOFA_100920
+#define BOOST_ICL_CONCEPT_INTERVAL_MAP_HPP_JOFA_100920
+
+#include <boost/icl/type_traits/element_type_of.hpp>
+#include <boost/icl/type_traits/segment_type_of.hpp>
+#include <boost/icl/type_traits/absorbs_identities.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/type_traits/is_interval_splitter.hpp>
+
+#include <boost/icl/detail/set_algo.hpp>
+#include <boost/icl/detail/interval_map_algo.hpp>
+#include <boost/icl/concept/interval.hpp>
+#include <boost/icl/concept/joinable.hpp>
+
+namespace boost{ namespace icl
+{
+
+template<class Type>
+inline typename enable_if<is_interval_map<Type>, typename Type::segment_type>::type
+make_segment(const typename Type::element_type& element)
+{
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::segment_type  segment_type;
+    return segment_type(icl::singleton<interval_type>(element.key), element.data);
+}
+
+
+//==============================================================================
+//= Containedness<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- bool contains(c T&, c P&) T:{M} P:{b p M} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, bool>::type
+contains(const Type& super, const typename Type::element_type& key_value_pair)
+{
+    typedef typename Type::const_iterator const_iterator;
+    const_iterator it_ = icl::find(super, key_value_pair.key);
+    return it_ != super.end() && (*it_).second == key_value_pair.data;
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, bool>::type
+contains(const Type& super, const typename Type::segment_type& sub_segment)
+{
+    typedef typename Type::interval_type  interval_type;
+    typedef typename Type::const_iterator const_iterator;
+
+    interval_type sub_interval = sub_segment.first;
+    if(icl::is_empty(sub_interval)) 
+        return true;
+
+    std::pair<const_iterator, const_iterator> exterior = super.equal_range(sub_interval);
+    if(exterior.first == exterior.second)
+        return false;
+
+    const_iterator last_overlap = prior(exterior.second);
+
+    if(!(sub_segment.second == exterior.first->second) )
+        return false;
+
+    return
+          icl::contains(hull(exterior.first->first, last_overlap->first), sub_interval)
+      &&  Interval_Map::is_joinable(super, exterior.first, last_overlap);
+}
+
+template<class Type, class CoType>
+typename enable_if<is_concept_compatible<is_interval_map, Type, CoType>, bool>::type
+contains(const Type& super, const CoType& sub)
+{
+    return Interval_Set::within(sub, super);
+}
+
+
+//------------------------------------------------------------------------------
+//- bool contains(c T&, c P&) T:{M} P:{e i S} key_types : total
+//------------------------------------------------------------------------------
+template<class Type, class CoType>
+typename enable_if< mpl::and_< is_interval_map<Type>
+                             , is_total<Type> 
+                             , is_cross_derivative<Type, CoType> >
+            , bool>::type
+contains(const Type&, const CoType&)
+{
+    return true;
+}
+
+//------------------------------------------------------------------------------
+//- bool contains(c T&, c P&) T:{M} P:{e i S} key_types : partial
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if< mpl::and_< is_interval_map<Type>
+                             , mpl::not_<is_total<Type> > >
+            , bool>::type
+contains(const Type& super, const typename Type::domain_type& key)    
+{
+    return icl::find(super, key) != super.end();
+}
+
+template<class Type>
+typename enable_if< mpl::and_< is_interval_map<Type>
+                             , mpl::not_<is_total<Type> > >
+            , bool>::type
+contains(const Type& super, const typename Type::interval_type& sub_interval)
+{
+    typedef typename Type::const_iterator const_iterator;
+
+    if(icl::is_empty(sub_interval)) 
+        return true;
+
+    std::pair<const_iterator, const_iterator> exterior = super.equal_range(sub_interval);
+    if(exterior.first == exterior.second)
+        return false;
+
+    const_iterator last_overlap = prior(exterior.second);
+
+    return
+          icl::contains(hull(exterior.first->first, last_overlap->first), sub_interval)
+      &&  Interval_Set::is_joinable(super, exterior.first, last_overlap);
+}
+
+template<class Type, class KeyT>
+typename enable_if< mpl::and_< is_concept_combinable<is_interval_map, is_interval_set, Type, KeyT>
+                             , mpl::not_<is_total<Type> > >
+            , bool>::type
+contains(const Type& super, const KeyT& sub)
+{
+    return Interval_Set::within(sub, super);
+}
+
+//==============================================================================
+//= Addition<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& add(T&, c P&) T:{M} P:{b p} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+add(Type& object, const typename Type::segment_type& operand)
+{
+    return object.add(operand);
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+add(Type& object, const typename Type::element_type& operand)
+{
+    return icl::add(object, make_segment<Type>(operand));
+}
+
+//------------------------------------------------------------------------------
+//- T& add(T&, J, c P&) T:{M} P:{p} segment_type
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, typename Type::iterator >::type
+add(Type& object, typename Type::iterator      prior_,
+            const typename Type::segment_type& operand)
+{
+    return object.add(prior_, operand);
+}
+
+//==============================================================================
+//= Insertion<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& insert(T&, c P&) T:{M} P:{b p} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+insert(Type& object, const typename Type::segment_type& operand)
+{
+    return object.insert(operand);
+}
+
+template<class Type>
+inline typename enable_if<is_interval_map<Type>, Type>::type&
+insert(Type& object, const typename Type::element_type& operand)
+{
+    return icl::insert(object, make_segment<Type>(operand));
+}
+
+//------------------------------------------------------------------------------
+//- T& insert(T&, J, c P&) T:{M} P:{p} with hint
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, typename Type::iterator>::type
+insert(Type& object, typename Type::iterator      prior,
+               const typename Type::segment_type& operand)
+{
+    return object.insert(prior, operand);
+}
+
+
+//==============================================================================
+//= Erasure<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& erase(T&, c P&) T:{M} P:{e i} key_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+erase(Type& object, const typename Type::interval_type& operand)
+{
+    return object.erase(operand);
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+erase(Type& object, const typename Type::domain_type& operand)
+{
+    typedef typename Type::interval_type interval_type;
+    return icl::erase(object, icl::singleton<interval_type>(operand));
+}
+
+//------------------------------------------------------------------------------
+//- T& erase(T&, c P&) T:{M} P:{b p} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+erase(Type& object, const typename Type::segment_type& operand)
+{
+    return object.erase(operand);
+}
+
+template<class Type>
+inline typename enable_if<is_interval_map<Type>, Type>::type&
+erase(Type& object, const typename Type::element_type& operand)
+{
+    return icl::erase(object, make_segment<Type>(operand));
+}
+
+//==============================================================================
+//= Subtraction<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{M} P:{b p} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type& 
+subtract(Type& object, const typename Type::segment_type& operand)
+{
+    return object.subtract(operand);
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+subtract(Type& object, const typename Type::element_type& operand)
+{
+    return icl::subtract(object, make_segment<Type>(operand));
+}
+
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{M} P:{e i} key_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+subtract(Type& object, const typename Type::domain_type& operand)
+{
+    return object.erase(operand);
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+subtract(Type& object, const typename Type::interval_type& operand)
+{
+    return object.erase(operand);
+}
+
+//==============================================================================
+//= Selective Update<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& set_at(T&, c P&) T:{M} P:{e i}
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+set_at(Type& object, const typename Type::segment_type& operand)
+{
+    icl::erase(object, operand.first); 
+    return icl::insert(object, operand); 
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+set_at(Type& object, const typename Type::element_type& operand)
+{
+    return icl::set_at(object, make_segment<Type>(operand));
+}
+
+//==============================================================================
+//= Intersection<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{M} P:{b p} fragment_type
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, void>::type
+add_intersection(Type& section, const Type& object, 
+                 const typename Type::element_type& operand)
+{
+    //CL typedef typename Type::segment_type segment_type;
+    object.add_intersection(section, make_segment<Type>(operand));
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, void>::type
+add_intersection(Type& section, const Type& object, 
+                 const typename Type::segment_type& operand)
+{
+    object.add_intersection(section, operand);
+}
+
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{M} P:{M'} map fragment_type total
+//------------------------------------------------------------------------------
+template<class Type, class MapT>
+typename enable_if
+<
+    mpl::and_< is_total<Type>
+             , is_concept_compatible<is_interval_map, Type, MapT> >
+  , void
+>::type
+add_intersection(Type& section, const Type& object, const MapT& operand)
+{
+    section += object;
+    section += operand;
+}
+
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{M} P:{M'} map fragment_type partial
+//------------------------------------------------------------------------------
+template<class Type, class MapT>
+typename enable_if
+<
+    mpl::and_< mpl::not_<is_total<Type> >
+             , is_concept_compatible<is_interval_map, Type, MapT> >
+  , void
+>::type
+add_intersection(Type& section, const Type& object, const MapT& operand)
+{
+    //CL typedef typename Type::segment_type   segment_type;
+    //CL typedef typename Type::interval_type  interval_type;
+    typedef typename MapT::const_iterator const_iterator;
+
+    if(operand.empty()) 
+        return;
+    const_iterator common_lwb, common_upb;
+    if(!Set::common_range(common_lwb, common_upb, operand, object))
+        return;
+    const_iterator it_ = common_lwb;
+    while(it_ != common_upb)
+        add_intersection(section, object, *it_++);
+}
+
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{M} P:{e i S} key_type
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, void>::type
+add_intersection(Type& section, const Type& object, 
+                 const typename Type::domain_type& key_value)
+{
+    typedef typename Type::interval_type  interval_type;
+    typedef typename Type::segment_type   segment_type;
+    typedef typename Type::const_iterator const_iterator;
+
+    const_iterator it_ = icl::find(object, key_value);
+    if(it_ != object.end())
+        add(section, segment_type(interval_type(key_value),(*it_).second));
+}
+
+template<class Type>
+typename enable_if<is_interval_map<Type>, void>::type
+add_intersection(Type& section, const Type& object, 
+                 const typename Type::interval_type& inter_val)
+{
+    typedef typename Type::interval_type  interval_type;
+    typedef typename Type::value_type     value_type;
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::iterator       iterator;
+
+    if(icl::is_empty(inter_val)) 
+        return;
+
+    std::pair<const_iterator, const_iterator> exterior 
+        = object.equal_range(inter_val);
+    if(exterior.first == exterior.second)
+        return;
+
+    iterator prior_ = section.end();
+    for(const_iterator it_=exterior.first; it_ != exterior.second; it_++) 
+    {
+        interval_type common_interval = (*it_).first & inter_val; 
+        if(!icl::is_empty(common_interval))
+            prior_ = add(section, prior_, 
+                         value_type(common_interval, (*it_).second) );
+    }
+}
+
+template<class Type, class KeySetT>
+typename enable_if<is_concept_combinable<is_interval_map, is_interval_set, Type, KeySetT>, void>::type
+add_intersection(Type& section, const Type& object, const KeySetT& key_set)
+{
+    typedef typename KeySetT::const_iterator const_iterator;
+
+    if(icl::is_empty(key_set)) 
+        return;
+
+    const_iterator common_lwb, common_upb;
+    if(!Set::common_range(common_lwb, common_upb, key_set, object))
+        return;
+
+    const_iterator it_ = common_lwb;
+    while(it_ != common_upb)
+        add_intersection(section, object, *it_++);
+}
+
+//------------------------------------------------------------------------------
+//- intersects<IntervalMaps> fragment_types
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if<mpl::and_< is_interval_map<Type>
+                            , is_total<Type>
+                            , boost::is_same< OperandT
+                                            , typename segment_type_of<Type>::type> >, 
+                   bool>::type
+intersects(const Type&, const OperandT&)
+{
+    return true;
+}
+
+template<class Type, class OperandT>
+typename enable_if<mpl::and_< is_interval_map<Type>
+                            , mpl::not_<is_total<Type> >
+                            , boost::is_same<OperandT, typename segment_type_of<Type>::type> >, 
+                   bool>::type
+intersects(const Type& object, const OperandT& operand)
+{
+    Type intersection;
+    icl::add_intersection(intersection, object, operand);
+    return !icl::is_empty(intersection); 
+}
+
+template<class Type, class OperandT>
+typename enable_if<mpl::and_< is_interval_map<Type>
+                            , boost::is_same<OperandT, typename element_type_of<Type>::type> >, 
+                   bool>::type
+intersects(const Type& object, const OperandT& operand)
+{
+    return icl::intersects(object, make_segment<Type>(operand)); 
+}
+
+//==============================================================================
+//= Symmetric difference<IntervalMap>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& flip(T&, c P&) T:{M} P:{b p} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_map<Type>, Type>::type&
+flip(Type& object, const typename Type::segment_type& operand)
+{
+    return object.flip(operand);
+}
+
+template<class Type>
+inline typename enable_if<is_interval_map<Type>, Type>::type&
+flip(Type& object, const typename Type::element_type& operand)
+{
+    return icl::flip(object, make_segment<Type>(operand));
+}
+
+//------------------------------------------------------------------------------
+//- T& flip(T&, c P&) T:{M} P:{M'} total absorber 
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if< mpl::and_< is_total<Type>
+                             , absorbs_identities<Type>
+                             , is_concept_compatible<is_interval_map, 
+                                                     Type, OperandT >
+                             >
+                  , Type>::type&
+flip(Type& object, const OperandT&)
+{
+    object.clear();
+    return object;
+}
+
+//------------------------------------------------------------------------------
+//- T& flip(T&, c P&) T:{M} P:{M'} total enricher 
+//------------------------------------------------------------------------------
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant
+#endif                        
+template<class Type, class OperandT>
+typename enable_if< mpl::and_< is_total<Type>
+                             , mpl::not_<absorbs_identities<Type> >
+                             , is_concept_compatible<is_interval_map, 
+                                                     Type, OperandT >
+                             >
+                  , Type>::type&
+flip(Type& object, const OperandT& operand)
+{
+    typedef typename Type::codomain_type  codomain_type;
+
+    object += operand;
+    ICL_FORALL(typename Type, it_, object)
+        (*it_).second = identity_element<codomain_type>::value();
+
+    if(mpl::not_<is_interval_splitter<Type> >::value)
+        icl::join(object);
+
+    return object;
+}
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+
+//------------------------------------------------------------------------------
+//- T& flip(T&, c P&) T:{M} P:{M'} partial 
+//------------------------------------------------------------------------------
+template<class Type, class OperandT>
+typename enable_if< mpl::and_< mpl::not_<is_total<Type> > 
+                             , is_concept_compatible<is_interval_map, 
+                                                     Type, OperandT >
+                             >
+                  , Type>::type&
+flip(Type& object, const OperandT& operand)
+{
+    typedef typename OperandT::const_iterator const_iterator;
+    //CL typedef typename Type::codomain_type  codomain_type;
+
+    const_iterator common_lwb, common_upb;
+
+    if(!Set::common_range(common_lwb, common_upb, operand, object))
+        return object += operand;
+
+    const_iterator it_ = operand.begin();
+
+    // All elements of operand left of the common range are added
+    while(it_ != common_lwb)
+        icl::add(object, *it_++);
+    // All elements of operand in the common range are symmetrically subtracted
+    while(it_ != common_upb)
+        icl::flip(object, *it_++);
+    // All elements of operand right of the common range are added
+    while(it_ != operand.end())
+        icl::add(object, *it_++);
+
+    return object;
+}
+
+//==============================================================================
+//= Set selection
+//==============================================================================
+template<class Type, class SetT>
+typename enable_if<is_concept_combinable<is_interval_set, is_interval_map, 
+                                         SetT, Type>, SetT>::type&
+domain(SetT& result, const Type& object)
+{
+    typedef typename SetT::iterator set_iterator;
+    result.clear(); 
+    set_iterator prior_ = result.end();
+    ICL_const_FORALL(typename Type, it_, object) 
+        prior_ = icl::insert(result, prior_, (*it_).first); 
+    
+    return result;
+}
+
+template<class Type, class SetT>
+typename enable_if<is_concept_combinable<is_interval_set, is_interval_map, 
+                                         SetT, Type>, SetT>::type&
+between(SetT& in_between, const Type& object)
+{
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename SetT::iterator       set_iterator;
+    in_between.clear();
+    const_iterator it_ = object.begin(), pred_;
+    set_iterator   prior_ = in_between.end();
+
+    if(it_ != object.end())
+        pred_ = it_++;
+
+    while(it_ != object.end())
+        prior_ = icl::insert(in_between, prior_, 
+                             between((*pred_++).first, (*it_++).first));
+    
+    return in_between;
+}
+
+//==============================================================================
+//= Manipulation by predicates
+//==============================================================================
+template<class MapT, class Predicate>
+typename enable_if<is_interval_map<MapT>, MapT>::type&
+erase_if(const Predicate& pred, MapT& object)
+{
+    typename MapT::iterator it_ = object.begin();
+    while(it_ != object.end())
+        if(pred(*it_))
+            object.erase(it_++); 
+        else ++it_;
+    return object;
+}
+
+template<class MapT, class Predicate>
+inline typename enable_if<is_interval_map<MapT>, MapT>::type&
+add_if(const Predicate& pred, MapT& object, const MapT& src)
+{
+    typename MapT::const_iterator it_ = src.begin();
+    while(it_ != src.end())
+        if(pred(*it_)) 
+            icl::add(object, *it_++); 
+    
+    return object;
+}
+
+template<class MapT, class Predicate>
+inline typename enable_if<is_interval_map<MapT>, MapT>::type&
+assign_if(const Predicate& pred, MapT& object, const MapT& src)
+{
+    icl::clear(object);
+    return add_if(object, src, pred);
+}
+
+
+//==============================================================================
+//= Morphisms
+//==============================================================================
+template<class Type>
+typename enable_if<mpl::and_< is_interval_map<Type>
+                            , absorbs_identities<Type> >, Type>::type&
+absorb_identities(Type& object)
+{
+    return object;
+}
+
+template<class Type>
+typename enable_if<mpl::and_< is_interval_map<Type>
+                            , mpl::not_<absorbs_identities<Type> > >, Type>::type&
+absorb_identities(Type& object)
+{
+    typedef typename Type::segment_type segment_type;
+    return icl::erase_if(content_is_identity_element<segment_type>(), object);
+}
+
+//==============================================================================
+//= Streaming
+//==============================================================================
+template<class CharType, class CharTraits, class Type>
+typename enable_if<is_interval_map<Type>, 
+                   std::basic_ostream<CharType, CharTraits> >::type& 
+operator << (std::basic_ostream<CharType, CharTraits>& stream, const Type& object)
+{
+    stream << "{";
+    ICL_const_FORALL(typename Type, it_, object)
+        stream << "(" << (*it_).first << "->" << (*it_).second << ")";
+
+    return stream << "}";
+}
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/interval_set.hpp
+++ b/inst/include/boost/icl/concept/interval_set.hpp
@@ -1,0 +1,354 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_INTERVAL_SET_HPP_JOFA_100920
+#define BOOST_ICL_CONCEPT_INTERVAL_SET_HPP_JOFA_100920
+
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/type_traits/interval_type_of.hpp>
+#include <boost/icl/detail/set_algo.hpp>
+#include <boost/icl/detail/interval_set_algo.hpp>
+#include <boost/icl/concept/interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= Containedness<IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- bool contains(c T&, c P&) T:{S} P:{e i S} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_set<Type>, bool>::type
+contains(const Type& super, const typename Type::element_type& element)
+{
+    return !(icl::find(super, element) == super.end());
+}
+
+template<class Type>
+typename enable_if<is_interval_set<Type>, bool>::type
+contains(const Type& super, const typename Type::segment_type& inter_val)
+{ 
+    typedef typename Type::const_iterator const_iterator;
+    if(icl::is_empty(inter_val)) 
+        return true;
+
+    std::pair<const_iterator, const_iterator> exterior 
+        = super.equal_range(inter_val);
+    if(exterior.first == exterior.second)
+        return false;
+
+    const_iterator last_overlap = cyclic_prior(super, exterior.second);
+
+    return 
+        icl::contains(hull(*(exterior.first), *last_overlap), inter_val)
+    &&  Interval_Set::is_joinable(super, exterior.first, last_overlap);
+}
+
+template<class Type, class OperandT>
+typename enable_if<has_same_concept<is_interval_set, Type, OperandT>, 
+                   bool>::type 
+contains(const Type& super, const OperandT& sub)
+{
+    return Interval_Set::contains(super, sub);
+}
+
+//==============================================================================
+//= Addition<IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& add(T&, c P&) T:{S} P:{e i} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+add(Type& object, const typename Type::segment_type& operand)
+{
+    return object.add(operand);
+}
+
+template<class Type>
+inline typename enable_if<is_interval_set<Type>, Type>::type&
+add(Type& object, const typename Type::element_type& operand)
+{
+    typedef typename Type::segment_type segment_type;
+    return icl::add(object, icl::singleton<segment_type>(operand));
+}
+
+//------------------------------------------------------------------------------
+//- T& add(T&, J, c P&) T:{S} P:{i} interval_type
+//------------------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_interval_set<Type>, typename Type::iterator>::type
+add(Type& object, typename Type::iterator      prior, 
+            const typename Type::segment_type& operand)
+{
+    return object.add(prior, operand);
+}
+
+//==============================================================================
+//= Insertion<IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& insert(T&, c P&) T:{S} P:{e i} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_interval_set<Type>, Type>::type&
+insert(Type& object, const typename Type::segment_type& operand)
+{
+    return icl::add(object, operand);
+}
+
+template<class Type>
+inline typename enable_if<is_interval_set<Type>, Type>::type&
+insert(Type& object, const typename Type::element_type& operand)
+{
+    return icl::add(object, operand);
+}
+
+//------------------------------------------------------------------------------
+//- T& insert(T&, J, c P&) T:{S} P:{i} with hint
+//------------------------------------------------------------------------------
+template<class Type>
+inline typename enable_if<is_interval_set<Type>, typename Type::iterator>::type
+insert(Type& object, typename Type::iterator      prior,
+               const typename Type::segment_type& operand)
+{
+    return icl::add(object, prior, operand);
+}
+
+//==============================================================================
+//= Subtraction<IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& subtract(T&, c P&) T:{S} P:{e i} fragment_type
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+subtract(Type& object, const typename Type::segment_type& operand)
+{
+    return object.subtract(operand);
+}
+
+template<class Type>
+inline typename enable_if<is_interval_set<Type>, Type>::type&
+subtract(Type& object, const typename Type::element_type& operand)
+{
+    typedef typename Type::segment_type segment_type;
+    return icl::subtract(object, icl::singleton<segment_type>(operand));
+}
+
+//==============================================================================
+//= Erasure<IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& erase(T&, c P&) T:{S} P:{e i} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+erase(Type& object, const typename Type::segment_type& minuend)
+{
+    return icl::subtract(object, minuend);
+}
+
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+erase(Type& object, const typename Type::element_type& minuend)
+{
+    return icl::subtract(object, minuend);
+}
+
+//==============================================================================
+//= Intersection
+//==============================================================================
+//------------------------------------------------------------------------------
+//- void add_intersection(T&, c T&, c P&) T:{S} P:{e i} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_set<Type>, void>::type
+add_intersection(Type& section, const Type& object, 
+                 const typename Type::element_type& operand)
+{
+    typedef typename Type::const_iterator const_iterator;
+    const_iterator found = icl::find(object, operand);
+    if(found != object.end())
+        icl::add(section, operand);
+}
+
+
+template<class Type>
+typename enable_if<is_interval_set<Type>, void>::type
+add_intersection(Type& section, const Type& object, 
+                 const typename Type::segment_type& segment)
+{
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::iterator       iterator;
+    typedef typename Type::interval_type  interval_type;
+
+    if(icl::is_empty(segment)) 
+        return;
+
+    std::pair<const_iterator, const_iterator> exterior 
+        = object.equal_range(segment);
+    if(exterior.first == exterior.second)
+        return;
+
+    iterator prior_ = section.end();
+    for(const_iterator it_=exterior.first; it_ != exterior.second; it_++) 
+    {
+        interval_type common_interval = key_value<Type>(it_) & segment;
+        if(!icl::is_empty(common_interval))
+            prior_ = section.insert(prior_, common_interval);
+    }
+}
+
+//==============================================================================
+//= Symmetric difference<IntervalSet>
+//==============================================================================
+//------------------------------------------------------------------------------
+//- T& flip(T&, c P&) T:{S} P:{e i S'} fragment_types
+//------------------------------------------------------------------------------
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+flip(Type& object, const typename Type::element_type& operand)
+{
+    if(icl::contains(object, operand))
+        return object -= operand;
+    else
+        return object += operand;
+}
+
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+flip(Type& object, const typename Type::segment_type& segment)
+{
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::interval_type  interval_type;
+    // That which is common shall be subtracted
+    // That which is not shall be added
+    // So x has to be 'complementary added' or flipped
+    interval_type span = segment;
+    std::pair<const_iterator, const_iterator> exterior 
+        = object.equal_range(span);
+
+    const_iterator fst_ = exterior.first;
+    const_iterator end_ = exterior.second;
+
+    interval_type covered, left_over;
+    const_iterator it_ = fst_;
+    while(it_ != end_) 
+    {
+        covered = *it_++; 
+        //[a      ...  : span
+        //     [b ...  : covered
+        //[a  b)       : left_over
+        left_over = right_subtract(span, covered);
+        icl::subtract(object, span & covered); //That which is common shall be subtracted
+        icl::add(object, left_over);           //That which is not shall be added
+
+        //...      d) : span
+        //... c)      : covered
+        //     [c  d) : span'
+        span = left_subtract(span, covered);
+    }
+
+    //If span is not empty here, it_ is not in the set so it_ shall be added
+    icl::add(object, span);
+    return object;
+}
+
+
+template<class Type, class OperandT>
+typename enable_if<is_concept_compatible<is_interval_set, Type, OperandT>, Type>::type&
+flip(Type& object, const OperandT& operand)
+{
+    typedef typename OperandT::const_iterator const_iterator;
+
+    if(operand.empty())
+        return object;
+
+    const_iterator common_lwb, common_upb;
+
+    if(!Set::common_range(common_lwb, common_upb, operand, object))
+        return object += operand;
+
+    const_iterator it_ = operand.begin();
+
+    // All elements of operand left of the common range are added
+    while(it_ != common_lwb)
+        icl::add(object, *it_++);
+    // All elements of operand in the common range are symmertrically subtracted
+    while(it_ != common_upb)
+        icl::flip(object, *it_++);
+    // All elements of operand right of the common range are added
+    while(it_ != operand.end())
+        icl::add(object, *it_++);
+
+    return object;
+}
+
+//==============================================================================
+//= Set selection
+//==============================================================================
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+domain(Type& dom, const Type& object)
+{
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::iterator       iterator;
+    dom.clear();
+    const_iterator it_    = object.begin();
+    iterator       prior_ = dom.end();
+
+    while(it_ != object.end())
+        prior_ = icl::insert(dom, prior_, *it_++);
+
+    return dom;
+}
+
+template<class Type>
+typename enable_if<is_interval_set<Type>, Type>::type&
+between(Type& in_between, const Type& object)
+{
+    typedef typename Type::const_iterator const_iterator;
+    typedef typename Type::iterator       iterator;
+    in_between.clear();
+    const_iterator it_ = object.begin(), pred_;
+    iterator prior_ = in_between.end();
+
+    if(it_ != object.end())
+        pred_ = it_++;
+
+    while(it_ != object.end())
+        prior_ = icl::insert(in_between, prior_, 
+                             icl::between(*pred_++, *it_++));
+
+    return in_between;
+}
+
+
+//==============================================================================
+//= Streaming
+//==============================================================================
+template<class CharType, class CharTraits, class Type>
+typename enable_if<is_interval_set<Type>, 
+                   std::basic_ostream<CharType, CharTraits> >::type& 
+operator << (std::basic_ostream<CharType, CharTraits>& stream, const Type& object)
+{
+    stream << "{";
+    ICL_const_FORALL(typename Type, it_, object)
+        stream << (*it_);
+
+    return stream << "}";
+}
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/interval_set_value.hpp
+++ b/inst/include/boost/icl/concept/interval_set_value.hpp
@@ -1,0 +1,33 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_INTERVAL_SET_VALUE_HPP_JOFA_100924
+#define BOOST_ICL_CONCEPT_INTERVAL_SET_VALUE_HPP_JOFA_100924
+
+#include <boost/utility/enable_if.hpp>
+#include <boost/icl/type_traits/is_interval_container.hpp>
+#include <boost/icl/concept/interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= AlgoUnifiers<Set>
+//==============================================================================
+template<class Type, class Iterator>
+inline typename enable_if<is_interval_set<Type>, typename Type::codomain_type>::type
+co_value(Iterator value_)
+{ 
+    typedef typename Type::codomain_type codomain_type;
+    return icl::is_empty(*value_)? codomain_type() : (*value_).lower(); 
+}
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/joinable.hpp
+++ b/inst/include/boost/icl/concept/joinable.hpp
@@ -1,0 +1,41 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_JOINABLE_HPP_JOFA_100920
+#define BOOST_ICL_CONCEPT_JOINABLE_HPP_JOFA_100920
+
+#include <boost/icl/type_traits/is_interval_container.hpp>
+#include <boost/icl/concept/interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+namespace segmental
+{
+    template<class Type>
+    typename enable_if<is_interval_set<Type>, bool>::type
+    is_joinable(typename Type::iterator it_, typename Type::iterator next_, Type* = 0)
+    {
+        return touches(*it_, *next_);
+    }
+
+    template<class Type>
+    typename enable_if<is_interval_map<Type>, bool>::type
+    is_joinable(typename Type::iterator it_, typename Type::iterator next_, Type* = 0)
+    {
+        return touches((*it_).first, (*next_).first)
+            && (*it_).second == (*next_).second    ;
+    }
+}
+
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/map_value.hpp
+++ b/inst/include/boost/icl/concept/map_value.hpp
@@ -1,0 +1,61 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_MAP_VALUE_HPP_JOFA_100924
+#define BOOST_ICL_CONCEPT_MAP_VALUE_HPP_JOFA_100924
+
+#include <boost/icl/type_traits/predicate.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= AlgoUnifiers<Map>
+//==============================================================================
+template<class Type, class Iterator>
+inline typename enable_if<is_map<Type>, const typename Type::key_type>::type&
+key_value(Iterator it_)
+{
+    return (*it_).first;
+}
+
+template<class Type, class Iterator>
+inline typename enable_if<is_map<Type>, const typename Type::codomain_type>::type&
+co_value(Iterator it_)
+{
+    return (*it_).second;
+}
+
+template<class Type>
+inline typename enable_if<is_map<Type>, typename Type::value_type>::type
+make_value(const typename Type::     key_type& key_val, 
+           const typename Type::codomain_type&  co_val)
+{
+    return typename Type::value_type(key_val, co_val);
+}
+
+
+template <class Type>
+class content_is_identity_element: public property<Type>
+{
+public:
+    bool operator() (const Type& value_pair)const 
+    { 
+        return value_pair.second 
+            == identity_element<typename Type::second_type>::value(); 
+    }
+} ;
+
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/concept/set_value.hpp
+++ b/inst/include/boost/icl/concept/set_value.hpp
@@ -1,0 +1,40 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_SET_VALUE_HPP_JOFA_100924
+#define BOOST_ICL_CONCEPT_SET_VALUE_HPP_JOFA_100924
+
+#include <boost/icl/type_traits/is_set.hpp>
+#include <boost/icl/type_traits/codomain_type_of.hpp>
+
+namespace boost{ namespace icl
+{
+
+//==============================================================================
+//= AlgoUnifiers<Set>
+//==============================================================================
+template<class Type, class Iterator>
+inline typename enable_if<is_set<Type>, const typename Type::key_type>::type&
+key_value(Iterator it_)
+{
+    return *it_;
+}
+
+template<class Type>
+inline typename enable_if<is_set<Type>, typename Type::value_type>::type
+make_value(const typename Type::key_type& key_val, 
+           const typename codomain_type_of<Type>::type& )
+{
+    return typename Type::value_type(key_val);
+}
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/continuous_interval.hpp
+++ b/inst/include/boost/icl/continuous_interval.hpp
@@ -1,0 +1,172 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONTINUOUS_INTERVAL_HPP_JOFA_100327
+#define BOOST_ICL_CONTINUOUS_INTERVAL_HPP_JOFA_100327
+
+#include <functional> 
+#include <boost/static_assert.hpp> 
+#include <boost/concept/assert.hpp>
+#include <boost/icl/detail/concept_check.hpp>
+#include <boost/icl/concept/interval.hpp>
+#include <boost/icl/concept/container.hpp>
+#include <boost/icl/type_traits/value_size.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+#include <boost/icl/type_traits/is_continuous.hpp>
+#include <boost/icl/type_traits/is_continuous_interval.hpp>
+#include <boost/icl/interval_bounds.hpp>
+
+namespace boost{namespace icl
+{
+
+template <class DomainT, 
+          ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)>
+class continuous_interval
+{
+public:
+    typedef continuous_interval<DomainT,Compare> type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef typename bounded_value<DomainT>::type bounded_domain_type;
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor; yields an empty interval <tt>[0,0)</tt>. */
+    continuous_interval()
+        : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value())
+        , _bounds(interval_bounds::right_open())
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((icl::is_continuous<DomainT>::value)); 
+    }
+
+    //NOTE: Compiler generated copy constructor is used
+
+    /** Constructor for a closed singleton interval <tt>[val,val]</tt> */
+    explicit continuous_interval(const DomainT& val)
+        : _lwb(val), _upb(val), _bounds(interval_bounds::closed())
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((icl::is_continuous<DomainT>::value));
+    }
+
+    /** Interval from <tt>low</tt> to <tt>up</tt> with bounds <tt>bounds</tt> */
+    continuous_interval(const DomainT& low, const DomainT& up, 
+                      interval_bounds bounds = interval_bounds::right_open(),
+                      continuous_interval* = 0)
+        : _lwb(low), _upb(up), _bounds(bounds)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((icl::is_continuous<DomainT>::value));
+    }
+
+    domain_type     lower()const { return _lwb; }
+    domain_type     upper()const { return _upb; }
+    interval_bounds bounds()const{ return _bounds; }
+
+    static continuous_interval open     (const DomainT& lo, const DomainT& up){ return continuous_interval(lo, up, interval_bounds::open());      }
+    static continuous_interval right_open(const DomainT& lo, const DomainT& up){ return continuous_interval(lo, up, interval_bounds::right_open());}
+    static continuous_interval left_open (const DomainT& lo, const DomainT& up){ return continuous_interval(lo, up, interval_bounds::left_open()); }
+    static continuous_interval closed   (const DomainT& lo, const DomainT& up){ return continuous_interval(lo, up, interval_bounds::closed());    }
+
+private:
+    domain_type     _lwb;
+    domain_type     _upb;
+    interval_bounds _bounds;
+};
+
+
+//==============================================================================
+//=T continuous_interval -> concept interval
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct interval_traits< icl::continuous_interval<DomainT, Compare> >
+{
+    typedef interval_traits type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef icl::continuous_interval<DomainT, Compare> interval_type;
+
+    static interval_type construct(const domain_type& lo, const domain_type& up)
+    {
+        return interval_type(lo, up);
+    }
+
+    static domain_type lower(const interval_type& inter_val){ return inter_val.lower(); };
+    static domain_type upper(const interval_type& inter_val){ return inter_val.upper(); };
+};
+
+
+//==============================================================================
+//=T continuous_interval -> concept dynamic_interval
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct dynamic_interval_traits<boost::icl::continuous_interval<DomainT,Compare> >
+{
+    typedef dynamic_interval_traits type;
+    typedef boost::icl::continuous_interval<DomainT,Compare> interval_type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+
+    static interval_type construct(const domain_type lo, const domain_type up, interval_bounds bounds)
+    {
+        return icl::continuous_interval<DomainT,Compare>(lo, up, bounds,
+            static_cast<icl::continuous_interval<DomainT,Compare>* >(0) );
+    }
+
+    static interval_type construct_bounded(const bounded_value<DomainT>& lo, 
+                                           const bounded_value<DomainT>& up)
+    {
+        return  icl::continuous_interval<DomainT,Compare>
+                (
+                    lo.value(), up.value(),
+                    lo.bound().left() | up.bound().right(),
+                    static_cast<icl::continuous_interval<DomainT,Compare>* >(0) 
+                );
+    }
+};
+
+//==============================================================================
+//= Type traits
+//==============================================================================
+template <class DomainT, ICL_COMPARE Compare> 
+struct interval_bound_type< continuous_interval<DomainT,Compare> >
+{
+    typedef interval_bound_type type;
+    BOOST_STATIC_CONSTANT(bound_type, value = interval_bounds::dynamic);
+};
+
+template <class DomainT, ICL_COMPARE Compare> 
+struct is_continuous_interval<continuous_interval<DomainT,Compare> >
+{
+    typedef is_continuous_interval<continuous_interval<DomainT,Compare> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+template <class DomainT, ICL_COMPARE Compare>
+struct type_to_string<icl::continuous_interval<DomainT,Compare> >
+{
+    static std::string apply()
+    { return "cI<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+template<class DomainT> 
+struct value_size<icl::continuous_interval<DomainT> >
+{
+    static std::size_t apply(const icl::continuous_interval<DomainT>&) 
+    { return 2; }
+};
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/detail/associated_value.hpp
+++ b/inst/include/boost/icl/detail/associated_value.hpp
@@ -1,0 +1,43 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DETAIL_ASSOCIATED_VALUE_HPP_JOFA_100829
+#define BOOST_ICL_DETAIL_ASSOCIATED_VALUE_HPP_JOFA_100829
+
+#include <boost/icl/detail/design_config.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/mpl/and.hpp>
+
+namespace boost{namespace icl
+{
+
+template<class Type, class CoType> 
+typename enable_if< mpl::and_< is_key_compare_equal<Type,CoType>
+                             , mpl::and_<is_map<Type>, is_map<CoType> > >, 
+                    bool>::type
+co_equal(typename Type::const_iterator left_, typename CoType::const_iterator right_, 
+         const Type* = 0, const CoType* = 0)
+{
+    return co_value<Type>(left_) == co_value<CoType>(right_);
+}
+
+template<class Type, class CoType> 
+typename enable_if< mpl::and_< is_key_compare_equal<Type,CoType>
+                             , mpl::not_<mpl::and_<is_map<Type>, is_map<CoType> > > >,
+                  bool>::type
+co_equal(typename Type::const_iterator, typename CoType::const_iterator,
+         const Type* = 0, const CoType* = 0)
+{
+    return true;
+}
+
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/detail/boost_config.hpp
+++ b/inst/include/boost/icl/detail/boost_config.hpp
@@ -1,0 +1,26 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DETAIL_BOOST_CONFIG_HPP_JOFA_101031
+#define BOOST_ICL_DETAIL_BOOST_CONFIG_HPP_JOFA_101031
+
+// Since boost_1_44_0 boost/config.hpp can produce warnings too.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4996) // Function call with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct. To disable this warning, use -D_SCL_SECURE_NO_WARNINGS. See documentation on how to use Visual C++ 'Checked Iterators'
+#endif
+
+#include <boost/config.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+
+#endif
+
+

--- a/inst/include/boost/icl/detail/concept_check.hpp
+++ b/inst/include/boost/icl/detail/concept_check.hpp
@@ -1,0 +1,31 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2009-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_CONCEPT_CHECK_HPP_JOFA_090913
+#define BOOST_ICL_CONCEPT_CHECK_HPP_JOFA_090913
+
+#include <boost/concept_check.hpp>
+
+#include <boost/concept/detail/concept_def.hpp>
+namespace boost{ namespace icl
+{
+
+    BOOST_concept(EqualComparable,(Type))
+    {
+        BOOST_CONCEPT_USAGE(EqualComparable) {
+            require_boolean_expr(_left == _right);
+        }
+    private:
+        Type _left, _right;
+    };
+
+}}// namespace boost icl
+#include <boost/concept/detail/concept_undef.hpp>
+
+#endif
+
+

--- a/inst/include/boost/icl/detail/design_config.hpp
+++ b/inst/include/boost/icl/detail/design_config.hpp
@@ -1,0 +1,113 @@
+/*-----------------------------------------------------------------------------+
+Author: Joachim Faulhaber
+Copyright (c) 2009-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------------+
+Template parameters of major itl class templates can be designed as
+template template parameters or
+template type parameter
+by setting defines in this file.
++-----------------------------------------------------------------------------*/
+#ifndef  BOOST_ICL_DESIGN_CONFIG_HPP_JOFA_090214
+#define  BOOST_ICL_DESIGN_CONFIG_HPP_JOFA_090214
+
+// If this macro is defined, right_open_interval with static interval borders
+// will be used as default for all interval containers. 
+// BOOST_ICL_USE_STATIC_BOUNDED_INTERVALS should be defined in the application
+// before other includes from the ITL
+//#define BOOST_ICL_USE_STATIC_BOUNDED_INTERVALS
+// If BOOST_ICL_USE_STATIC_BOUNDED_INTERVALS is NOT defined, ITL uses intervals
+// with dynamic borders as default.
+
+
+//------------------------------------------------------------------------------
+// Auxiliary macros for denoting template signatures.
+// Purpose:
+// (1) Shorten the lenthy and redundant template signatures.
+// (2) Name anonymous template types according to their meaning ...
+// (3) Making easier to refactor by redefinitin of the macros
+// (4) Being able to check template template parameter variants against
+//     template type parameter variants.
+
+#define ICL_USE_COMPARE_TEMPLATE_TEMPLATE
+#define ICL_USE_COMBINE_TEMPLATE_TEMPLATE
+#define ICL_USE_SECTION_TEMPLATE_TEMPLATE
+//      ICL_USE_INTERVAL_TEMPLATE_TYPE
+
+//------------------------------------------------------------------------------
+// template parameter Compare can not be a template type parameter as long as
+// Compare<Interval<DomainT,Compare> >() is called in std::lexicographical_compare
+// implementing operator< for interval_base_{set,map}. see NOTE DESIGN TTP
+#ifdef ICL_USE_COMPARE_TEMPLATE_TEMPLATE
+#   define ICL_COMPARE template<class>class
+#   define ICL_COMPARE_DOMAIN(itl_compare, domain_type) itl_compare<domain_type> 
+#   define ICL_COMPARE_INSTANCE(compare_instance, domain_type) compare_instance
+#   define ICL_EXCLUSIVE_LESS(interval_type) exclusive_less_than
+#else//ICL_USE_COMPARE_TEMPLATE_TYPE
+#   define ICL_COMPARE class
+#   define ICL_COMPARE_DOMAIN(itl_compare, domain_type) itl_compare 
+#   define ICL_COMPARE_INSTANCE(compare_instance, domain_type) compare_instance<domain_type> 
+#   define ICL_EXCLUSIVE_LESS(interval_type) exclusive_less_than<interval_type>
+#endif
+
+//------------------------------------------------------------------------------
+// template parameter Combine could be a template type parameter.
+#ifdef ICL_USE_COMBINE_TEMPLATE_TEMPLATE
+#   define ICL_COMBINE template<class>class
+#   define ICL_COMBINE_CODOMAIN(itl_combine, codomain_type) itl_combine<codomain_type> 
+#   define ICL_COMBINE_INSTANCE(combine_instance,codomain_type) combine_instance
+#else//ICL_USE_COMBINE_TEMPLATE_TYPE
+#   define ICL_COMBINE class
+#   define ICL_COMBINE_CODOMAIN(itl_combine, codomain_type) itl_combine 
+#   define ICL_COMBINE_INSTANCE(combine_instance,codomain_type) combine_instance<codomain_type>
+#endif
+
+//------------------------------------------------------------------------------
+// template parameter Section could be a template type parameter.
+#ifdef ICL_USE_SECTION_TEMPLATE_TEMPLATE
+#   define ICL_SECTION template<class>class
+#   define ICL_SECTION_CODOMAIN(itl_intersect, codomain_type) itl_intersect<codomain_type> 
+#   define ICL_SECTION_INSTANCE(section_instance,codomain_type) section_instance
+#else//ICL_USE_SECTION_TEMPLATE_TYPE
+#   define ICL_SECTION class
+#   define ICL_SECTION_CODOMAIN(itl_intersect, codomain_type) itl_intersect 
+#   define ICL_SECTION_INSTANCE(section_instance,codomain_type) section_instance<codomain_type>
+#endif
+
+
+//------------------------------------------------------------------------------
+// template parameter Interval could be a template type parameter.
+#ifdef ICL_USE_INTERVAL_TEMPLATE_TEMPLATE
+#   define ICL_INTERVAL(itl_compare) template<class,itl_compare>class
+#   define ICL_INTERVAL2(itl_compare) template<class DomT2,itl_compare>class
+#   define ICL_INTERVAL_TYPE(itl_interval, domain_type, itl_compare) itl_interval<domain_type,itl_compare> 
+#   define ICL_INTERVAL_INSTANCE(interval_instance,domain_type,itl_compare) interval_instance
+#else//ICL_USE_INTERVAL_TEMPLATE_TYPE
+#   define ICL_INTERVAL(itl_compare) class
+#   define ICL_INTERVAL2(itl_compare) class
+#   define ICL_INTERVAL_TYPE(itl_interval, domain_type, itl_compare) itl_interval  
+#   define ICL_INTERVAL_INSTANCE(interval_instance,domain_type,itl_compare) typename interval_instance<domain_type,itl_compare>::type
+#endif
+
+
+//------------------------------------------------------------------------------
+#define ICL_ALLOC    template<class>class
+
+//------------------------------------------------------------------------------
+#define ICL_INTERVAL_DEFAULT boost::icl::interval_type_default
+
+#ifndef BOOST_ICL_USE_COMPARE_STD_GREATER
+#   define ICL_COMPARE_DEFAULT std::less
+#else
+#   define ICL_COMPARE_DEFAULT std::greater
+#endif
+
+//------------------------------------------------------------------------------
+
+#endif // BOOST_ICL_DESIGN_CONFIG_HPP_JOFA_090214
+
+

--- a/inst/include/boost/icl/detail/element_comparer.hpp
+++ b/inst/include/boost/icl/detail/element_comparer.hpp
@@ -1,0 +1,210 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_ELEMENT_COMPARER_HPP_JOFA_090202
+#define BOOST_ICL_ELEMENT_COMPARER_HPP_JOFA_090202
+
+#include <boost/mpl/and.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+
+namespace boost{namespace icl
+{
+
+namespace Interval_Set
+{
+
+template<class LeftT, class RightT>
+class element_comparer
+{
+public:
+    typedef typename LeftT::const_iterator  LeftIterT;
+    typedef typename RightT::const_iterator RightIterT;
+
+    BOOST_STATIC_CONSTANT(bool, 
+        _compare_codomain = (mpl::and_<is_map<LeftT>, is_map<RightT> >::value)); 
+
+    element_comparer(const LeftT&      left,
+                     const RightT&     right,
+                     const LeftIterT&  left_end,
+                     const RightIterT& right_end)
+        : _left(left), _right(right),
+          _left_end(left_end), _right_end(right_end), _result(equal)
+    {}
+
+    enum{nextboth, nextleft, nextright, stop};
+
+    enum
+    {
+        less    = comparison::less, 
+        equal   = comparison::equal, 
+        greater = comparison::greater
+    };
+
+    int result()const{ return _result; }
+
+    bool covalues_are_equal(LeftIterT& left, RightIterT& right)
+    {
+        if(co_value<LeftT>(left) < co_value<RightT>(right))
+            _result = less;
+        if(co_value<RightT>(right) < co_value<LeftT>(left))
+            _result = greater;
+        return _result == equal;
+    }
+
+    int proceed(LeftIterT& left, RightIterT& right)
+    {
+        if(upper_less(key_value<LeftT>(left), key_value<RightT>(right)))
+        {
+            _prior_left = left;
+            ++left;
+            return nextleft;
+        }
+        else if(upper_less(key_value<RightT>(right), key_value<LeftT>(left)))
+        {
+            _prior_right = right;
+            ++right;
+            return nextright;
+        }
+        else
+        {
+            ++left; 
+            ++right;    
+            return nextboth;
+        }
+    }
+
+    int next_both(LeftIterT& left, RightIterT& right)
+    {
+        if(left == _left_end)
+        {
+            _result = (right == _right_end) ? equal : less;
+            return stop;
+        }
+
+        // left != _left_end
+        if(right == _right_end)
+        {
+            _result = greater;
+            return stop;
+        }
+
+        // The starting intervals have to begin equally
+        if(lower_less(key_value<LeftT>(left), key_value<RightT>(right)))
+        {   // left: same A... = sameA...
+            // right:same  B.. = sameB...
+            _result = less;
+            return stop;
+        }
+
+        if(lower_less(key_value<LeftT>(right), key_value<RightT>(left)))
+        {   // left: same  B.. = sameB...
+            // right:same A... = sameA...
+            _result = greater;
+            return stop;
+        }
+
+        if(_compare_codomain && !covalues_are_equal(left, right))
+            return stop;
+
+        return proceed(left, right);
+    }
+
+    int next_left(LeftIterT& left, RightIterT& right)
+    {
+        if(left == _left_end)
+        {   // left: same
+            // right:sameA...
+            _result = less;
+            return stop;
+        }
+
+        if(!key_value<LeftT>(_prior_left).touches(key_value<LeftT>(left)))
+        {   // left: same B = sameB...
+            // right:sameA  = sameA...
+            _result = greater;
+            return stop;
+        }
+
+        if(_compare_codomain && !covalues_are_equal(left, right))
+            return stop;
+
+        return proceed(left, right);
+    }
+
+    int next_right(LeftIterT& left, RightIterT& right)
+    {
+        if(right == _right_end)
+        {   // left: sameA...
+            // right:same
+            _result = greater;
+            return stop;
+        }
+
+        if(!key_value<RightT>(_prior_right).touches(key_value<RightT>(right)))
+        {
+            // left: sameA... = sameA...
+            // right:same B.. = sameB...
+            _result = less;
+            return stop;
+        }
+
+        if(_compare_codomain && !covalues_are_equal(left, right))
+            return stop;
+
+        return proceed(left, right);
+    }
+
+private:
+    const LeftT&  _left;
+    const RightT& _right;
+    LeftIterT     _left_end;
+    RightIterT    _right_end;
+    LeftIterT     _prior_left;
+    RightIterT    _prior_right;
+    int           _result;
+};
+
+
+
+template<class LeftT, class RightT>
+int element_compare
+(
+    const LeftT& left,   //sub
+    const RightT& right, //super
+    typename LeftT::const_iterator  left_begin,   
+    typename LeftT::const_iterator  left_end,
+    typename RightT::const_iterator right_begin, 
+    typename RightT::const_iterator right_end
+)
+{
+    typedef element_comparer<LeftT,RightT> Step;
+    Step step(left, right, left_end, right_end);
+
+    typename LeftT::const_iterator  left_  = left_begin;
+    typename RightT::const_iterator right_ = right_begin;
+
+    int state = Step::nextboth;
+    while(state != Step::stop)
+    {
+        switch(state){
+        case Step::nextboth:  state = step.next_both (left_, right_); break;
+        case Step::nextleft:  state = step.next_left (left_, right_); break;
+        case Step::nextright: state = step.next_right(left_, right_); break;
+        }
+    }
+    return step.result();
+}
+
+
+} // namespace Interval_Set
+    
+}} // namespace icl boost
+
+#endif 
+

--- a/inst/include/boost/icl/detail/element_iterator.hpp
+++ b/inst/include/boost/icl/detail/element_iterator.hpp
@@ -1,0 +1,335 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2009-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DETAIL_ELEMENT_ITERATOR_HPP_JOFA_091104
+#define BOOST_ICL_DETAIL_ELEMENT_ITERATOR_HPP_JOFA_091104
+
+#include <boost/mpl/if.hpp>
+#include <boost/iterator/iterator_facade.hpp>
+#include <boost/config/warning_disable.hpp>
+#include <boost/icl/type_traits/succ_pred.hpp>
+#include <boost/icl/detail/mapped_reference.hpp>
+
+namespace boost{namespace icl
+{
+
+//------------------------------------------------------------------------------
+template<class Type>
+struct is_std_pair
+{ 
+    typedef is_std_pair<Type> type; 
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+template<class FirstT, class SecondT>
+struct is_std_pair<std::pair<FirstT, SecondT> >
+{ 
+    typedef is_std_pair<std::pair<FirstT, SecondT> > type; 
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+
+//------------------------------------------------------------------------------
+template<class Type>
+struct first_element
+{ 
+    typedef Type type; 
+};
+
+template<class FirstT, class SecondT>
+struct first_element<std::pair<FirstT, SecondT> >
+{ 
+    typedef FirstT type; 
+};
+
+//------------------------------------------------------------------------------
+template <class SegmentIteratorT> class element_iterator;
+
+template<class IteratorT>
+struct is_reverse
+{ 
+    typedef is_reverse type; 
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+template<class BaseIteratorT>
+struct is_reverse<std::reverse_iterator<BaseIteratorT> >
+{ 
+    typedef is_reverse<std::reverse_iterator<BaseIteratorT> > type; 
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+template<class BaseIteratorT>
+struct is_reverse<icl::element_iterator<BaseIteratorT> >
+{ 
+    typedef is_reverse<icl::element_iterator<BaseIteratorT> > type; 
+    BOOST_STATIC_CONSTANT(bool, value = is_reverse<BaseIteratorT>::value);
+};
+
+//------------------------------------------------------------------------------
+template<class SegmentT>
+struct elemental;
+
+#ifdef ICL_USE_INTERVAL_TEMPLATE_TEMPLATE
+
+    template<class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval>
+    struct elemental<ICL_INTERVAL_TYPE(Interval,DomainT,Compare) >
+    {
+        typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) segment_type;
+        typedef segment_type              interval_type;
+        typedef DomainT                   type;
+        typedef DomainT                   domain_type;
+        typedef DomainT                   codomain_type;
+        typedef DomainT                   transit_type;
+    };
+
+    template< class DomainT, class CodomainT, 
+              ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval >
+    struct elemental<std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+    {
+        typedef std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare), CodomainT> segment_type;
+        typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)                       interval_type;
+        typedef std::pair<DomainT, CodomainT>                   type;
+        typedef DomainT                                         domain_type;
+        typedef CodomainT                                       codomain_type;
+        typedef mapped_reference<DomainT, CodomainT>            transit_type;
+    };
+
+#else //ICL_USE_INTERVAL_TEMPLATE_TYPE
+
+    template<ICL_INTERVAL(ICL_COMPARE) Interval>
+    struct elemental
+    {
+        typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) segment_type;
+        typedef segment_type                        interval_type;
+        typedef typename interval_traits<interval_type>::domain_type domain_type;
+        typedef domain_type                         type;
+        typedef domain_type                         codomain_type;
+        typedef domain_type                         transit_type;
+    };
+
+    template< class CodomainT, ICL_INTERVAL(ICL_COMPARE) Interval >
+    struct elemental<std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+    {
+        typedef std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare), CodomainT> segment_type;
+        typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)                       interval_type;
+        typedef typename interval_traits<interval_type>::domain_type domain_type;
+        typedef CodomainT                                       codomain_type;
+        typedef std::pair<domain_type, codomain_type>           type;
+        typedef mapped_reference<domain_type, codomain_type>    transit_type;
+    };
+
+#endif //ICL_USE_INTERVAL_TEMPLATE_TEMPLATE
+
+
+//------------------------------------------------------------------------------
+//- struct segment_adapter
+//------------------------------------------------------------------------------
+template<class SegmentIteratorT, class SegmentT>
+struct segment_adapter;
+
+#ifdef ICL_USE_INTERVAL_TEMPLATE_TEMPLATE
+
+template<class SegmentIteratorT, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval>
+struct segment_adapter<SegmentIteratorT, ICL_INTERVAL_TYPE(Interval,DomainT,Compare) >
+{
+    typedef segment_adapter                         type;
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) segment_type;
+    typedef segment_type                            interval_type;
+    typedef typename interval_type::difference_type domain_difference_type;
+    typedef DomainT                                 domain_type;
+    typedef DomainT                                 codomain_type;
+    typedef domain_type                             element_type;
+    typedef domain_type&                            transit_type;
+
+    static domain_type     first (const SegmentIteratorT& leaper){ return leaper->first(); } 
+    static domain_type     last  (const SegmentIteratorT& leaper){ return leaper->last();  } 
+    static domain_difference_type length(const SegmentIteratorT& leaper){ return leaper->length();}
+
+    static transit_type transient_element(domain_type& inter_pos, const SegmentIteratorT& leaper, 
+                                          const domain_difference_type& sneaker)
+    { 
+        inter_pos = is_reverse<SegmentIteratorT>::value ? leaper->last()  - sneaker
+                                                        : leaper->first() + sneaker;
+        return inter_pos; 
+    }
+};
+
+template < class SegmentIteratorT, class DomainT, class CodomainT, 
+           ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval >
+struct segment_adapter<SegmentIteratorT, std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+{
+    typedef segment_adapter                         type;
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)               interval_type;
+    typedef DomainT                                 domain_type;
+    typedef std::pair<DomainT, CodomainT>           element_type;
+    typedef CodomainT                               codomain_type;
+    typedef mapped_reference<DomainT, CodomainT>    transit_type;    
+    typedef typename difference_type_of<interval_traits<interval_type> >::type 
+                                                    domain_difference_type;
+
+    static domain_type     first (const SegmentIteratorT& leaper){ return leaper->first.first(); } 
+    static domain_type     last  (const SegmentIteratorT& leaper){ return leaper->first.last();  } 
+    static domain_difference_type length(const SegmentIteratorT& leaper){ return leaper->first.length();}
+
+    static transit_type transient_element(domain_type& inter_pos, const SegmentIteratorT& leaper,
+                                          const domain_difference_type& sneaker)
+    {
+        inter_pos = is_reverse<SegmentIteratorT>::value ? leaper->first.last()  - sneaker
+                                                        : leaper->first.first() + sneaker;
+        return transit_type(inter_pos, leaper->second); 
+    }
+};
+
+#else // ICL_USE_INTERVAL_TEMPLATE_TYPE
+
+template<class SegmentIteratorT, ICL_INTERVAL(ICL_COMPARE) Interval>
+struct segment_adapter 
+{
+    typedef segment_adapter                          type;
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) segment_type;
+    typedef segment_type                             interval_type;
+    typedef typename interval_traits<interval_type>::domain_type domain_type;
+    typedef domain_type                              codomain_type;
+    typedef domain_type                              element_type;
+    typedef domain_type&                             transit_type;
+    typedef typename difference_type_of<interval_traits<interval_type> >::type 
+                                                     domain_difference_type;
+
+    static domain_type     first (const SegmentIteratorT& leaper){ return leaper->first(); } 
+    static domain_type     last  (const SegmentIteratorT& leaper){ return leaper->last();  } 
+    static domain_difference_type length(const SegmentIteratorT& leaper){ return icl::length(*leaper);}
+
+    static transit_type transient_element(domain_type& inter_pos, const SegmentIteratorT& leaper, 
+                                          const domain_difference_type& sneaker)
+    { 
+        inter_pos = is_reverse<SegmentIteratorT>::value ? icl::last(*leaper)  - sneaker
+                                                        : icl::first(*leaper) + sneaker;
+        return inter_pos; 
+    }
+};
+
+template < class SegmentIteratorT, class CodomainT, ICL_INTERVAL(ICL_COMPARE) Interval >
+struct segment_adapter<SegmentIteratorT, std::pair<ICL_INTERVAL_TYPE(Interval,DomainT,Compare)const, CodomainT> >
+{
+    typedef segment_adapter                                type;
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare)    interval_type;
+    typedef typename interval_traits<interval_type>::domain_type domain_type;
+    typedef CodomainT                                      codomain_type;
+    typedef std::pair<domain_type, codomain_type>          element_type;
+    typedef mapped_reference<domain_type, CodomainT>       transit_type;    
+    typedef typename difference_type_of<interval_traits<interval_type> >::type 
+                                                           domain_difference_type;
+
+    static domain_type     first (const SegmentIteratorT& leaper){ return leaper->first.first(); } 
+    static domain_type     last  (const SegmentIteratorT& leaper){ return leaper->first.last();  } 
+    static domain_difference_type length(const SegmentIteratorT& leaper){ return icl::length(leaper->first);}
+
+    static transit_type transient_element(domain_type& inter_pos, const SegmentIteratorT& leaper,
+                                          const domain_difference_type& sneaker)
+    {
+        inter_pos = is_reverse<SegmentIteratorT>::value ? icl::last(leaper->first)  - sneaker
+                                                        : icl::first(leaper->first) + sneaker;
+        return transit_type(inter_pos, leaper->second); 
+    }
+};
+
+#endif // ICL_USE_INTERVAL_TEMPLATE_TEMPLATE
+
+template <class SegmentIteratorT>
+class element_iterator
+  : public boost::iterator_facade<
+          element_iterator<SegmentIteratorT>
+        , typename elemental<typename SegmentIteratorT::value_type>::transit_type
+        , boost::bidirectional_traversal_tag
+        , typename elemental<typename SegmentIteratorT::value_type>::transit_type
+    >
+{
+public:
+    typedef element_iterator                                type;
+    typedef SegmentIteratorT                                segment_iterator;
+    typedef typename SegmentIteratorT::value_type           segment_type;
+    typedef typename first_element<segment_type>::type      interval_type;
+    typedef typename elemental<segment_type>::type          element_type;
+    typedef typename elemental<segment_type>::domain_type   domain_type;
+    typedef typename elemental<segment_type>::codomain_type codomain_type;
+    typedef typename elemental<segment_type>::transit_type  transit_type;
+    typedef transit_type                                    value_type;
+    typedef typename difference_type_of<interval_traits<interval_type> >::type 
+                                                            domain_difference_type;
+
+private:
+    typedef typename segment_adapter<segment_iterator,segment_type>::type adapt;
+
+    struct enabler{};
+
+public:
+    element_iterator()
+        : _saltator(identity_element<segment_iterator>::value())
+        , _reptator(identity_element<domain_difference_type>::value()){}
+
+    explicit element_iterator(segment_iterator jumper)
+        : _saltator(jumper), _reptator(identity_element<domain_difference_type>::value()) {}
+
+    template <class SaltatorT>
+    element_iterator
+        ( element_iterator<SaltatorT> const& other
+        , typename enable_if<boost::is_convertible<SaltatorT*,SegmentIteratorT*>, enabler>::type = enabler())
+        : _saltator(other._saltator), _reptator(other._reptator) {}
+
+private:
+    friend class boost::iterator_core_access;
+    template <class> friend class element_iterator;
+
+    template <class SaltatorT>
+    bool equal(element_iterator<SaltatorT> const& other) const
+    {
+        return this->_saltator == other._saltator
+            && this->_reptator == other._reptator;
+    }
+
+    void increment()
+    { 
+        if(_reptator < icl::pred(adapt::length(_saltator)))
+            ++_reptator; 
+        else
+        {
+            ++_saltator;
+            _reptator = identity_element<domain_difference_type>::value();
+        }
+    }
+
+    void decrement()
+    { 
+        if(identity_element<domain_difference_type>::value() < _reptator)
+            --_reptator; 
+        else
+        {
+            --_saltator;
+            _reptator = adapt::length(_saltator);
+            --_reptator;
+        }
+    }
+
+    value_type dereference()const
+    {
+        return adapt::transient_element(_inter_pos, _saltator, _reptator);
+    }
+
+private:
+    segment_iterator               _saltator;  // satltare: to jump  : the fast moving iterator
+    mutable domain_difference_type _reptator;  // reptare:  to sneak : the slow moving iterator 0 based
+    mutable domain_type            _inter_pos; // inter position : Position within the current segment
+                                               // _saltator->first.first() <= _inter_pos <= _saltator->first.last() 
+};
+
+}} // namespace icl boost
+
+#endif // BOOST_ICL_DETAIL_ELEMENT_ITERATOR_HPP_JOFA_091104
+
+
+

--- a/inst/include/boost/icl/detail/exclusive_less_than.hpp
+++ b/inst/include/boost/icl/detail/exclusive_less_than.hpp
@@ -1,0 +1,31 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DETAIL_EXCLUSIVE_LESS_THAN_HPP_JOFA_100929
+#define BOOST_ICL_DETAIL_EXCLUSIVE_LESS_THAN_HPP_JOFA_100929
+
+#include <boost/icl/concept/interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+/// Comparison functor on intervals implementing an overlap free less 
+template <class IntervalT>
+struct exclusive_less_than 
+{
+    /** Operator <tt>operator()</tt> implements a strict weak ordering on intervals. */
+    bool operator()(const IntervalT& left, const IntervalT& right)const
+    { 
+        return icl::non_empty::exclusive_less(left, right); 
+    }
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/detail/interval_map_algo.hpp
+++ b/inst/include/boost/icl/detail/interval_map_algo.hpp
@@ -1,0 +1,171 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_MAP_ALGO_HPP_JOFA_100730
+#define BOOST_ICL_INTERVAL_MAP_ALGO_HPP_JOFA_100730
+
+#include <boost/utility/enable_if.hpp>
+#include <boost/mpl/not.hpp>
+
+#include <boost/icl/type_traits/is_total.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/detail/relation_state.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/interval_combining_style.hpp>
+#include <boost/icl/detail/element_comparer.hpp>
+#include <boost/icl/detail/interval_subset_comparer.hpp>
+
+namespace boost{namespace icl
+{
+
+
+namespace Interval_Map
+{
+using namespace segmental;
+
+template<class IntervalMapT>
+bool is_joinable(const IntervalMapT& container, 
+                 typename IntervalMapT::const_iterator first, 
+                 typename IntervalMapT::const_iterator past) 
+{
+    if(first == container.end())
+        return true;
+
+    typename IntervalMapT::const_iterator it_ = first, next_ = first;
+    ++next_;
+
+    const typename IntervalMapT::codomain_type& co_value 
+        = icl::co_value<IntervalMapT>(first);
+    while(it_ != past)
+    {
+        if(icl::co_value<IntervalMapT>(next_) != co_value)
+            return false;
+        if(!icl::touches(key_value<IntervalMapT>(it_++),
+                         key_value<IntervalMapT>(next_++)))
+            return false;
+    }
+
+    return true;
+}
+
+//------------------------------------------------------------------------------
+//- Containedness of key objects
+//------------------------------------------------------------------------------
+
+//- domain_type ----------------------------------------------------------------
+template<class IntervalMapT>
+typename enable_if<mpl::not_<is_total<IntervalMapT> >, bool>::type
+contains(const IntervalMapT& container, 
+         const typename IntervalMapT::domain_type& key) 
+{
+    return container.find(key) != container.end();
+}
+
+template<class IntervalMapT>
+typename enable_if<is_total<IntervalMapT>, bool>::type
+contains(const IntervalMapT&, 
+         const typename IntervalMapT::domain_type&) 
+{
+    return true;
+}
+
+//- interval_type --------------------------------------------------------------
+template<class IntervalMapT>
+typename enable_if<mpl::not_<is_total<IntervalMapT> >, bool>::type
+contains(const IntervalMapT& container, 
+         const typename IntervalMapT::interval_type& sub_interval) 
+{
+    typedef typename IntervalMapT::const_iterator const_iterator;
+    if(icl::is_empty(sub_interval)) 
+        return true;
+
+    std::pair<const_iterator, const_iterator> exterior = container.equal_range(sub_interval);
+    if(exterior.first == exterior.second)
+        return false;
+
+    const_iterator last_overlap = prior(exterior.second);
+
+    return
+          icl::contains(hull(exterior.first->first, last_overlap->first), sub_interval)
+      &&  Interval_Set::is_joinable(container, exterior.first, last_overlap);
+}
+
+template<class IntervalMapT>
+typename enable_if<is_total<IntervalMapT>, bool>::type
+contains(const IntervalMapT&, 
+         const typename IntervalMapT::interval_type&) 
+{
+    return true;
+}
+
+//- set_type -------------------------------------------------------------------
+template<class IntervalMapT, class IntervalSetT>
+typename enable_if<mpl::and_<mpl::not_<is_total<IntervalMapT> >
+                            ,is_interval_set<IntervalSetT> >, bool>::type
+contains(const IntervalMapT& super_map, const IntervalSetT& sub_set) 
+{
+    return Interval_Set::within(sub_set, super_map);
+}
+
+template<class IntervalMapT, class IntervalSetT>
+typename enable_if<mpl::and_<is_total<IntervalMapT>
+                            ,is_interval_set<IntervalSetT> >, bool>::type
+contains(const IntervalMapT&, const IntervalSetT&) 
+{
+    return true;
+}
+
+
+//------------------------------------------------------------------------------
+//- Containedness of sub objects
+//------------------------------------------------------------------------------
+
+template<class IntervalMapT>
+bool contains(const IntervalMapT& container, 
+              const typename IntervalMapT::element_type& key_value_pair) 
+{
+    typename IntervalMapT::const_iterator it_ = container.find(key_value_pair.key);
+    return it_ != container.end() && (*it_).second == key_value_pair.data;
+}
+
+template<class IntervalMapT>
+bool contains(const IntervalMapT& container, 
+              const typename IntervalMapT::segment_type sub_segment) 
+{
+    typedef typename IntervalMapT::const_iterator const_iterator;
+    typename IntervalMapT::interval_type sub_interval = sub_segment.first;
+    if(icl::is_empty(sub_interval)) 
+        return true;
+
+    std::pair<const_iterator, const_iterator> exterior = container.equal_range(sub_interval);
+    if(exterior.first == exterior.second)
+        return false;
+
+    const_iterator last_overlap = prior(exterior.second);
+
+    if(!(sub_segment.second == exterior.first->second) )
+        return false;
+
+    return
+          icl::contains(hull(exterior.first->first, last_overlap->first), sub_interval)
+      &&  Interval_Map::is_joinable(container, exterior.first, last_overlap);
+}
+
+
+template<class IntervalMapT>
+bool contains(const IntervalMapT& super, const IntervalMapT& sub) 
+{
+    return Interval_Set::within(sub, super);
+}
+
+} // namespace Interval_Map
+
+}} // namespace icl boost
+
+#endif 
+

--- a/inst/include/boost/icl/detail/interval_morphism.hpp
+++ b/inst/include/boost/icl/detail/interval_morphism.hpp
@@ -1,0 +1,107 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DETAIL_INTERVAL_MORPHISM_HPP_JOFA_080315
+#define BOOST_ICL_DETAIL_INTERVAL_MORPHISM_HPP_JOFA_080315
+
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/concept/interval_set_value.hpp>
+#include <boost/icl/concept/element_set_value.hpp>
+#include <boost/icl/concept/set_value.hpp>
+#include <boost/icl/concept/map_value.hpp>
+#include <boost/icl/associative_interval_container.hpp>
+#include <boost/icl/associative_element_container.hpp>
+
+namespace boost{namespace icl
+{
+    namespace segmental
+    {
+        template <typename ElementContainerT, typename IntervalContainerT>
+        void atomize(ElementContainerT& result, const IntervalContainerT& src)
+        {
+            ICL_const_FORALL(typename IntervalContainerT, itv_, src)
+            {
+                const typename IntervalContainerT::key_type& itv   = icl::key_value<IntervalContainerT>(itv_);
+                typename IntervalContainerT::codomain_type   coval = icl::co_value<IntervalContainerT>(itv_);
+
+                for(typename IntervalContainerT::domain_type element = first(itv); element <= last(itv); ++element)
+                    icl::insert(result, icl::make_value<ElementContainerT>(element, coval));
+            }
+        }
+
+        template <typename IntervalContainerT, typename ElementContainerT>
+        void cluster(IntervalContainerT& result, const ElementContainerT& src)
+        {
+            typedef typename IntervalContainerT::key_type key_type;
+            ICL_const_FORALL(typename ElementContainerT, element_, src)
+            {
+                const typename ElementContainerT::key_type&  key  
+                    = key_value<ElementContainerT>(element_);
+                const typename codomain_type_of<ElementContainerT>::type& coval 
+                    = co_value<ElementContainerT>(element_);
+
+                result += icl::make_value<IntervalContainerT>(key_type(key), coval);
+            }
+        }
+
+        template <typename AtomizedType, typename ClusteredType>
+        struct atomizer
+        {
+            void operator()(AtomizedType& atomized, const ClusteredType& clustered)
+            {
+                segmental::atomize(atomized, clustered);
+            }
+        };
+
+        template <typename ClusteredType, typename AtomizedType>
+        struct clusterer
+        {
+            void operator()(ClusteredType& clustered, const AtomizedType& atomized)
+            {
+                segmental::cluster(clustered, atomized);
+            }
+        };
+
+        template <typename JointType, typename SplitType>
+        struct joiner
+        {
+            void operator()(JointType& joint, SplitType& split)
+            {
+                icl::join(split);
+                ICL_FORALL(typename SplitType, split_, split)
+                    joint.insert(*split_);
+            }
+        };
+
+        template <typename AbsorberType, typename EnricherType>
+        struct identity_absorber
+        {
+            void operator()(AbsorberType& absorber, EnricherType& enricher)
+            {
+                icl::absorb_identities(enricher);
+                ICL_FORALL(typename EnricherType, enricher_, enricher)
+                    absorber.insert(*enricher_);
+            }
+        };
+
+    } // namespace Interval
+
+
+    template<> 
+    inline std::string binary_template_to_string<segmental::atomizer>::apply() { return "@"; }
+    template<> 
+    inline std::string binary_template_to_string<segmental::clusterer>::apply() { return "&"; }
+    template<> 
+    inline std::string binary_template_to_string<segmental::joiner>::apply() { return "j"; }
+    template<> 
+    inline std::string binary_template_to_string<segmental::identity_absorber>::apply() { return "a0"; }
+}} // namespace boost icl
+
+#endif // BOOST_ICL_DETAIL_INTERVAL_MORPHISM_HPP_JOFA_080315
+
+
+

--- a/inst/include/boost/icl/detail/interval_set_algo.hpp
+++ b/inst/include/boost/icl/detail/interval_set_algo.hpp
@@ -1,0 +1,648 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_SET_ALGO_HPP_JOFA_081005
+#define BOOST_ICL_INTERVAL_SET_ALGO_HPP_JOFA_081005
+
+#include <boost/next_prior.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/detail/relation_state.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/type_traits/is_total.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/concept/set_value.hpp>
+#include <boost/icl/concept/map_value.hpp>
+#include <boost/icl/interval_combining_style.hpp>
+#include <boost/icl/detail/element_comparer.hpp>
+#include <boost/icl/detail/interval_subset_comparer.hpp>
+#include <boost/icl/detail/associated_value.hpp>
+
+namespace boost{namespace icl
+{
+
+namespace Interval_Set
+{
+
+//------------------------------------------------------------------------------
+// Lexicographical comparison on ranges of two interval container 
+//------------------------------------------------------------------------------
+
+template<class LeftT, class RightT>
+bool is_element_equal(const LeftT& left, const RightT& right)
+{
+    return subset_compare
+            (
+                left, right, 
+                left.begin(), left.end(), 
+                right.begin(), right.end()
+            ) == inclusion::equal;
+}
+
+template<class LeftT, class RightT>
+bool is_element_less(const LeftT& left, const RightT& right)
+{
+    return element_compare
+            (
+                left, right, 
+                left.begin(), left.end(), 
+                right.begin(), right.end()
+            )  == comparison::less;
+}
+
+template<class LeftT, class RightT>
+bool is_element_greater(const LeftT& left, const RightT& right)
+{
+    return element_compare
+            (
+                left, right, 
+                left.begin(), left.end(), 
+                right.begin(), right.end()
+            )  == comparison::greater;
+}
+
+//------------------------------------------------------------------------------
+// Subset/superset compare on ranges of two interval container 
+//------------------------------------------------------------------------------
+
+template<class IntervalContainerT>
+bool is_joinable(const IntervalContainerT& container, 
+                 typename IntervalContainerT::const_iterator first, 
+                 typename IntervalContainerT::const_iterator past) 
+{
+    if(first == container.end())
+        return true;
+
+    typename IntervalContainerT::const_iterator it_ = first, next_ = first;
+    ++next_;
+
+    while(next_ != container.end() && it_ != past)
+        if(!icl::touches(key_value<IntervalContainerT>(it_++),
+                         key_value<IntervalContainerT>(next_++)))
+            return false;
+
+    return true;
+}
+
+
+template<class LeftT, class RightT>
+bool is_inclusion_equal(const LeftT& left, const RightT& right)
+{
+    return subset_compare
+            (
+                left, right, 
+                left.begin(), left.end(), 
+                right.begin(), right.end()
+            ) == inclusion::equal;
+}
+
+template<class LeftT, class RightT>
+typename enable_if<mpl::and_<is_concept_combinable<is_interval_set, is_interval_map, LeftT, RightT>, 
+                             is_total<RightT> >,
+                   bool>::type
+within(const LeftT&, const RightT&)
+{
+    return true;
+}
+
+template<class LeftT, class RightT>
+typename enable_if<mpl::and_<is_concept_combinable<is_interval_set, is_interval_map, LeftT, RightT>, 
+                             mpl::not_<is_total<RightT> > >,
+                   bool>::type
+within(const LeftT& sub, const RightT& super)
+{
+    int result =
+        subset_compare
+        (
+            sub, super, 
+            sub.begin(), sub.end(), 
+            super.begin(), super.end()
+        );
+    return result == inclusion::subset || result == inclusion::equal;
+}
+
+
+template<class LeftT, class RightT>
+typename enable_if<is_concept_combinable<is_interval_map, is_interval_map, LeftT, RightT>, 
+                   bool>::type
+within(const LeftT& sub, const RightT& super)
+{
+    int result =
+        subset_compare
+        (
+            sub, super, 
+            sub.begin(), sub.end(), 
+            super.begin(), super.end()
+        );
+    return result == inclusion::subset || result == inclusion::equal;
+}
+
+template<class LeftT, class RightT>
+typename enable_if<is_concept_combinable<is_interval_set, is_interval_set, LeftT, RightT>, 
+                   bool>::type
+within(const LeftT& sub, const RightT& super)
+{
+    int result =
+        subset_compare
+        (
+            sub, super, 
+            sub.begin(), sub.end(), 
+            super.begin(), super.end()
+        );
+    return result == inclusion::subset || result == inclusion::equal;
+}
+
+
+
+template<class LeftT, class RightT>
+typename enable_if<mpl::and_<is_concept_combinable<is_interval_map, is_interval_set, LeftT, RightT>, 
+                             is_total<LeftT> >,
+                   bool>::type
+contains(const LeftT&, const RightT&)
+{
+    return true;
+}
+
+template<class LeftT, class RightT>
+typename enable_if<mpl::and_<is_concept_combinable<is_interval_map, is_interval_set, LeftT, RightT>, 
+                             mpl::not_<is_total<LeftT> > >,
+                   bool>::type
+contains(const LeftT& super, const RightT& sub)
+{
+    int result =
+        subset_compare
+        (
+            super, sub, 
+            super.begin(), super.end(), 
+            sub.begin(), sub.end()
+        );
+    return result == inclusion::superset || result == inclusion::equal;
+}
+
+template<class LeftT, class RightT>
+typename enable_if<is_concept_combinable<is_interval_set, is_interval_set, LeftT, RightT>, 
+                   bool>::type
+contains(const LeftT& super, const RightT& sub)
+{
+    int result =
+        subset_compare
+        (
+            super, sub, 
+            super.begin(), super.end(), 
+            sub.begin(), sub.end()
+        );
+    return result == inclusion::superset || result == inclusion::equal;
+}
+
+template<class IntervalContainerT>
+bool is_dense(const IntervalContainerT& container, 
+              typename IntervalContainerT::const_iterator first, 
+              typename IntervalContainerT::const_iterator past) 
+{
+    if(first == container.end())
+        return true;
+
+    typename IntervalContainerT::const_iterator it_ = first, next_ = first;
+    ++next_;
+
+    while(next_ != container.end() && it_ != past)
+        if(!icl::touches(key_value<IntervalContainerT>(it_++), 
+                         key_value<IntervalContainerT>(next_++)))
+            return false;
+
+    return true;
+}
+
+} // namespace Interval_Set
+
+namespace segmental
+{
+
+template<class Type>
+inline bool joinable(const Type& _Type, typename Type::iterator& some, typename Type::iterator& next)
+{
+    // assert: next != end && some++ == next
+    return touches(key_value<Type>(some), key_value<Type>(next)) 
+        && co_equal(some, next, &_Type, &_Type); 
+}
+
+template<class Type>
+inline void join_nodes(Type& object, typename Type::iterator& left_, 
+                                     typename Type::iterator& right_)
+{
+    typedef typename Type::interval_type interval_type;
+    interval_type right_interval = key_value<Type>(right_);
+    object.erase(right_);
+    const_cast<interval_type&>(key_value<Type>(left_)) 
+        = hull(key_value<Type>(left_), right_interval);
+}
+
+template<class Type>
+inline typename Type::iterator 
+    join_on_left(Type& object, typename Type::iterator& left_, 
+                               typename Type::iterator& right_)
+{
+    //CL typedef typename Type::interval_type interval_type;
+    // both left and right are in the set and they are neighbours
+    BOOST_ASSERT(exclusive_less(key_value<Type>(left_), key_value<Type>(right_)));
+    BOOST_ASSERT(joinable(object, left_, right_));
+
+    join_nodes(object, left_, right_);
+    return left_;
+}
+
+template<class Type>
+inline typename Type::iterator 
+    join_on_right(Type& object, typename Type::iterator& left_, 
+                                typename Type::iterator& right_)
+{
+    //CL typedef typename Type::interval_type interval_type;
+    // both left and right are in the map and they are neighbours
+    BOOST_ASSERT(exclusive_less(key_value<Type>(left_), key_value<Type>(right_)));
+    BOOST_ASSERT(joinable(object, left_, right_));
+
+    join_nodes(object, left_, right_);
+    right_ = left_;
+    return right_;
+}
+
+template<class Type>
+typename Type::iterator join_left(Type& object, typename Type::iterator& it_)
+{
+    typedef typename Type::iterator iterator;
+
+    if(it_ == object.begin())
+        return it_;
+
+    // there is a predecessor
+    iterator pred_ = it_;
+    if(joinable(object, --pred_, it_)) 
+        return join_on_right(object, pred_, it_); 
+
+    return it_;
+}
+
+template<class Type>
+typename Type::iterator join_right(Type& object, typename Type::iterator& it_)
+{
+    typedef typename Type::iterator iterator;
+
+    if(it_ == object.end())
+        return it_;
+
+    // there is a successor
+    iterator succ_ = it_;
+
+    if(++succ_ != object.end() && joinable(object, it_, succ_)) 
+        return join_on_left(object, it_, succ_);
+
+    return it_;
+}
+
+template<class Type>
+typename Type::iterator join_neighbours(Type& object, typename Type::iterator& it_)
+{
+           join_left (object, it_); 
+    return join_right(object, it_);
+}
+
+template<class Type>
+inline typename Type::iterator 
+    join_under(Type& object, const typename Type::value_type& addend)
+{
+    //ASSERT: There is at least one interval in object that overlaps with addend
+    typedef typename Type::iterator      iterator;
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::value_type    value_type;
+
+    std::pair<iterator,iterator> overlap = object.equal_range(addend);
+    iterator first_ = overlap.first,
+             end_   = overlap.second,
+             last_  = end_; --last_;
+
+    iterator second_= first_; ++second_;
+
+    interval_type left_resid  = right_subtract(key_value<Type>(first_), addend);
+    interval_type right_resid =  left_subtract(key_value<Type>(last_) , addend);
+
+    object.erase(second_, end_);
+
+    const_cast<value_type&>(key_value<Type>(first_)) 
+        = hull(hull(left_resid, addend), right_resid);
+    return first_;
+}
+
+template<class Type>
+inline typename Type::iterator 
+    join_under(Type& object, const typename Type::value_type& addend,
+                                   typename Type::iterator last_)
+{
+    //ASSERT: There is at least one interval in object that overlaps with addend
+    typedef typename Type::iterator      iterator;
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::value_type    value_type;
+
+    iterator first_ = object.lower_bound(addend);
+    //BOOST_ASSERT(next(last_) == this->_set.upper_bound(inter_val));
+    iterator second_= boost::next(first_), end_ = boost::next(last_);
+
+    interval_type left_resid  = right_subtract(key_value<Type>(first_), addend);
+    interval_type right_resid =  left_subtract(key_value<Type>(last_) , addend);
+
+    object.erase(second_, end_);
+
+    const_cast<value_type&>(key_value<Type>(first_)) 
+        = hull(hull(left_resid, addend), right_resid);
+    return first_;
+}
+
+} // namespace segmental
+
+namespace Interval_Set
+{
+using namespace segmental;
+
+template<class Type, int combining_style>
+struct on_style;
+
+template<class Type>
+struct on_style<Type, interval_combine::joining>
+{
+    typedef          on_style            type;
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+
+    inline static iterator handle_inserted(Type& object, iterator inserted_)
+    { return join_neighbours(object, inserted_); }
+
+    inline static iterator add_over
+        (Type& object, const interval_type& addend, iterator last_)
+    {
+        iterator joined_ = join_under(object, addend, last_);
+        return join_neighbours(object, joined_);
+    }
+
+    inline static iterator add_over
+        (Type& object, const interval_type& addend)
+    {
+        iterator joined_ = join_under(object, addend);
+        return join_neighbours(object, joined_);
+    }
+};
+
+template<class Type>
+struct on_style<Type, interval_combine::separating>
+{
+    typedef          on_style            type;
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+
+    inline static iterator handle_inserted(Type&, iterator inserted_)
+    { return inserted_; }
+
+    inline static iterator add_over
+        (Type& object, const interval_type& addend, iterator last_)
+    {
+        return join_under(object, addend, last_);
+    }
+
+    inline static iterator add_over
+        (Type& object, const interval_type& addend)
+    {
+        return join_under(object, addend);
+    }
+};
+
+template<class Type>
+struct on_style<Type, interval_combine::splitting>
+{
+    typedef          on_style            type;
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+
+    inline static iterator handle_inserted(Type&, iterator inserted_)
+    { return inserted_; }
+
+    inline static iterator add_over
+        (Type& object, const interval_type& addend, iterator last_)
+    {
+        iterator first_ = object.lower_bound(addend);
+        //BOOST_ASSERT(next(last_) == this->_set.upper_bound(inter_val));
+
+        iterator it_ = first_;
+        interval_type rest_interval = addend;
+
+        add_front(object, rest_interval, it_);
+        add_main (object, rest_interval, it_, last_);
+        add_rear (object, rest_interval, it_);
+        return it_;
+    }
+
+    inline static iterator add_over
+        (Type& object, const interval_type& addend)
+    {
+        std::pair<iterator,iterator> overlap = object.equal_range(addend);
+        iterator first_ = overlap.first,
+                 end_   = overlap.second,
+                 last_  = end_; --last_;
+
+        iterator it_ = first_;
+        interval_type rest_interval = addend;
+
+        add_front(object, rest_interval, it_);
+        add_main (object, rest_interval, it_, last_);
+        add_rear (object, rest_interval, it_);
+
+        return it_;
+    }
+};
+
+
+template<class Type>
+void add_front(Type& object, const typename Type::interval_type& inter_val, 
+                                   typename Type::iterator&      first_)
+{
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+    // If the collision sequence has a left residual 'left_resid' it will
+    // be split, to provide a standardized start of algorithms:
+    // The addend interval 'inter_val' covers the beginning of the collision sequence.
+
+    // only for the first there can be a left_resid: a part of *first_ left of inter_val
+    interval_type left_resid = right_subtract(key_value<Type>(first_), inter_val);
+
+    if(!icl::is_empty(left_resid))
+    {   //            [------------ . . .
+        // [left_resid---first_ --- . . .
+        iterator prior_ = cyclic_prior(object, first_);
+        const_cast<interval_type&>(key_value<Type>(first_)) 
+            = left_subtract(key_value<Type>(first_), left_resid);
+        //NOTE: Only splitting
+        object._insert(prior_, icl::make_value<Type>(left_resid, co_value<Type>(first_)));
+    }
+
+    //POST:
+    // [----- inter_val ---- . . .
+    // ...[-- first_ --...
+}
+
+
+template<class Type>
+void add_segment(Type& object, const typename Type::interval_type& inter_val, 
+                                     typename Type::iterator&      it_      )
+{
+    typedef typename Type::interval_type interval_type;
+    interval_type lead_gap = right_subtract(inter_val, *it_);
+    if(!icl::is_empty(lead_gap))
+        //           [lead_gap--- . . .
+        // [prior_)           [-- it_ ...
+        object._insert(prior(it_), lead_gap);
+
+    // . . . --------- . . . addend interval
+    //      [-- it_ --)      has a common part with the first overval
+    ++it_;
+}
+
+
+template<class Type>
+void add_main(Type& object, typename Type::interval_type& rest_interval, 
+                            typename Type::iterator&      it_,
+                      const typename Type::iterator&      last_)
+{
+    typedef typename Type::interval_type interval_type;
+    interval_type cur_interval;
+    while(it_ != last_)
+    {
+        cur_interval = *it_ ;
+        add_segment(object, rest_interval, it_);
+        // shrink interval
+        rest_interval = left_subtract(rest_interval, cur_interval);
+    }
+}
+
+
+template<class Type>
+void add_rear(Type& object, const typename Type::interval_type& inter_val, 
+                                  typename Type::iterator&      it_      )
+{
+    typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+
+    iterator prior_ = cyclic_prior(object, it_);
+    interval_type cur_itv = *it_;
+
+    interval_type lead_gap = right_subtract(inter_val, cur_itv);
+    if(!icl::is_empty(lead_gap))
+        //          [lead_gap--- . . .
+        // [prior_)          [-- it_ ...
+        object._insert(prior_, lead_gap);
+    
+    interval_type end_gap = left_subtract(inter_val, cur_itv);
+    if(!icl::is_empty(end_gap))
+        // [---------------end_gap)
+        //      [-- it_ --)
+        it_ = object._insert(it_, end_gap);
+    else
+    {
+        // only for the last there can be a right_resid: a part of *it_ right of addend
+        interval_type right_resid = left_subtract(cur_itv, inter_val);
+
+        if(!icl::is_empty(right_resid))
+        {
+            // [--------------)
+            //      [-- it_ --right_resid)
+            const_cast<interval_type&>(*it_) = right_subtract(*it_, right_resid);
+            it_ = object._insert(it_, right_resid);
+        }
+    }
+}
+
+
+//==============================================================================
+//= Addition
+//==============================================================================
+template<class Type>
+typename Type::iterator 
+    add(Type& object, const typename Type::value_type& addend)
+{
+    //CL typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+    typedef typename on_style<Type, Type::fineness>::type on_style_;
+
+    if(icl::is_empty(addend)) 
+        return object.end();
+
+    std::pair<iterator,bool> insertion = object._insert(addend);
+
+    if(insertion.second)
+        return on_style_::handle_inserted(object, insertion.first);
+    else
+        return on_style_::add_over(object, addend, insertion.first);
+}
+
+
+template<class Type>
+typename Type::iterator 
+    add(Type& object, typename Type::iterator    prior_, 
+                const typename Type::value_type& addend)
+{
+    //CL typedef typename Type::interval_type interval_type;
+    typedef typename Type::iterator      iterator;
+    typedef typename on_style<Type, Type::fineness>::type on_style_;
+
+    if(icl::is_empty(addend)) 
+        return prior_;
+
+    iterator insertion = object._insert(prior_, addend);
+
+    if(*insertion == addend)
+        return on_style_::handle_inserted(object, insertion);
+    else
+        return on_style_::add_over(object, addend);
+}
+
+
+//==============================================================================
+//= Subtraction
+//==============================================================================
+template<class Type>
+void subtract(Type& object, const typename Type::value_type& minuend)
+{
+    typedef typename Type::iterator      iterator;
+    typedef typename Type::interval_type interval_type;
+    //CL typedef typename Type::value_type    value_type;
+
+    if(icl::is_empty(minuend)) return;
+
+    std::pair<iterator, iterator> exterior = object.equal_range(minuend);
+    if(exterior.first == exterior.second) return;
+
+    iterator first_ = exterior.first;
+    iterator end_   = exterior.second;
+    iterator last_  = end_; --last_;
+
+    interval_type leftResid = right_subtract(*first_, minuend);
+    interval_type rightResid; 
+    if(first_ != end_  )
+        rightResid = left_subtract(*last_ , minuend);
+
+    object.erase(first_, end_);
+
+    if(!icl::is_empty(leftResid))
+        object._insert(leftResid);
+
+    if(!icl::is_empty(rightResid))
+        object._insert(rightResid);
+}
+
+
+} // namespace Interval_Set
+
+}} // namespace icl boost
+
+#endif 
+

--- a/inst/include/boost/icl/detail/interval_subset_comparer.hpp
+++ b/inst/include/boost/icl/detail/interval_subset_comparer.hpp
@@ -1,0 +1,368 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_SUBSET_COMPARER_HPP_JOFA_090827
+#define BOOST_ICL_INTERVAL_SUBSET_COMPARER_HPP_JOFA_090827
+
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/detail/relation_state.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/is_concept_equivalent.hpp>
+#include <boost/icl/type_traits/is_interval_container.hpp>
+#include <boost/icl/type_traits/is_set.hpp>
+#include <boost/icl/concept/interval_set_value.hpp>
+
+namespace boost{namespace icl
+{
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant
+#endif                        
+
+namespace Interval_Set
+{
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+struct settic_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator& left_, typename RightT::const_iterator& right_)
+    {
+        return inclusion_compare( icl::co_value<LeftT>(left_), 
+                                 icl::co_value<RightT>(right_));
+    }
+};
+
+template<class LeftT, class RightT>
+struct atomic_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator& left_, typename RightT::const_iterator& right_)
+    {
+        if(icl::co_value<LeftT>(left_) == icl::co_value<RightT>(right_))
+            return inclusion::equal;
+        else
+            return inclusion::unrelated;
+    }
+};
+
+template<class LeftT, class RightT>
+struct empty_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator&, typename RightT::const_iterator)
+    {
+        return inclusion::equal;
+    }
+};
+
+template<class LeftT, class RightT>
+struct map_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator& left_, typename RightT::const_iterator& right_)
+    {
+        using namespace boost::mpl;
+        typedef typename LeftT::codomain_type  LeftCodomainT;
+        typedef typename RightT::codomain_type RightCodomainT;
+
+        return
+            if_<
+                bool_<is_concept_equivalent<is_set,LeftCodomainT,
+                                                   RightCodomainT>::value>,
+                settic_codomain_compare<LeftT,RightT>,
+                atomic_codomain_compare<LeftT,RightT>
+            >
+            ::type::apply(left_, right_);
+    }
+};
+
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+class subset_comparer
+{
+private:
+    subset_comparer& operator = (const subset_comparer&);
+public:
+    typedef typename LeftT::const_iterator  LeftIterT;
+    typedef typename RightT::const_iterator RightIterT;
+
+    BOOST_STATIC_CONSTANT(bool, 
+        _compare_codomain = (mpl::and_<is_map<LeftT>, is_map<RightT> >::value)); 
+
+
+    subset_comparer(const LeftT&      left,
+                    const RightT&     right,
+                    const LeftIterT&  left_end,
+                    const RightIterT& right_end)
+        : _left(left), _right(right),
+          _left_end(left_end), _right_end(right_end), _result(equal)
+    {}
+
+    enum{nextboth, nextleft, nextright, stop};
+
+    enum
+    {
+        unrelated  = inclusion::unrelated, 
+        subset     = inclusion::subset,     // left is_subset_of   right 
+        superset   = inclusion::superset,   // left is_superset_of right
+        equal      = inclusion::equal       // equal = subset | superset
+    };
+
+    int result()const{ return _result; }
+
+
+    int co_compare(LeftIterT& left, RightIterT& right)
+    {
+        using namespace boost::mpl;
+
+        return  
+            if_<
+                bool_<is_concept_equivalent<is_interval_map,LeftT,RightT>::value>,
+                map_codomain_compare<LeftT,RightT>,
+                empty_codomain_compare<LeftT,RightT>
+            >
+            ::type::apply(left,right);
+    }
+
+    int restrict_result(int state) { return _result &= state; }
+
+    int proceed(LeftIterT& left, RightIterT& right)
+    {
+        if(upper_less(key_value<LeftT>(left), key_value<RightT>(right)))
+        {   // left  ..)  
+            // right .....)
+            _prior_left = left;
+            ++left;
+            return nextleft;
+        }
+        else if(upper_less(key_value<RightT>(right), key_value<LeftT>(left)))
+        {   // left  .....)
+            // right ..)
+            _prior_right = right;
+            ++right;
+            return nextright;
+        }
+        else//key_value<LeftT>(left).upper_equal(key_value<RightT>(right))
+        {   // left  ..)
+            // right ..)
+            ++left; 
+            ++right;    
+            return nextboth;
+        }
+    }
+
+    int next_both(LeftIterT& left, RightIterT& right)
+    {
+        if(left == _left_end && right == _right_end)
+            return stop;
+        else if(left == _left_end)
+        {   // left: ....end    left could be subset
+            // right:....[..
+            restrict_result(subset);
+            return stop;
+        }
+        else if(right == _right_end)
+        {   // left: ....[..    left could be superset
+            // right:....end
+            restrict_result(superset);
+            return stop;
+        }
+        else if(exclusive_less(key_value<LeftT>(left), key_value<RightT>(right)))
+        {   // left: [..) . . .[---)      left could be superset
+            // right:           [..)....  if [---) exists
+            restrict_result(superset);
+            if(unrelated == _result)
+                return stop;
+            else
+            {
+                LeftIterT joint_ = _left.lower_bound(key_value<RightT>(right));
+                if(joint_ == _left.end())
+                {
+                    _result = unrelated;
+                    return stop;
+                }
+                else
+                {
+                    left = joint_;
+                    return nextboth;
+                }
+            }
+        }
+        else if(exclusive_less(key_value<RightT>(right), key_value<LeftT>(left)))
+        {   // left:             [..  left could be subset
+            // right:....) . . .[---) if [---) exists 
+            restrict_result(subset);
+            if(unrelated == _result)
+                return stop;
+            else
+            {
+                RightIterT joint_ = _right.lower_bound(key_value<LeftT>(left));
+                if(joint_ == _right.end())
+                {
+                    _result = unrelated;
+                    return stop;
+                }
+                else
+                {
+                    right = joint_;
+                    return nextboth;
+                }
+            }
+        }
+
+        // left and right have intervals with nonempty intersection:
+        if(_compare_codomain)
+            if(unrelated == restrict_result(co_compare(left,right)))
+                return stop;
+
+        // examine left borders only. Right borders are checked in proceed
+        if(lower_less(key_value<LeftT>(left), key_value<RightT>(right)))
+        {   // left: ....[...     left could be superset
+            // right:....   [..
+            if(unrelated == restrict_result(superset))
+                return stop;
+        }
+        else if(lower_less(key_value<RightT>(right), key_value<LeftT>(left)))
+        {   // left: ....   [..   left can be subset
+            // right:....[...
+            if(unrelated == restrict_result(subset))
+                return stop;
+        }
+        //else key_value<LeftT>(right).lower_equal(key_value<RightT>(left))
+            // left: ....[..   both can be equal
+            // right:....[..
+            // nothing to do: proceed
+
+        return proceed(left, right);
+    }
+
+    int next_left(LeftIterT& left, RightIterT& right)
+    {
+        if(left == _left_end)
+        {   // left: ..)end    left could be subset
+            // right:......)
+            restrict_result(subset);
+            return stop;            
+        }
+        else if(!touches(key_value<LeftT>(_prior_left), key_value<LeftT>(left)))
+        {   // left: ..)   [..
+            // right:.........)
+            if(lower_less(key_value<RightT>(right), key_value<LeftT>(left)))
+            {   //   ..)   [..   left could be subset
+                //   ..........)
+                if(unrelated == restrict_result(subset))
+                    return stop;            
+            }
+            //else   ..)   [...
+            //          [..
+            if(_compare_codomain && intersects(key_value<LeftT>(left),key_value<RightT>(right)) )
+                if(unrelated == restrict_result(co_compare(left,right)))
+                    return stop;
+        }
+        else
+        {   // left: ..)[..  left could be subset
+            // right:.......)
+            if(_compare_codomain && intersects(key_value<LeftT>(left), key_value<RightT>(right)) )
+                if(unrelated == restrict_result(co_compare(left,right)))
+                    return stop;
+        }
+
+        return proceed(left, right);
+    }
+
+
+    int next_right(LeftIterT& left, RightIterT& right)
+    {
+        if(right == _right_end)
+        {   // left: ......)    left could be superset
+            // right:..)end
+            restrict_result(superset);
+            return stop;            
+        }
+        else if(!touches(key_value<RightT>(_prior_right), key_value<RightT>(right)))
+        {   // left: .........)
+            // right:..)   [..
+            if(lower_less(key_value<LeftT>(left), key_value<RightT>(right)))
+            {   //       [....)  left could be superset
+                //   ..)   [..
+                if(unrelated == restrict_result(superset))
+                    return stop;            
+            }
+            //else       [....)
+            //   ..)   [..
+            if(_compare_codomain && intersects(key_value<LeftT>(left), key_value<RightT>(right)) )
+                if(unrelated == restrict_result(co_compare(left,right)))
+                    return stop;
+        }
+        else
+        {
+            if(_compare_codomain && intersects(key_value<LeftT>(left), key_value<RightT>(right)) )
+                if(unrelated == restrict_result(co_compare(left,right)))
+                    return stop;
+        }
+
+        return proceed(left, right);
+    }
+
+private:
+    const LeftT&  _left;
+    const RightT& _right;
+    LeftIterT     _left_end;
+    RightIterT    _right_end;
+    LeftIterT     _prior_left;
+    RightIterT    _prior_right;
+    int           _result;
+};
+
+
+
+
+
+//------------------------------------------------------------------------------
+// Subset/superset comparison on ranges of two interval container 
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+int subset_compare
+(
+    const LeftT& left,   //sub
+    const RightT& right, //super
+    typename LeftT::const_iterator  left_begin,   
+    typename LeftT::const_iterator  left_end,
+    typename RightT::const_iterator right_begin, 
+    typename RightT::const_iterator right_end
+)
+{
+    typedef subset_comparer<LeftT,RightT> Step;
+    Step step(left, right, left_end, right_end);
+
+    typename LeftT::const_iterator  left_  = left_begin;
+    typename RightT::const_iterator right_ = right_begin;
+
+    int state = Step::nextboth;
+    while(state != Step::stop)
+    {
+        switch(state){
+        case Step::nextboth:    state = step.next_both(left_, right_);  break;
+        case Step::nextleft:    state = step.next_left(left_, right_);  break;
+        case Step::nextright:   state = step.next_right(left_, right_); break;
+        }
+    }
+    return step.result();
+}
+
+
+} // namespace Interval_Set
+    
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+}} // namespace icl boost
+
+#endif 
+

--- a/inst/include/boost/icl/detail/map_algo.hpp
+++ b/inst/include/boost/icl/detail/map_algo.hpp
@@ -1,0 +1,90 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_MAPALGO_HPP_JOFA_080225
+#define BOOST_ICL_MAPALGO_HPP_JOFA_080225
+
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/detail/set_algo.hpp>
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant
+#endif                        
+
+namespace boost{namespace icl
+{
+namespace Map 
+{
+
+template <class ObjectT, class CoObjectT>
+bool intersects(const ObjectT& left, const CoObjectT& right)
+{
+    typedef typename CoObjectT::const_iterator co_iterator;
+    co_iterator right_common_lower_, right_common_upper_;
+    if(!Set::common_range(right_common_lower_, right_common_upper_, right, left))
+        return false;
+
+    co_iterator right_ = right_common_lower_;
+    while(right_ != right_common_upper_)
+        if(!(left.find(key_value<CoObjectT>(right_++))==left.end()))
+            return true;
+
+    return false;
+}
+
+
+template<class MapT>
+typename MapT::const_iterator next_proton(typename MapT::const_iterator& iter_, const MapT& object)
+{
+    while(   iter_ != object.end() 
+          && (*iter_).second == identity_element<typename MapT::codomain_type>::value())
+        ++iter_;
+
+    return iter_;
+}
+
+/** Function template <tt>lexicographical_equal</tt> implements 
+lexicographical equality except for identity_elementic content values. */
+template<class MapT>
+bool lexicographical_distinct_equal(const MapT& left, const MapT& right)
+{
+    if(&left == &right)        
+        return true;
+
+    typename MapT::const_iterator left_  = left.begin();
+    typename MapT::const_iterator right_ = right.begin();
+
+    left_  = next_proton(left_,  left);
+    right_ = next_proton(right_, right);
+
+    while(left_ != left.end() && right_ != right.end())
+    {
+        if(!(left_->first == right_->first && left_->second == right_->second))
+            return false;
+
+        ++left_;
+        ++right_;
+        left_  = next_proton(left_,  left);
+        right_ = next_proton(right_, right);
+    }
+
+    return left_ == left.end() && right_ == right.end();
+}
+
+} // namespace Map
+}} // namespace boost icl
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+#endif
+

--- a/inst/include/boost/icl/detail/mapped_reference.hpp
+++ b/inst/include/boost/icl/detail/mapped_reference.hpp
@@ -1,0 +1,192 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2009-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DETAIL_MAPPED_REFERENCE_HPP_JOFA_091108
+#define BOOST_ICL_DETAIL_MAPPED_REFERENCE_HPP_JOFA_091108
+
+#include <boost/type_traits/is_const.hpp>
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/icl/type_traits/is_concept_equivalent.hpp>
+
+namespace boost{namespace icl
+{
+
+template<class FirstT, class SecondT> class mapped_reference;
+
+//------------------------------------------------------------------------------
+template<class Type>
+struct is_mapped_reference_combinable{
+    typedef is_mapped_reference_combinable type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+template<class FirstT, class SecondT>
+struct is_mapped_reference_combinable<std::pair<const FirstT,SecondT> >
+{
+    typedef is_mapped_reference_combinable<std::pair<const FirstT,SecondT> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+template<class FirstT, class SecondT>
+struct is_mapped_reference_combinable<std::pair<FirstT,SecondT> >
+{
+    typedef is_mapped_reference_combinable<std::pair<FirstT,SecondT> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+//------------------------------------------------------------------------------
+template<class Type>
+struct is_mapped_reference_or_combinable{
+    typedef is_mapped_reference_or_combinable type;
+    BOOST_STATIC_CONSTANT(bool, value = is_mapped_reference_combinable<Type>::value);
+};
+
+template<class FirstT, class SecondT>
+struct is_mapped_reference_or_combinable<mapped_reference<FirstT,SecondT> >
+{
+    typedef is_mapped_reference_or_combinable<mapped_reference<FirstT,SecondT> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+
+
+//------------------------------------------------------------------------------
+template<class FirstT, class SecondT>
+class mapped_reference
+{
+private:
+    mapped_reference& operator = (const mapped_reference&);
+public:
+    typedef FirstT  first_type;   
+    typedef SecondT second_type; 
+    typedef mapped_reference type;
+
+    typedef typename 
+        mpl::if_<is_const<second_type>, 
+                       second_type&, 
+                 const second_type&>::type second_reference_type;
+
+    typedef std::pair<      first_type, second_type>     std_pair_type; 
+    typedef std::pair<const first_type, second_type> key_std_pair_type; 
+
+    const first_type&     first ;
+    second_reference_type second;
+
+    mapped_reference(const FirstT& fst, second_reference_type snd) : first(fst), second(snd){}
+
+    template<class FstT, class SndT>
+    mapped_reference(const mapped_reference<FstT, SndT>& source):
+        first(source.first), second(source.second){}
+
+    template<class FstT, class SndT>
+    operator std::pair<FstT,SndT>(){ return std::pair<FstT,SndT>(first, second); }
+
+    template<class Comparand>
+    typename enable_if<is_mapped_reference_or_combinable<Comparand>, bool>::type
+    operator == (const Comparand& right)const
+    { return first == right.first && second == right.second; }
+
+    template<class Comparand>
+    typename enable_if<is_mapped_reference_or_combinable<Comparand>, bool>::type
+    operator != (const Comparand& right)const
+    { return !(*this == right); }
+
+    template<class Comparand>
+    typename enable_if<is_mapped_reference_or_combinable<Comparand>, bool>::type
+    operator < (const Comparand& right)const
+    { 
+        return         first < right.first 
+            ||(!(right.first <       first) && second < right.second); 
+    }
+
+    template<class Comparand>
+    typename enable_if<is_mapped_reference_or_combinable<Comparand>, bool>::type
+    operator > (const Comparand& right)const
+    { 
+        return         first > right.first 
+            ||(!(right.first >       first) && second > right.second); 
+    }
+
+    template<class Comparand>
+    typename enable_if<is_mapped_reference_or_combinable<Comparand>, bool>::type
+    operator <= (const Comparand& right)const
+    { 
+        return !(*this > right);
+    }
+
+    template<class Comparand>
+    typename enable_if<is_mapped_reference_or_combinable<Comparand>, bool>::type
+    operator >= (const Comparand& right)const
+    { 
+        return !(*this < right);
+    }
+
+};
+
+//------------------------------------------------------------------------------
+template<class FirstT, class SecondT, class StdPairT>
+inline typename enable_if<is_mapped_reference_combinable<StdPairT>, bool>::type
+operator == (                         const StdPairT& left, 
+             const mapped_reference<FirstT, SecondT>& right)
+{ 
+    return right == left; 
+}
+
+template<class FirstT, class SecondT, class StdPairT>
+inline typename enable_if<is_mapped_reference_combinable<StdPairT>, bool>::type
+operator != (                         const StdPairT& left, 
+             const mapped_reference<FirstT, SecondT>& right)
+{ 
+    return !(right == left); 
+}
+
+//------------------------------------------------------------------------------
+template<class FirstT, class SecondT, class StdPairT>
+inline typename enable_if<is_mapped_reference_combinable<StdPairT>, bool>::type
+operator < (                         const StdPairT& left, 
+            const mapped_reference<FirstT, SecondT>& right)
+{ 
+    return right > left; 
+}
+
+//------------------------------------------------------------------------------
+template<class FirstT, class SecondT, class StdPairT>
+inline typename enable_if<is_mapped_reference_combinable<StdPairT>, bool>::type
+operator > (                         const StdPairT& left, 
+            const mapped_reference<FirstT, SecondT>& right)
+{ 
+    return right < left; 
+}
+
+//------------------------------------------------------------------------------
+template<class FirstT, class SecondT, class StdPairT>
+inline typename enable_if<is_mapped_reference_combinable<StdPairT>, bool>::type
+operator <= (                         const StdPairT& left, 
+             const mapped_reference<FirstT, SecondT>& right)
+{ 
+    return !(right < left); 
+}
+
+//------------------------------------------------------------------------------
+template<class FirstT, class SecondT, class StdPairT>
+inline typename enable_if<is_mapped_reference_combinable<StdPairT>, bool>::type
+operator >= (                         const StdPairT& left, 
+             const mapped_reference<FirstT, SecondT>& right)
+{ 
+    return !(left < right); 
+}
+
+//------------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+template<class FirstT, class SecondT>
+inline mapped_reference<FirstT, SecondT> make_mapped_reference(const FirstT& left, SecondT& right)
+{ return mapped_reference<FirstT, SecondT>(left, right); }
+
+}} // namespace icl boost
+
+#endif // BOOST_ICL_DETAIL_MAPPED_REFERENCE_HPP_JOFA_091108

--- a/inst/include/boost/icl/detail/notate.hpp
+++ b/inst/include/boost/icl/detail/notate.hpp
@@ -1,0 +1,35 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------------
+    Macro definitions for some useful notations e.g. iteration headers
+-----------------------------------------------------------------------------*/
+#ifndef  BOOST_ICL_DETAIL_NOTATE_HPP_JOFA_990119
+#define  BOOST_ICL_DETAIL_NOTATE_HPP_JOFA_990119
+
+
+// Iterations over stl or stl-compatible containers:
+#define ICL_FORALL(type,iter,obj) for(type::iterator iter=(obj).begin(); (iter)!=(obj).end(); (iter)++)
+#define ICL_const_FORALL(type,iter,obj) for(type::const_iterator iter=(obj).begin(); !((iter)==(obj).end()); (iter)++)
+
+#define ICL_FORALL_THIS(iter) for(iterator iter=begin(); (iter)!=end(); (iter)++)
+#define ICL_const_FORALL_THIS(iter) for(const_iterator iter=this->begin(); (iter)!=this->end(); (iter)++)
+
+// Plain old array iteration (assuming member function VecT::size()!)
+#define ICL_FORALL_VEC(idx, vec) for(int idx=0; idx<vec.size(); idx++)
+
+namespace boost{namespace icl
+{
+    const int UNDEFINED_INDEX = -1;
+}} // namespace icl boost
+
+
+#endif // BOOST_ICL_DETAIL_NOTATE_HPP_JOFA_990119
+
+

--- a/inst/include/boost/icl/detail/on_absorbtion.hpp
+++ b/inst/include/boost/icl/detail/on_absorbtion.hpp
@@ -1,0 +1,43 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_ON_ABSORBTION_HPP_JOFA_100915
+#define BOOST_ICL_TYPE_TRAITS_ON_ABSORBTION_HPP_JOFA_100915
+
+namespace boost{ namespace icl
+{
+
+template<class Type, class Combiner, bool absorbs_identities>
+struct on_absorbtion;
+
+template<class Type, class Combiner>
+struct on_absorbtion<Type, Combiner, false>
+{
+    typedef on_absorbtion type;
+    typedef typename Type::codomain_type codomain_type;
+
+    static bool is_absorbable(const codomain_type&){ return false; }
+};
+
+template<class Type, class Combiner>
+struct on_absorbtion<Type, Combiner, true>
+{
+    typedef on_absorbtion type;
+    typedef typename Type::codomain_type codomain_type;
+    typedef typename Type::codomain_combine codomain_combine;
+
+    static bool is_absorbable(const codomain_type& co_value)
+    {
+        return co_value == Combiner::identity_element();
+    }
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/detail/relation_state.hpp
+++ b/inst/include/boost/icl/detail/relation_state.hpp
@@ -1,0 +1,37 @@
+/*-----------------------------------------------------------------------------+
+Author: Joachim Faulhaber
+Copyright (c) 2009-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+/*-----------------------------------------------------------------------------+
+States of comparison and inclusion relations as static constants
++-----------------------------------------------------------------------------*/
+#ifndef  BOOST_ICL_RELATION_STATE_HPP_JOFA_090214
+#define  BOOST_ICL_RELATION_STATE_HPP_JOFA_090214
+
+namespace boost{namespace icl
+{
+    namespace comparison
+    {
+        static const int less    = -1;
+        static const int equal   =  0;
+        static const int greater =  1;
+    }
+
+    namespace inclusion
+    {
+        static const int unrelated =  0;
+        static const int subset    =  1;
+        static const int superset  =  2;
+        static const int equal     =  3;
+    }
+
+
+}} // namespace icl boost
+
+#endif // BOOST_ICL_RELATION_STATE_HPP_JOFA_090214
+
+

--- a/inst/include/boost/icl/detail/set_algo.hpp
+++ b/inst/include/boost/icl/detail/set_algo.hpp
@@ -1,0 +1,131 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_SET_ALGO_HPP_JOFA_990225
+#define BOOST_ICL_SET_ALGO_HPP_JOFA_990225
+
+#include <boost/type_traits/remove_const.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/concept/container.hpp>
+#include <boost/icl/concept/set_value.hpp>
+#include <boost/icl/concept/map_value.hpp>
+
+
+namespace boost{namespace icl
+{
+
+namespace Set
+{
+
+template<class ObjectT, class ConstObjectT, class IteratorT>
+bool common_range(IteratorT& lwb, IteratorT& upb, ObjectT& x1, const ConstObjectT& x2)
+{
+    // lwb and upb are iterators of x1 marking the lower and upper bound of
+    // the common range of x1 and x2.
+    typedef typename ConstObjectT::const_iterator ConstObject_iterator;
+    // ObjectT may be const or non const. 
+    typedef typename remove_const<ObjectT>::type  PureObjectT;
+
+    lwb = x1.end();
+    upb = x1.end();
+
+    if(icl::is_empty(x1) || icl::is_empty(x2)) 
+        return false;
+
+    IteratorT x1_fst_ = x1.begin();
+    IteratorT x1_lst_ = x1.end(); x1_lst_--;
+
+    ConstObject_iterator x2_fst_ = x2.begin();
+    ConstObject_iterator x2_lst_ = x2.end(); x2_lst_--;
+
+    typename ObjectT::key_compare key_less;
+    if(key_less(icl::key_value< PureObjectT>(x1_lst_), 
+                icl::key_value<ConstObjectT>(x2_fst_))) // {x1}   {x2}
+        return false;
+    if(key_less(icl::key_value<ConstObjectT>(x2_lst_), 
+                icl::key_value< PureObjectT>(x1_fst_))) // {x2}   {x1} 
+        return false;
+
+    // We do have a common range
+    lwb = x1.lower_bound(icl::key_value<ConstObjectT>(x2_fst_));
+    upb = x1.upper_bound(icl::key_value<ConstObjectT>(x2_lst_));
+
+    return true;
+}
+
+
+/** Function template <tt>contained_in</tt> implements the subset relation. 
+<tt>contained_in(sub, super)</tt> is true if <tt>sub</tt> is contained in <tt>super</tt> */
+template<class SetType>
+inline bool within(const SetType& sub, const SetType& super)
+{
+    if(&super == &sub)                   return true;
+    if(icl::is_empty(sub))               return true;
+    if(icl::is_empty(super))             return false;
+
+    typename SetType::const_iterator common_lwb_, common_upb_;
+    if(!common_range(common_lwb_, common_upb_, sub, super))
+        return false;
+
+    typename SetType::const_iterator sub_ = common_lwb_, super_;
+    while(sub_ != common_upb_)
+    {
+        super_ = super.find(*sub_++);
+        if(super_ == super.end()) 
+            return false;
+    }
+    return true;
+}
+
+template<class SetType>
+bool intersects(const SetType& left, const SetType& right)
+{
+    typename SetType::const_iterator common_lwb_right_, common_upb_right_;
+    if(!common_range(common_lwb_right_, common_upb_right_, right, left))
+        return false;
+
+    typename SetType::const_iterator right_ = common_lwb_right_, found_;
+    while(right_ != common_upb_right_)
+    {
+        found_ = left.find(*right_++);
+        if(found_ != left.end()) 
+            return true; // found a common element
+    }
+    // found no common element
+    return false;    
+}
+
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4996) //'std::equal': Function call with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct. To disable this warning, use -D_SCL_SECURE_NO_WARNINGS. See documentation on how to use Visual C++ 'Checked Iterators'
+#endif                        // I do guarantee here that I am using the parameters correctly :)
+
+/** Function template <tt>lexicographical_equal</tt> implements 
+    lexicographical equality. */
+template<class SetType>
+inline bool lexicographical_equal(const SetType& left, const SetType& right)
+{
+    if(&left == &right)
+        return true;
+    else return left.iterative_size() == right.iterative_size()
+             && std::equal(left.begin(), left.end(), right.begin()); 
+}
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+
+} // namespace Set
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/detail/std_set.hpp
+++ b/inst/include/boost/icl/detail/std_set.hpp
@@ -1,0 +1,45 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DETAIL_STD_SET_HPP_JOFA_101007
+#define BOOST_ICL_DETAIL_STD_SET_HPP_JOFA_101007
+
+#include <set>
+#include <boost/config.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+#include <boost/icl/type_traits/is_set.hpp>
+
+
+namespace boost{namespace icl
+{
+
+template <class Type>
+struct is_set<std::set<Type> >
+{ 
+    typedef is_set<std::set<Type> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+
+template <class Type>
+struct type_to_string<std::set<Type> >
+{
+    static std::string apply()
+    { return "set<"+ type_to_string<Type>::apply() +">"; }
+};
+
+template <class Type>
+struct type_to_string<std::set<Type, std::greater<Type> > >
+{
+    static std::string apply()
+    { return "set<"+ type_to_string<Type>::apply() +" g>"; }
+};
+
+}} // namespace icl boost
+
+#endif // BOOST_ICL_DETAIL_STD_SET_HPP_JOFA_101007
+

--- a/inst/include/boost/icl/detail/subset_comparer.hpp
+++ b/inst/include/boost/icl/detail/subset_comparer.hpp
@@ -1,0 +1,259 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_SUBSET_COMPARER_HPP_JOFA_090202
+#define BOOST_ICL_SUBSET_COMPARER_HPP_JOFA_090202
+
+#include <boost/mpl/and.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/detail/relation_state.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/codomain_type_of.hpp>
+#include <boost/icl/type_traits/is_concept_equivalent.hpp>
+#include <boost/icl/type_traits/is_element_container.hpp>
+#include <boost/icl/concept/interval_set_value.hpp>
+#include <boost/icl/concept/map_value.hpp>
+
+namespace boost{namespace icl
+{
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant
+#endif                        
+
+namespace Set
+{
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+struct settic_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator& left_, typename RightT::const_iterator& right_)
+    {
+        return inclusion_compare( co_value<LeftT>(left_), 
+                                 co_value<RightT>(right_));
+    }
+};
+
+template<class LeftT, class RightT>
+struct atomic_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator& left_, typename RightT::const_iterator& right_)
+    {
+        if(co_value<LeftT>(left_) == co_value<RightT>(right_))
+            return inclusion::equal;
+        else
+            return inclusion::unrelated;
+    }
+};
+
+template<class LeftT, class RightT>
+struct empty_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator&, typename RightT::const_iterator&)
+    {
+        return inclusion::equal;
+    }
+};
+
+template<class LeftT, class RightT>
+struct map_codomain_compare
+{
+    static int apply(typename LeftT::const_iterator& left_, typename RightT::const_iterator& right_)
+    {
+        using namespace boost::mpl;
+        typedef typename LeftT::codomain_type  LeftCodomainT;
+        typedef typename RightT::codomain_type RightCodomainT;
+
+        return
+            if_<
+                bool_<is_concept_equivalent<is_set,LeftCodomainT,
+                                                   RightCodomainT>::value>,
+                settic_codomain_compare<LeftT,RightT>,
+                atomic_codomain_compare<LeftT,RightT>
+            >
+            ::type::apply(left_, right_);
+    }
+};
+
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+class subset_comparer
+{
+private:
+    subset_comparer& operator = (const subset_comparer&);
+public:
+    typedef typename LeftT::const_iterator  LeftIterT;
+    typedef typename RightT::const_iterator RightIterT;
+
+    BOOST_STATIC_CONSTANT(bool, 
+        _compare_codomain = (mpl::and_<is_map<LeftT>, is_map<RightT> >::value)); 
+
+    subset_comparer(const LeftT&      left,
+                    const RightT&     right,
+                    const LeftIterT&  left_end,
+                    const RightIterT& right_end)
+        : _left(left), _right(right),
+          _left_end(left_end), _right_end(right_end), _result(equal)
+    {}
+
+    enum{nextboth, stop};
+
+    enum
+    {
+        unrelated  = inclusion::unrelated, 
+        subset     = inclusion::subset,     // left is_subset_of   right 
+        superset   = inclusion::superset,   // left is_superset_of right
+        equal      = inclusion::equal       // equal = subset | superset
+    };
+
+    int result()const{ return _result; }
+
+    int co_compare(LeftIterT& left, RightIterT& right)
+    {
+        using namespace boost::mpl;
+        //CL typedef typename codomain_type_of<LeftT>::type  LeftCodomainT;
+        //CL typedef typename codomain_type_of<RightT>::type RightCodomainT;
+
+        return  
+            if_<
+                bool_<is_concept_equivalent<is_element_map,LeftT,RightT>::value>,
+                map_codomain_compare<LeftT,RightT>,
+                empty_codomain_compare<LeftT,RightT>
+            >
+            ::type::apply(left,right);
+    }
+
+    int restrict_result(int state) { return _result &= state; }
+
+    int next_both(LeftIterT& left, RightIterT& right)
+    {
+        if(left == _left_end && right == _right_end)
+            return stop;
+        else if(left == _left_end)
+        {
+            restrict_result(subset);
+            return stop;
+        }
+        else if(right == _right_end)
+        {
+            restrict_result(superset);
+            return stop;
+        }
+        else if(typename LeftT::key_compare()(key_value<LeftT>(left), key_value<RightT>(right)))
+        {   // left:  *left . . *joint_     left could be superset
+            // right:           *right ...  if joint_ exists
+            restrict_result(superset);
+            if(unrelated == _result)
+                return stop;
+            else
+            {
+                LeftIterT joint_ = _left.lower_bound(key_value<RightT>(right));
+                if(    joint_ == _left.end() 
+                    || typename LeftT::key_compare()(key_value<RightT>(right), key_value<LeftT>(joint_)))
+                {
+                    _result = unrelated;
+                    return stop;
+                }
+                else
+                    left = joint_;
+            }
+        }
+        else if(typename LeftT::key_compare()(key_value<RightT>(right), key_value<LeftT>(left)))
+        {   // left:             *left   left could be subset
+            // right:*right . . .*joint_ if *joint_ exists 
+            restrict_result(subset);
+            if(unrelated == _result)
+                return stop;
+            else
+            {
+                RightIterT joint_ = _right.lower_bound(key_value<LeftT>(left));
+                if(    joint_ == _right.end()
+                    || typename LeftT::key_compare()(key_value<LeftT>(left), key_value<RightT>(joint_)))
+                {
+                    _result = unrelated;
+                    return stop;
+                }
+                else
+                    right = joint_;
+            }
+        }
+
+        // left =key= right 
+        if(_compare_codomain)
+            if(unrelated == restrict_result(co_compare(left,right)))
+                return stop;
+
+        ++left;
+        ++right;
+        return nextboth;
+    }
+
+private:
+    const LeftT&  _left;
+    const RightT& _right;
+    LeftIterT     _left_end;
+    RightIterT    _right_end;
+    int           _result;
+};
+
+
+
+
+
+//------------------------------------------------------------------------------
+// Subset/superset comparison on ranges of two interval container 
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+int subset_compare
+(
+    const LeftT& left,   //sub
+    const RightT& right, //super
+    typename LeftT::const_iterator  left_begin,   
+    typename LeftT::const_iterator  left_end,
+    typename RightT::const_iterator right_begin, 
+    typename RightT::const_iterator right_end
+)
+{
+    typedef subset_comparer<LeftT,RightT> Step;
+    Step step(left, right, left_end, right_end);
+
+    typename LeftT::const_iterator  left_  = left_begin;
+    typename RightT::const_iterator right_ = right_begin;
+
+    int state = Step::nextboth;
+    while(state != Step::stop)
+        state = step.next_both(left_, right_);
+
+    return step.result();
+}
+
+template<class LeftT, class RightT>
+int subset_compare(const LeftT& left, const RightT& right)
+{
+    return subset_compare
+        (
+            left, right,
+            left.begin(), left.end(),
+            right.begin(), right.end()
+        );
+}
+
+
+} // namespace Set
+    
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+}} // namespace icl boost
+
+#endif 
+

--- a/inst/include/boost/icl/discrete_interval.hpp
+++ b/inst/include/boost/icl/discrete_interval.hpp
@@ -1,0 +1,169 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DISCRETE_INTERVAL_HPP_JOFA_100403
+#define BOOST_ICL_DISCRETE_INTERVAL_HPP_JOFA_100403
+
+#include <functional> 
+#include <boost/static_assert.hpp> 
+#include <boost/concept/assert.hpp>
+#include <boost/icl/detail/concept_check.hpp>
+#include <boost/icl/type_traits/succ_pred.hpp>
+#include <boost/icl/concept/interval.hpp>
+#include <boost/icl/type_traits/value_size.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+#include <boost/icl/type_traits/is_continuous.hpp>
+#include <boost/icl/type_traits/is_discrete_interval.hpp>
+#include <boost/icl/interval_bounds.hpp>
+
+namespace boost{namespace icl
+{
+
+template <class DomainT, 
+          ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)>
+class discrete_interval
+{
+public:
+    typedef discrete_interval<DomainT,Compare> type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef typename bounded_value<DomainT>::type bounded_domain_type;
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor; yields an empty interval <tt>[0,0)</tt>. */
+    discrete_interval()
+        : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value())
+        , _bounds(interval_bounds::right_open())
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
+    }
+
+    //NOTE: Compiler generated copy constructor is used
+
+    /** Constructor for a closed singleton interval <tt>[val,val]</tt> */
+    explicit discrete_interval(const DomainT& val)
+        : _lwb(val), _upb(val), _bounds(interval_bounds::closed())
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
+    }
+
+    /** Interval from <tt>low</tt> to <tt>up</tt> with bounds <tt>bounds</tt> */
+    discrete_interval(const DomainT& low, const DomainT& up, 
+                      interval_bounds bounds = interval_bounds::right_open(),
+                      discrete_interval* = 0)
+        : _lwb(low), _upb(up), _bounds(bounds)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
+    }
+
+    domain_type     lower()const { return _lwb; }
+    domain_type     upper()const { return _upb; }
+    interval_bounds bounds()const{ return _bounds; }
+
+    static discrete_interval open      (const DomainT& lo, const DomainT& up){ return discrete_interval(lo, up, interval_bounds::open());      }
+    static discrete_interval right_open(const DomainT& lo, const DomainT& up){ return discrete_interval(lo, up, interval_bounds::right_open());}
+    static discrete_interval left_open (const DomainT& lo, const DomainT& up){ return discrete_interval(lo, up, interval_bounds::left_open()); }
+    static discrete_interval closed    (const DomainT& lo, const DomainT& up){ return discrete_interval(lo, up, interval_bounds::closed());    }
+
+private:
+    domain_type     _lwb;
+    domain_type     _upb;
+    interval_bounds _bounds;
+};
+
+//==============================================================================
+//=T discrete_interval -> concept intervals
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct interval_traits< icl::discrete_interval<DomainT, Compare> >
+{
+    typedef interval_traits type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef icl::discrete_interval<DomainT, Compare> interval_type;
+
+    static interval_type construct(const domain_type& lo, const domain_type& up)
+    {
+        return interval_type(lo, up);
+    }
+
+    static domain_type lower(const interval_type& inter_val){ return inter_val.lower(); };
+    static domain_type upper(const interval_type& inter_val){ return inter_val.upper(); };
+};
+
+//==============================================================================
+//=T discrete_interval -> concept dynamic_interval_traits
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct dynamic_interval_traits<boost::icl::discrete_interval<DomainT,Compare> >
+{
+    typedef dynamic_interval_traits type;
+    typedef boost::icl::discrete_interval<DomainT,Compare> interval_type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+
+    static interval_type construct(const domain_type& lo, const domain_type& up, interval_bounds bounds)
+    {
+        return interval_type(lo, up, bounds, static_cast<interval_type*>(0) );
+    }
+
+    static interval_type construct_bounded(const bounded_value<DomainT>& lo, 
+                                           const bounded_value<DomainT>& up)
+    {
+        return  interval_type
+                (
+                    lo.value(), up.value(),
+                    lo.bound().left() | up.bound().right(),
+                    static_cast<interval_type* >(0) 
+                );
+    }
+};
+
+//==============================================================================
+//= Type traits
+//==============================================================================
+template <class DomainT, ICL_COMPARE Compare> 
+struct interval_bound_type< discrete_interval<DomainT,Compare> >
+{
+    typedef interval_bound_type type;
+    BOOST_STATIC_CONSTANT(bound_type, value = interval_bounds::dynamic);
+};
+
+template <class DomainT, ICL_COMPARE Compare> 
+struct is_discrete_interval<discrete_interval<DomainT,Compare> >
+{
+    typedef is_discrete_interval<discrete_interval<DomainT,Compare> > type;
+    BOOST_STATIC_CONSTANT(bool, value = is_discrete<DomainT>::value);
+};
+
+template <class DomainT, ICL_COMPARE Compare>
+struct type_to_string<icl::discrete_interval<DomainT,Compare> >
+{
+    static std::string apply()
+    { return "dI<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+template<class DomainT> 
+struct value_size<icl::discrete_interval<DomainT> >
+{
+    static std::size_t apply(const icl::discrete_interval<DomainT>&) 
+    { return 2; }
+};
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/dynamic_interval_traits.hpp
+++ b/inst/include/boost/icl/dynamic_interval_traits.hpp
@@ -1,0 +1,37 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_DYNAMIC_INTERVAL_TRAITS_HPP_JOFA_100926
+#define BOOST_ICL_DYNAMIC_INTERVAL_TRAITS_HPP_JOFA_100926
+
+namespace boost{ namespace icl
+{
+
+class interval_bounds;
+template<class DomainT> class bounded_value;
+
+
+//------------------------------------------------------------------------------
+//- Adapter class
+//------------------------------------------------------------------------------
+template<class Type>
+struct dynamic_interval_traits
+{
+    typedef typename Type::domain_type    domain_type;
+    typedef typename Type::domain_compare domain_compare;
+
+    static Type construct(const domain_type& lo, const domain_type& up, interval_bounds bounds);
+    static Type construct_bounded(const bounded_value<domain_type>& lo, 
+                                  const bounded_value<domain_type>& up);
+};
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/functors.hpp
+++ b/inst/include/boost/icl/functors.hpp
@@ -1,0 +1,470 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_FUNCTORS_HPP_JOFA_080315
+#define BOOST_ICL_FUNCTORS_HPP_JOFA_080315
+
+#include <functional>
+#include <boost/type_traits.hpp>
+#include <boost/mpl/if.hpp>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/unit_element.hpp>
+#include <boost/icl/type_traits/is_set.hpp>
+#include <boost/icl/type_traits/has_set_semantics.hpp>
+
+namespace boost{namespace icl
+{
+    // ------------------------------------------------------------------------
+    template <typename Type> struct identity_based_inplace_combine 
+        : public std::binary_function<Type&, const Type&, void>
+    {
+        inline static Type identity_element() { return boost::icl::identity_element<Type>::value(); }
+    };
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct unit_element_based_inplace_combine 
+        : public std::binary_function<Type&, const Type&, void>
+    {
+        inline static Type identity_element() { return boost::icl::unit_element<Type>::value(); }
+    };
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_identity 
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_identity<Type> type;
+        void operator()(Type&, const Type&)const{}
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_identity>::apply() 
+    { return "i="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_erasure 
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_erasure<Type> type;
+        typedef identity_based_inplace_combine<Type> base_type;
+
+        void operator()(Type& object, const Type& operand)const
+        { 
+            if(object == operand)
+                //identity_element(); //JODO Old gcc-3.4.4 does not compile this
+                object = base_type::identity_element(); //<-- but this.
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_erasure>::apply() 
+    { return "0="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_plus 
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_plus<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object += operand; }
+
+        static void version(Type&){}
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_plus>::apply() { return "+="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_minus 
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_minus<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object -= operand; }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_minus>::apply() { return "-="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_bit_add
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_bit_add<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object |= operand; }
+
+        static void version(Type&){}
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_bit_add>::apply() { return "b|="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_bit_subtract
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_bit_subtract<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object &= ~operand; }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_bit_subtract>::apply() { return "b-="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_bit_and
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_bit_and<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object &= operand; }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_bit_and>::apply() { return "b&="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_bit_xor
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_bit_xor<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object ^= operand; }
+    };
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_et
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_et<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object &= operand; }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_et>::apply() { return "&="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_caret
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_caret<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object ^= operand; }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_caret>::apply() { return "^="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_insert
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_insert<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { insert(object,operand); }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_insert>::apply() { return "ins="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_erase
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_erase<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { erase(object,operand); }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_erase>::apply() { return "ers="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_star
+        : public identity_based_inplace_combine<Type> //JODO unit_element_
+    {
+        typedef inplace_star<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object *= operand; }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_star>::apply() { return "*="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_slash
+        : public identity_based_inplace_combine<Type> //JODO unit_element_
+    {
+        typedef inplace_slash<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        { object /= operand; }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_slash>::apply() { return "/="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_max
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_max<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        {
+            if(object < operand)
+                object = operand;
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_max>::apply() { return "max="; }
+
+    // ------------------------------------------------------------------------
+    template <typename Type> struct inplace_min
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef inplace_min<Type> type;
+
+        void operator()(Type& object, const Type& operand)const
+        {
+            if(object > operand)
+                object = operand;
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<inplace_min>::apply() { return "min="; }
+
+    //--------------------------------------------------------------------------
+    // Inter_section functor
+    //--------------------------------------------------------------------------
+    template<class Type> struct inter_section
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef typename boost::mpl::
+            if_<has_set_semantics<Type>,
+                icl::inplace_et<Type>, 
+                icl::inplace_plus<Type> 
+               >::type
+            type;
+
+        void operator()(Type& object, const Type& operand)const
+        { 
+            type()(object, operand);
+        }
+    };
+
+    //--------------------------------------------------------------------------
+    // Inverse functor
+    //--------------------------------------------------------------------------
+    template<class Functor> struct inverse;
+
+    template<class Type> 
+    struct inverse<icl::inplace_plus<Type> >
+    { typedef icl::inplace_minus<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_minus<Type> >
+    { typedef icl::inplace_plus<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_bit_add<Type> >
+    { typedef icl::inplace_bit_subtract<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_bit_subtract<Type> >
+    { typedef icl::inplace_bit_add<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_et<Type> >
+    { typedef icl::inplace_caret<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_caret<Type> >
+    { typedef icl::inplace_et<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_bit_and<Type> >
+    { typedef icl::inplace_bit_xor<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_bit_xor<Type> >
+    { typedef icl::inplace_bit_and<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_star<Type> >
+    { typedef icl::inplace_slash<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_slash<Type> >
+    { typedef icl::inplace_star<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_max<Type> >
+    { typedef icl::inplace_min<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_min<Type> >
+    { typedef icl::inplace_max<Type> type; };
+
+    template<class Type> 
+    struct inverse<icl::inplace_identity<Type> >
+    { typedef icl::inplace_erasure<Type> type; };
+
+    // If a Functor 
+    template<class Functor> 
+    struct inverse
+    {
+        typedef typename 
+            remove_reference<typename Functor::first_argument_type>::type argument_type;
+        typedef icl::inplace_erasure<argument_type> type; 
+    };
+
+
+    //--------------------------------------------------------------------------
+    // Inverse inter_section functor
+    //--------------------------------------------------------------------------
+    template<class Type> 
+    struct inverse<icl::inter_section<Type> >
+        : public identity_based_inplace_combine<Type>
+    {
+        typedef typename boost::mpl::
+            if_<has_set_semantics<Type>,
+                icl::inplace_caret<Type>, 
+                icl::inplace_minus<Type> 
+               >::type
+            type;
+
+        void operator()(Type& object, const Type& operand)const
+        { 
+            type()(object, operand);
+        }
+    };
+
+
+    //--------------------------------------------------------------------------
+    // Positive or negative functor trait
+    //--------------------------------------------------------------------------
+
+    // A binary operation - is negative (or inverting) with respect to the
+    // neutral element iff it yields the inverse element if it is applied to the 
+    // identity element:
+    // 0 - x = -x
+    // For a functor that wraps the inplace of op-assign version this is 
+    // equivalent to
+    //
+    // T x = ..., y;
+    // y = Functor::identity_element();
+    // Functor()(y, x); // y == inverse_of(x) 
+
+    template<class Functor> struct is_negative;
+
+    template<class Functor> 
+    struct is_negative
+    {
+        typedef is_negative<Functor> type;
+        BOOST_STATIC_CONSTANT(bool, value = false);
+    };
+
+    template<class Type> 
+    struct is_negative<icl::inplace_minus<Type> >
+    {
+        typedef is_negative type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    template<class Type> 
+    struct is_negative<icl::inplace_bit_subtract<Type> >
+    {
+        typedef is_negative type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    //--------------------------------------------------------------------------
+    // Pro- or in-version functor
+    //--------------------------------------------------------------------------
+    template<class Combiner> struct conversion;
+
+    template<class Combiner> 
+    struct conversion
+    { 
+        typedef conversion<Combiner> type;
+        typedef typename
+            remove_const<
+                typename remove_reference<typename Combiner::first_argument_type
+                >::type
+            >::type
+            argument_type;
+        // The proversion of an op-assign functor o= lets the value unchanged
+        // (0 o= x) == x;
+        // Example += :  (0 += x) == x
+        static argument_type proversion(const argument_type& value)
+        { 
+            return value; 
+        } 
+
+        // The inversion of an op-assign functor o= inverts the value x
+        // to it's inverse element -x
+        // (0 o= x) == -x;
+        // Example -= :  (0 -= x) == -x
+        static argument_type inversion(const argument_type& value)
+        {
+            argument_type inverse = Combiner::identity_element();
+            Combiner()(inverse, value);
+            return inverse;
+        }
+    };
+
+    template<class Combiner> struct version : public conversion<Combiner>
+    {
+        typedef    version<Combiner> type;
+        typedef conversion<Combiner> base_type;
+        typedef typename base_type::argument_type argument_type;
+
+        argument_type operator()(const argument_type& value)
+        { return base_type::proversion(value); } 
+    };
+
+    template<>struct version<icl::inplace_minus<short      > >{short       operator()(short       val){return -val;}};
+    template<>struct version<icl::inplace_minus<int        > >{int         operator()(int         val){return -val;}};
+    template<>struct version<icl::inplace_minus<long       > >{long        operator()(long        val){return -val;}};
+    template<>struct version<icl::inplace_minus<long long  > >{long long   operator()(long long   val){return -val;}};
+    template<>struct version<icl::inplace_minus<float      > >{float       operator()(float       val){return -val;}};
+    template<>struct version<icl::inplace_minus<double     > >{double      operator()(double      val){return -val;}};
+    template<>struct version<icl::inplace_minus<long double> >{long double operator()(long double val){return -val;}};
+
+    template<class Type> 
+    struct version<icl::inplace_minus<Type> > : public conversion<icl::inplace_minus<Type> >
+    { 
+        typedef    version<icl::inplace_minus<Type> > type;
+        typedef conversion<icl::inplace_minus<Type> > base_type;
+        typedef typename base_type::argument_type argument_type;
+
+        Type operator()(const Type& value)
+        {
+            return base_type::inversion(value);
+        } 
+    };
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/gregorian.hpp
+++ b/inst/include/boost/icl/gregorian.hpp
@@ -1,0 +1,127 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_GREGORIAN_DATE_HPP_JOFA_080416
+#define BOOST_ICL_GREGORIAN_DATE_HPP_JOFA_080416
+
+#include <boost/icl/detail/boost_config.hpp>
+#include <boost/detail/workaround.hpp>
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4100) // unreferenced formal parameter
+#pragma warning(disable:4127) // conditional expression is constant
+#pragma warning(disable:4244) // 'argument' : conversion from 'int' to 'unsigned short', possible loss of data
+#pragma warning(disable:4702) // boost\lexical_cast.hpp(1159) : warning C4702: unreachable code
+#pragma warning(disable:4996) // Function call with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct. To disable this warning, use -D_SCL_SECURE_NO_WARNINGS. See documentation on how to use Visual C++ 'Checked Iterators'
+#endif
+
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <boost/date_time/gregorian/gregorian.hpp>
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/is_discrete.hpp>
+#include <boost/icl/type_traits/difference_type_of.hpp>
+#include <boost/icl/type_traits/size_type_of.hpp>
+
+namespace boost{namespace icl
+{
+    template<> struct is_discrete<boost::gregorian::date>
+    {
+        typedef is_discrete type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    template<> 
+    inline boost::gregorian::date identity_element<boost::gregorian::date>::value()
+    { 
+        return boost::gregorian::date(boost::gregorian::min_date_time); 
+    }
+
+    template<> 
+    struct identity_element<boost::gregorian::date_duration>
+    {
+        static boost::gregorian::date_duration value()
+        { 
+            return boost::gregorian::date(boost::gregorian::min_date_time) 
+                 - boost::gregorian::date(boost::gregorian::min_date_time); 
+        }
+    };
+
+    template<> 
+    struct has_difference<boost::gregorian::date> 
+    { 
+        typedef has_difference type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };  
+
+    template<> 
+    struct difference_type_of<boost::gregorian::date> 
+    { typedef boost::gregorian::date_duration type; };  
+
+    template<> 
+    struct size_type_of<boost::gregorian::date> 
+    { typedef boost::gregorian::date_duration type; };  
+
+
+
+    // ------------------------------------------------------------------------
+    inline boost::gregorian::date operator ++(boost::gregorian::date& x)
+    {
+        return x += boost::gregorian::date::duration_type::unit();
+    }
+
+    inline boost::gregorian::date operator --(boost::gregorian::date& x)
+    {
+        return x -= boost::gregorian::date::duration_type::unit();
+    }
+
+    // ------------------------------------------------------------------------
+    template<> struct is_discrete<boost::gregorian::date_duration>
+    {
+        typedef is_discrete type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    template<> 
+    struct has_difference<boost::gregorian::date_duration> 
+    { 
+        typedef has_difference type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };  
+
+    template<> 
+    struct size_type_of<boost::gregorian::date_duration> 
+    { 
+        typedef boost::gregorian::date_duration type; 
+    };  
+
+    inline boost::gregorian::date_duration operator ++(boost::gregorian::date_duration& x)
+    {
+        return x += boost::gregorian::date::duration_type::unit();
+    }
+
+    inline boost::gregorian::date_duration operator --(boost::gregorian::date_duration& x)
+    {
+        return x -= boost::gregorian::date::duration_type::unit();
+    }
+
+    // ------------------------------------------------------------------------
+
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/impl_config.hpp
+++ b/inst/include/boost/icl/impl_config.hpp
@@ -1,0 +1,61 @@
+/*-----------------------------------------------------------------------------+
+Author: Joachim Faulhaber
+Copyright (c) 2009-2011: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef  BOOST_ICL_IMPL_CONFIG_HPP_JOFA_091225
+#define  BOOST_ICL_IMPL_CONFIG_HPP_JOFA_091225
+
+#include <boost/icl/detail/boost_config.hpp>
+
+/*-----------------------------------------------------------------------------+
+| You can choose an implementation for the basic set and map classes.          |
+| Select at most ONE of the following defines to change the default            |
++-----------------------------------------------------------------------------*/
+
+//#define ICL_USE_STD_IMPLEMENTATION                // Default
+//#define ICL_USE_BOOST_MOVE_IMPLEMENTATION         // Boost.Container
+//        ICL_USE_BOOST_INTERPROCESS_IMPLEMENTATION // No longer available
+
+/*-----------------------------------------------------------------------------+
+| NO define or ICL_USE_STD_IMPLEMENTATION: Choose std::set and std::map from   |
+|     your local std implementation as implementing containers (DEFAULT).      |
+|     Whether move semantics is available depends on the version of your local |
+|     STL.                                                                     |
+|                                                                              |
+| ICL_USE_BOOST_MOVE_IMPLEMENTATION:                                           |
+|     Use move aware containers from boost::container.                         |
+|                                                                              |
+| NOTE: ICL_USE_BOOST_INTERPROCESS_IMPLEMENTATION: This define has been        |
+|     available until boost version 1.48.0 and is no longer supported.         |
++-----------------------------------------------------------------------------*/
+
+#if defined(ICL_USE_BOOST_MOVE_IMPLEMENTATION)
+#   define ICL_IMPL_SPACE boost::container
+#elif defined(ICL_USE_STD_IMPLEMENTATION)
+#   define ICL_IMPL_SPACE std
+#else
+#   define ICL_IMPL_SPACE std
+#endif
+
+/*-----------------------------------------------------------------------------+
+| MEMO 2012-12-30: Due to problems with new c++11 compilers and their          | 
+| implementation of rvalue references, ICL's move implementation will be       |
+| disabled for some new compilers for version 1.53.                            |
++-----------------------------------------------------------------------------*/
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+#   define BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//#elif defined(__clang__)
+//#   define BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+//#elif (defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))
+//#   define BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+#endif
+
+#include <boost/move/move.hpp>
+
+#endif // BOOST_ICL_IMPL_CONFIG_HPP_JOFA_091225
+
+

--- a/inst/include/boost/icl/interval.hpp
+++ b/inst/include/boost/icl/interval.hpp
@@ -1,0 +1,136 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_HPP_JOFA_101014
+#define BOOST_ICL_INTERVAL_HPP_JOFA_101014
+
+
+#include <boost/icl/type_traits/interval_type_default.hpp>
+
+
+namespace boost{ namespace icl
+{
+
+    template <class IntervalT, bool IsDiscrete, bound_type PretendedBounds, bound_type RepresentedBounds> 
+    struct static_interval;
+
+    template <class DomainT, ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)> 
+    struct interval
+    {
+        typedef typename interval_type_default<DomainT,Compare>::type interval_type;
+        typedef interval_type type;
+
+#ifdef BOOST_ICL_USE_STATIC_BOUNDED_INTERVALS
+
+        static inline interval_type open(const DomainT& low, const DomainT& up)
+        {
+            return 
+                static_interval
+                < interval_type                // if the domain_type is discrete ...
+                , is_discrete<typename interval_traits<interval_type>::domain_type>::value
+                , interval_bounds::static_open // 'pretended' bounds will be transformed to
+                , interval_bound_type<interval_type>::value // the represented bounds
+                >
+                ::construct(low, up); 
+        }
+
+        static inline interval_type left_open(const DomainT& low, const DomainT& up)
+        {
+            return 
+                static_interval
+                < interval_type
+                , is_discrete<typename interval_traits<interval_type>::domain_type>::value
+                , interval_bounds::static_left_open
+                , interval_bound_type<interval_type>::value
+                >
+                ::construct(low, up); 
+        }
+
+        static inline interval_type right_open(const DomainT& low, const DomainT& up)
+        {
+            return 
+                static_interval
+                < interval_type
+                , is_discrete<typename interval_traits<interval_type>::domain_type>::value
+                , interval_bounds::static_right_open
+                , interval_bound_type<interval_type>::value
+                >
+                ::construct(low, up); 
+        }
+
+        static inline interval_type closed(const DomainT& low, const DomainT& up)
+        {
+            return 
+                static_interval
+                < interval_type
+                , is_discrete<typename interval_traits<interval_type>::domain_type>::value
+                , interval_bounds::static_closed
+                , interval_bound_type<interval_type>::value
+                >
+                ::construct(low, up); 
+        }
+
+        static inline interval_type construct(const DomainT& low, const DomainT& up)
+        { return icl::construct<interval_type>(low, up); }
+
+#else // ICL_USE_DYNAMIC_INTERVAL_BORDER_DEFAULTS
+        static inline interval_type right_open(const DomainT& low, const DomainT& up)
+        { return icl::construct<interval_type>(low, up, interval_bounds::right_open()); }
+
+        static inline interval_type left_open(const DomainT& low, const DomainT& up)
+        { return icl::construct<interval_type>(low, up, interval_bounds::left_open()); }
+
+        static inline interval_type open(const DomainT& low, const DomainT& up)
+        { return icl::construct<interval_type>(low, up, interval_bounds::open()); }
+
+        static inline interval_type closed(const DomainT& low, const DomainT& up)
+        { return icl::construct<interval_type>(low, up, interval_bounds::closed()); }
+
+        static inline interval_type construct(const DomainT& low, const DomainT& up)
+        { return icl::construct<interval_type>(low, up); }
+
+#endif 
+    };
+
+    template <class IntervalT, bound_type PretendedBounds, bound_type RepresentedBounds> 
+    struct static_interval<IntervalT, true, PretendedBounds, RepresentedBounds>
+    {// is_discrete<domain_type<IntervalT>>
+        typedef typename interval_traits<IntervalT>::domain_type domain_type;
+
+        static inline IntervalT construct(const domain_type& low, const domain_type& up)
+        {
+            return icl::construct<IntervalT>(
+                  shift_lower(interval_bounds(PretendedBounds), interval_bounds(RepresentedBounds), low)
+                , shift_upper(interval_bounds(PretendedBounds), interval_bounds(RepresentedBounds), up )
+                ); 
+        }
+    };
+
+    template <class IntervalT, bound_type PretendedBounds, bound_type RepresentedBounds> 
+    struct static_interval<IntervalT, false, PretendedBounds, RepresentedBounds>
+    {// !is_discrete<domain_type<IntervalT>>
+        typedef typename interval_traits<IntervalT>::domain_type domain_type;
+
+        static inline IntervalT construct(const domain_type& low, const domain_type& up)
+        {
+            BOOST_STATIC_ASSERT((is_discrete<domain_type>::value || PretendedBounds==RepresentedBounds));
+            // For domain_types that are not discrete, e.g. interval<float> 
+            // one of the following must hold: If you call
+            // interval<T>::right_open(x,y) then interval<T>::type must be static_right_open
+            // interval<T>::left_open(x,y)  then interval<T>::type must be static_left_open
+            // interval<T>::open(x,y)       then interval<T>::type must be static_open
+            // interval<T>::closed(x,y)     then interval<T>::type must be static_closed
+            // Conversion between 'PretendedBounds' and 'RepresentedBounds' is only possible
+            // for discrete domain_types.
+            return icl::construct<IntervalT>(low, up);
+        }
+    };
+
+}} // namespace boost icl
+
+#endif // BOOST_ICL_INTERVAL_HPP_JOFA_101014
+

--- a/inst/include/boost/icl/interval_base_map.hpp
+++ b/inst/include/boost/icl/interval_base_map.hpp
@@ -1,0 +1,1389 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2012: Joachim Faulhaber
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_BASE_MAP_HPP_JOFA_990223
+#define BOOST_ICL_INTERVAL_BASE_MAP_HPP_JOFA_990223
+
+#include <limits>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/not.hpp>
+
+#include <boost/icl/detail/notate.hpp> 
+#include <boost/icl/detail/design_config.hpp>
+#include <boost/icl/detail/on_absorbtion.hpp>
+#include <boost/icl/detail/interval_map_algo.hpp>
+
+#include <boost/icl/associative_interval_container.hpp>
+
+#include <boost/icl/type_traits/is_interval_splitter.hpp>
+#include <boost/icl/map.hpp>
+
+namespace boost{namespace icl
+{
+
+template<class DomainT, class CodomainT>
+struct mapping_pair
+{
+    DomainT   key;
+    CodomainT data;
+
+    mapping_pair():key(), data(){}
+
+    mapping_pair(const DomainT& key_value, const CodomainT& data_value)
+        :key(key_value), data(data_value){}
+
+    mapping_pair(const std::pair<DomainT,CodomainT>& std_pair)
+        :key(std_pair.first), data(std_pair.second){}
+};
+
+/** \brief Implements a map as a map of intervals (base class) */
+template
+<
+    class SubType,
+    typename DomainT,
+    typename CodomainT,
+    class Traits = icl::partial_absorber,
+    ICL_COMPARE Compare  = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_COMBINE Combine  = ICL_COMBINE_INSTANCE(icl::inplace_plus, CodomainT),
+    ICL_SECTION Section  = ICL_SECTION_INSTANCE(icl::inter_section, CodomainT), 
+    ICL_INTERVAL(ICL_COMPARE) Interval = ICL_INTERVAL_INSTANCE(ICL_INTERVAL_DEFAULT, DomainT, Compare),
+    ICL_ALLOC   Alloc    = std::allocator
+>
+class interval_base_map
+{
+public:
+    //==========================================================================
+    //= Associated types
+    //==========================================================================
+    typedef interval_base_map<SubType,DomainT,CodomainT,
+                              Traits,Compare,Combine,Section,Interval,Alloc>
+                              type;
+
+    /// The designated \e derived or \e sub_type of this base class
+    typedef SubType sub_type;
+
+    /// Auxilliary type for overloadresolution
+    typedef type overloadable_type;
+
+    /// Traits of an itl map
+    typedef Traits traits;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Related types
+    //--------------------------------------------------------------------------
+    /// The atomized type representing the corresponding container of elements
+    typedef typename icl::map<DomainT,CodomainT,
+                              Traits,Compare,Combine,Section,Alloc> atomized_type;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Data
+    //--------------------------------------------------------------------------
+    /// Domain type (type of the keys) of the map
+    typedef DomainT   domain_type;
+    typedef typename boost::call_traits<DomainT>::param_type domain_param;
+    /// Domain type (type of the keys) of the map
+    typedef CodomainT codomain_type;
+    /// Auxiliary type to help the compiler resolve ambiguities when using std::make_pair
+    typedef mapping_pair<domain_type,codomain_type> domain_mapping_type;
+    /// Conceptual is a map a set of elements of type \c element_type
+    typedef domain_mapping_type element_type;
+    /// The interval type of the map
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) interval_type;
+    /// Auxiliary type for overload resolution
+    typedef std::pair<interval_type,CodomainT> interval_mapping_type;
+    /// Type of an interval containers segment, that is spanned by an interval
+    typedef std::pair<interval_type,CodomainT> segment_type;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Size
+    //--------------------------------------------------------------------------
+    /// The difference type of an interval which is sometimes different form the domain_type
+    typedef typename difference_type_of<domain_type>::type difference_type;
+    /// The size type of an interval which is mostly std::size_t
+    typedef typename size_type_of<domain_type>::type size_type;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Functors
+    //--------------------------------------------------------------------------
+    /// Comparison functor for domain values
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT)      domain_compare;
+    typedef ICL_COMPARE_DOMAIN(Compare,segment_type) segment_compare;
+    /// Combine functor for codomain value aggregation
+    typedef ICL_COMBINE_CODOMAIN(Combine,CodomainT)  codomain_combine;
+    /// Inverse Combine functor for codomain value aggregation
+    typedef typename inverse<codomain_combine>::type inverse_codomain_combine;
+    /// Intersection functor for codomain values
+
+    typedef typename mpl::if_
+    <has_set_semantics<codomain_type>
+    , ICL_SECTION_CODOMAIN(Section,CodomainT)     
+    , codomain_combine
+    >::type                                            codomain_intersect;
+
+
+    /// Inverse Combine functor for codomain value intersection
+    typedef typename inverse<codomain_intersect>::type inverse_codomain_intersect;
+
+    /// Comparison functor for intervals which are keys as well
+    typedef exclusive_less_than<interval_type> interval_compare;
+
+    /// Comparison functor for keys
+    typedef exclusive_less_than<interval_type> key_compare;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Implementation and stl related
+    //--------------------------------------------------------------------------
+    /// The allocator type of the set
+    typedef Alloc<std::pair<const interval_type, codomain_type> > 
+        allocator_type;
+
+    /// Container type for the implementation 
+    typedef ICL_IMPL_SPACE::map<interval_type,codomain_type,
+                                key_compare,allocator_type> ImplMapT;
+
+    /// key type of the implementing container
+    typedef typename ImplMapT::key_type   key_type;
+    /// value type of the implementing container
+    typedef typename ImplMapT::value_type value_type;
+    /// data type of the implementing container
+    typedef typename ImplMapT::value_type::second_type data_type;
+
+    /// pointer type
+    typedef typename ImplMapT::pointer         pointer;
+    /// const pointer type
+    typedef typename ImplMapT::const_pointer   const_pointer;
+    /// reference type
+    typedef typename ImplMapT::reference       reference;
+    /// const reference type
+    typedef typename ImplMapT::const_reference const_reference;
+
+    /// iterator for iteration over intervals
+    typedef typename ImplMapT::iterator iterator;
+    /// const_iterator for iteration over intervals
+    typedef typename ImplMapT::const_iterator const_iterator;
+    /// iterator for reverse iteration over intervals
+    typedef typename ImplMapT::reverse_iterator reverse_iterator;
+    /// const_iterator for iteration over intervals
+    typedef typename ImplMapT::const_reverse_iterator const_reverse_iterator;
+
+    /// element iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<iterator> element_iterator; 
+    /// const element iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<const_iterator> element_const_iterator; 
+    /// element reverse iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<reverse_iterator> element_reverse_iterator; 
+    /// element const reverse iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<const_reverse_iterator> element_const_reverse_iterator; 
+    
+    typedef typename on_absorbtion<type, codomain_combine, 
+                                Traits::absorbs_identities>::type on_codomain_absorbtion;
+
+public:
+    BOOST_STATIC_CONSTANT(bool, 
+        is_total_invertible = (   Traits::is_total 
+                               && has_inverse<codomain_type>::value));
+
+    BOOST_STATIC_CONSTANT(int, fineness = 0); 
+
+public:
+
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor for the empty object */
+    interval_base_map()
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
+        BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
+    }
+
+    /** Copy constructor */
+    interval_base_map(const interval_base_map& src): _map(src._map)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
+        BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    /** Move constructor */
+    interval_base_map(interval_base_map&& src): _map(boost::move(src._map))
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
+        BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
+    }
+
+    /** Move assignment operator */
+    interval_base_map& operator = (interval_base_map src) 
+    {                           //call by value sice 'src' is a "sink value" 
+        this->_map = boost::move(src._map);
+        return *this; 
+    }
+
+    //==========================================================================
+#   else 
+
+    /** Copy assignment operator */
+    interval_base_map& operator = (const interval_base_map& src) 
+    { 
+        this->_map = src._map;
+        return *this; 
+    }
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+    /** swap the content of containers */
+    void swap(interval_base_map& object) { _map.swap(object._map); }
+
+    //==========================================================================
+    //= Containedness
+    //==========================================================================
+    /** clear the map */
+    void clear() { icl::clear(*that()); }
+
+    /** is the map empty? */
+    bool empty()const { return icl::is_empty(*that()); }
+
+    //==========================================================================
+    //= Size
+    //==========================================================================
+    /** An interval map's size is it's cardinality */
+    size_type size()const
+    {
+        return icl::cardinality(*that());
+    }
+
+    /** Size of the iteration over this container */
+    std::size_t iterative_size()const 
+    { 
+        return _map.size(); 
+    }
+
+    //==========================================================================
+    //= Selection
+    //==========================================================================
+
+    /** Find the interval value pair, that contains \c key */
+    const_iterator find(const domain_type& key_value)const
+    { 
+        return icl::find(*this, key_value);
+    }
+
+    /** Find the first interval value pair, that collides with interval 
+        \c key_interval */
+    const_iterator find(const interval_type& key_interval)const
+    { 
+        return _map.find(key_interval); 
+    }
+
+    /** Total select function. */
+    codomain_type operator()(const domain_type& key_value)const
+    {
+        const_iterator it_ = icl::find(*this, key_value);
+        return it_==end() ? identity_element<codomain_type>::value()
+                          : (*it_).second;
+    }
+
+    //==========================================================================
+    //= Addition
+    //==========================================================================
+
+    /** Addition of a key value pair to the map */
+    SubType& add(const element_type& key_value_pair) 
+    {
+        return icl::add(*that(), key_value_pair);
+    }
+
+    /** Addition of an interval value pair to the map. */
+    SubType& add(const segment_type& interval_value_pair) 
+    {
+        this->template _add<codomain_combine>(interval_value_pair);
+        return *that();
+    }
+
+    /** Addition of an interval value pair \c interval_value_pair to the map. 
+        Iterator \c prior_ is a hint to the position \c interval_value_pair can be 
+        inserted after. */
+    iterator add(iterator prior_, const segment_type& interval_value_pair) 
+    {
+        return this->template _add<codomain_combine>(prior_, interval_value_pair);
+    }
+
+    //==========================================================================
+    //= Subtraction
+    //==========================================================================
+    /** Subtraction of a key value pair from the map */
+    SubType& subtract(const element_type& key_value_pair)
+    { 
+        return icl::subtract(*that(), key_value_pair);
+    }
+
+    /** Subtraction of an interval value pair from the map. */
+    SubType& subtract(const segment_type& interval_value_pair)
+    {
+        on_invertible<type, is_total_invertible>
+            ::subtract(*that(), interval_value_pair);
+        return *that();
+    }
+
+    //==========================================================================
+    //= Insertion
+    //==========================================================================
+    /** Insertion of a \c key_value_pair into the map. */
+    SubType& insert(const element_type& key_value_pair) 
+    {
+        return icl::insert(*that(), key_value_pair);
+    }
+
+    /** Insertion of an \c interval_value_pair into the map. */
+    SubType& insert(const segment_type& interval_value_pair)
+    { 
+        _insert(interval_value_pair); 
+        return *that();
+    }
+
+    /** Insertion of an \c interval_value_pair into the map. Iterator \c prior_. 
+        serves as a hint to insert after the element \c prior point to. */
+    iterator insert(iterator prior, const segment_type& interval_value_pair)
+    { 
+        return _insert(prior, interval_value_pair);
+    }
+
+    /** With <tt>key_value_pair = (k,v)</tt> set value \c v for key \c k */
+    SubType& set(const element_type& key_value_pair) 
+    { 
+        return icl::set_at(*that(), key_value_pair);
+    }
+
+    /** With <tt>interval_value_pair = (I,v)</tt> set value \c v 
+        for all keys in interval \c I in the map. */
+    SubType& set(const segment_type& interval_value_pair)
+    { 
+        return icl::set_at(*that(), interval_value_pair);
+    }
+
+    //==========================================================================
+    //= Erasure
+    //==========================================================================
+    /** Erase a \c key_value_pair from the map. */
+    SubType& erase(const element_type& key_value_pair) 
+    { 
+        icl::erase(*that(), key_value_pair);
+        return *that();
+    }
+
+    /** Erase an \c interval_value_pair from the map. */
+    SubType& erase(const segment_type& interval_value_pair);
+
+    /** Erase a key value pair for \c key. */
+    SubType& erase(const domain_type& key) 
+    { 
+        return icl::erase(*that(), key); 
+    }
+
+    /** Erase all value pairs within the range of the 
+        interval <tt>inter_val</tt> from the map.   */
+    SubType& erase(const interval_type& inter_val);
+
+
+    /** Erase all value pairs within the range of the interval that iterator 
+        \c position points to. */
+    void erase(iterator position){ this->_map.erase(position); }
+
+    /** Erase all value pairs for a range of iterators <tt>[first,past)</tt>. */
+    void erase(iterator first, iterator past){ this->_map.erase(first, past); }
+
+    //==========================================================================
+    //= Intersection
+    //==========================================================================
+    /** The intersection of \c interval_value_pair and \c *this map is added to \c section. */
+    void add_intersection(SubType& section, const segment_type& interval_value_pair)const
+    {
+        on_definedness<SubType, Traits::is_total>
+            ::add_intersection(section, *that(), interval_value_pair);
+    }
+
+    //==========================================================================
+    //= Symmetric difference
+    //==========================================================================
+    /** If \c *this map contains \c key_value_pair it is erased, otherwise it is added. */
+    SubType& flip(const element_type& key_value_pair)
+    { 
+        return icl::flip(*that(), key_value_pair); 
+    }
+
+    /** If \c *this map contains \c interval_value_pair it is erased, otherwise it is added. */
+    SubType& flip(const segment_type& interval_value_pair)
+    {
+        on_total_absorbable<SubType, Traits::is_total, Traits::absorbs_identities>
+            ::flip(*that(), interval_value_pair);
+        return *that();
+    }
+
+    //==========================================================================
+    //= Iterator related
+    //==========================================================================
+
+    iterator lower_bound(const key_type& interval)
+    { return _map.lower_bound(interval); }
+
+    iterator upper_bound(const key_type& interval)
+    { return _map.upper_bound(interval); }
+
+    const_iterator lower_bound(const key_type& interval)const
+    { return _map.lower_bound(interval); }
+
+    const_iterator upper_bound(const key_type& interval)const
+    { return _map.upper_bound(interval); }
+
+    std::pair<iterator,iterator> equal_range(const key_type& interval)
+    { 
+        return std::pair<iterator,iterator>
+               (lower_bound(interval), upper_bound(interval)); 
+    }
+
+    std::pair<const_iterator,const_iterator> 
+        equal_range(const key_type& interval)const
+    { 
+        return std::pair<const_iterator,const_iterator>
+               (lower_bound(interval), upper_bound(interval)); 
+    }
+
+    iterator begin() { return _map.begin(); }
+    iterator end()   { return _map.end(); }
+    const_iterator begin()const { return _map.begin(); }
+    const_iterator end()const   { return _map.end(); }
+    reverse_iterator rbegin() { return _map.rbegin(); }
+    reverse_iterator rend()   { return _map.rend(); }
+    const_reverse_iterator rbegin()const { return _map.rbegin(); }
+    const_reverse_iterator rend()const   { return _map.rend(); }
+
+private:
+    template<class Combiner>
+    iterator _add(const segment_type& interval_value_pair);
+
+    template<class Combiner>
+    iterator _add(iterator prior_, const segment_type& interval_value_pair);
+
+    template<class Combiner>
+    void _subtract(const segment_type& interval_value_pair);
+
+    iterator _insert(const segment_type& interval_value_pair);
+    iterator _insert(iterator prior_, const segment_type& interval_value_pair);
+
+private:
+    template<class Combiner>
+    void add_segment(const interval_type& inter_val, const CodomainT& co_val, iterator& it_);
+
+    template<class Combiner>
+    void add_main(interval_type& inter_val, const CodomainT& co_val, 
+                  iterator& it_, const iterator& last_);
+
+    template<class Combiner>
+    void add_rear(const interval_type& inter_val, const CodomainT& co_val, iterator& it_);
+
+    void add_front(const interval_type& inter_val, iterator& first_);
+
+private:
+    void subtract_front(const interval_type& inter_val, iterator& first_);
+
+    template<class Combiner>
+    void subtract_main(const CodomainT& co_val, iterator& it_, const iterator& last_);
+
+    template<class Combiner>
+    void subtract_rear(interval_type& inter_val, const CodomainT& co_val, iterator& it_);
+
+private:
+    void insert_main(const interval_type&, const CodomainT&, iterator&, const iterator&);
+    void erase_rest (      interval_type&, const CodomainT&, iterator&, const iterator&);
+
+    template<class FragmentT>
+    void total_add_intersection(SubType& section, const FragmentT& fragment)const
+    {
+        section += *that();
+        section.add(fragment);
+    }
+
+    void partial_add_intersection(SubType& section, const segment_type& operand)const
+    {
+        interval_type inter_val = operand.first;
+        if(icl::is_empty(inter_val)) 
+            return;
+
+        std::pair<const_iterator, const_iterator> exterior = equal_range(inter_val);
+        if(exterior.first == exterior.second)
+            return;
+
+        for(const_iterator it_=exterior.first; it_ != exterior.second; it_++) 
+        {
+            interval_type common_interval = (*it_).first & inter_val; 
+            if(!icl::is_empty(common_interval))
+            {
+                section.template _add<codomain_combine>  (value_type(common_interval, (*it_).second) );
+                section.template _add<codomain_intersect>(value_type(common_interval, operand.second));
+            }
+        }
+    }
+
+    void partial_add_intersection(SubType& section, const element_type& operand)const
+    {
+        partial_add_intersection(section, make_segment<type>(operand));
+    }
+
+
+protected:
+
+    template <class Combiner>
+    iterator gap_insert(iterator prior_, const interval_type& inter_val, 
+                                         const codomain_type& co_val   )
+    {
+        // inter_val is not conained in this map. Insertion will be successful
+        BOOST_ASSERT(this->_map.find(inter_val) == this->_map.end());
+        BOOST_ASSERT((!on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable(co_val)));
+        return this->_map.insert(prior_, value_type(inter_val, version<Combiner>()(co_val)));
+    }
+
+    template <class Combiner>
+    std::pair<iterator, bool>
+    add_at(const iterator& prior_, const interval_type& inter_val, 
+                                   const codomain_type& co_val   )
+    {
+        // Never try to insert an identity element into an identity element absorber here:
+        BOOST_ASSERT((!(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable(co_val))));
+
+        iterator inserted_ 
+            = this->_map.insert(prior_, value_type(inter_val, Combiner::identity_element()));
+
+        if((*inserted_).first == inter_val && (*inserted_).second == Combiner::identity_element())
+        {
+            Combiner()((*inserted_).second, co_val);
+            return std::pair<iterator,bool>(inserted_, true);
+        }
+        else
+            return std::pair<iterator,bool>(inserted_, false);
+    }
+
+    std::pair<iterator, bool>
+    insert_at(const iterator& prior_, const interval_type& inter_val, 
+                                      const codomain_type& co_val   )
+    {
+        iterator inserted_
+            = this->_map.insert(prior_, value_type(inter_val, co_val));
+
+        if(inserted_ == prior_)
+            return std::pair<iterator,bool>(inserted_, false);
+        else if((*inserted_).first == inter_val)
+            return std::pair<iterator,bool>(inserted_, true);
+        else
+            return std::pair<iterator,bool>(inserted_, false);
+    }
+
+
+protected:
+    sub_type* that() { return static_cast<sub_type*>(this); }
+    const sub_type* that()const { return static_cast<const sub_type*>(this); }
+
+protected:
+    ImplMapT _map;
+
+
+private:
+    //--------------------------------------------------------------------------
+    template<class Type, bool is_total_invertible>
+    struct on_invertible;
+
+    template<class Type>
+    struct on_invertible<Type, true>
+    {
+        typedef typename Type::segment_type segment_type;
+        typedef typename Type::inverse_codomain_combine inverse_codomain_combine;
+
+        static void subtract(Type& object, const segment_type& operand)
+        { object.template _add<inverse_codomain_combine>(operand); }
+    };
+
+    template<class Type>
+    struct on_invertible<Type, false>
+    {
+        typedef typename Type::segment_type segment_type;
+        typedef typename Type::inverse_codomain_combine inverse_codomain_combine;
+
+        static void subtract(Type& object, const segment_type& operand)
+        { object.template _subtract<inverse_codomain_combine>(operand); }
+    };
+
+    friend struct on_invertible<type, true>;
+    friend struct on_invertible<type, false>;
+    //--------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------
+    template<class Type, bool is_total>
+    struct on_definedness;
+
+    template<class Type>
+    struct on_definedness<Type, true>
+    {
+        static void add_intersection(Type& section, const Type& object, 
+                                     const segment_type& operand)
+        { object.total_add_intersection(section, operand); }
+    };
+
+    template<class Type>
+    struct on_definedness<Type, false>
+    {
+        static void add_intersection(Type& section, const Type& object, 
+                                     const segment_type& operand)
+        { object.partial_add_intersection(section, operand); }
+    };
+
+    friend struct on_definedness<type, true>;
+    friend struct on_definedness<type, false>;
+    //--------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------
+    template<class Type, bool has_set_semantics> 
+    struct on_codomain_model;
+
+    template<class Type>
+    struct on_codomain_model<Type, true>
+    {
+        typedef typename Type::interval_type interval_type;
+        typedef typename Type::codomain_type codomain_type;
+        typedef typename Type::segment_type  segment_type;
+        typedef typename Type::codomain_combine codomain_combine;
+        typedef typename Type::inverse_codomain_intersect inverse_codomain_intersect;
+
+        static void add(Type& intersection, interval_type& common_interval, 
+                        const codomain_type& flip_value, const codomain_type& co_value)
+        {
+            codomain_type common_value = flip_value;
+            inverse_codomain_intersect()(common_value, co_value);
+            intersection.template 
+                _add<codomain_combine>(segment_type(common_interval, common_value));
+        }
+    };
+
+    template<class Type>
+    struct on_codomain_model<Type, false>
+    {
+        typedef typename Type::interval_type interval_type;
+        typedef typename Type::codomain_type codomain_type;
+        typedef typename Type::segment_type  segment_type;
+        typedef typename Type::codomain_combine codomain_combine;
+
+        static void add(Type& intersection, interval_type& common_interval, 
+                        const codomain_type&, const codomain_type&)
+        {
+            intersection.template 
+              _add<codomain_combine>(segment_type(common_interval, 
+                                                  identity_element<codomain_type>::value()));
+        }
+    };
+
+    friend struct on_codomain_model<type, true>;
+    friend struct on_codomain_model<type, false>;
+    //--------------------------------------------------------------------------
+
+
+    //--------------------------------------------------------------------------
+    template<class Type, bool is_total, bool absorbs_identities>
+    struct on_total_absorbable;
+
+    template<class Type>
+    struct on_total_absorbable<Type, true, true>
+    {
+        static void flip(Type& object, const typename Type::segment_type&)
+        { icl::clear(object); }
+    };
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant
+#endif                        
+
+    template<class Type>
+    struct on_total_absorbable<Type, true, false>
+    {
+        typedef typename Type::segment_type  segment_type;
+        typedef typename Type::codomain_type codomain_type;
+
+        static void flip(Type& object, const segment_type& operand)
+        { 
+            object += operand;
+            ICL_FORALL(typename Type, it_, object)
+                (*it_).second = identity_element<codomain_type>::value();
+
+            if(mpl::not_<is_interval_splitter<Type> >::value)
+                icl::join(object);
+        }
+    };
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+    template<class Type, bool absorbs_identities>
+    struct on_total_absorbable<Type, false, absorbs_identities>
+    {
+        typedef typename Type::segment_type   segment_type;
+        typedef typename Type::codomain_type  codomain_type;
+        typedef typename Type::interval_type  interval_type;
+        typedef typename Type::value_type     value_type;
+        typedef typename Type::const_iterator const_iterator;
+        typedef typename Type::set_type       set_type;
+        typedef typename Type::inverse_codomain_intersect inverse_codomain_intersect;
+
+        static void flip(Type& object, const segment_type& interval_value_pair)
+        {
+            // That which is common shall be subtracted
+            // That which is not shall be added
+            // So interval_value_pair has to be 'complementary added' or flipped
+            interval_type span = interval_value_pair.first;
+            std::pair<const_iterator, const_iterator> exterior 
+                = object.equal_range(span);
+
+            const_iterator first_ = exterior.first;
+            const_iterator end_   = exterior.second;
+
+            interval_type covered, left_over, common_interval;
+            const codomain_type& x_value = interval_value_pair.second;
+            const_iterator it_ = first_;
+
+            set_type eraser;
+            Type     intersection;
+
+            while(it_ != end_  ) 
+            {
+                const codomain_type& co_value = (*it_).second;
+                covered = (*it_++).first;
+                //[a      ...  : span
+                //     [b ...  : covered
+                //[a  b)       : left_over
+                left_over = right_subtract(span, covered);
+
+                //That which is common ...
+                common_interval = span & covered;
+                if(!icl::is_empty(common_interval))
+                {
+                    // ... shall be subtracted
+                    icl::add(eraser, common_interval);
+
+                    on_codomain_model<Type, has_set_semantics<codomain_type>::value>
+                        ::add(intersection, common_interval, x_value, co_value);
+                }
+
+                icl::add(object, value_type(left_over, x_value)); //That which is not shall be added
+                // Because this is a collision free addition I don't have to distinguish codomain_types.
+
+                //...      d) : span
+                //... c)      : covered
+                //     [c  d) : span'
+                span = left_subtract(span, covered);
+            }
+
+            //If span is not empty here, it is not in the set so it shall be added
+            icl::add(object, value_type(span, x_value));
+
+            //finally rewrite the common segments
+            icl::erase(object, eraser);
+            object += intersection;
+        }
+    };
+    //--------------------------------------------------------------------------
+} ;
+
+
+//==============================================================================
+//= Addition detail
+//==============================================================================
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::add_front(const interval_type& inter_val, iterator& first_)
+{
+    // If the collision sequence has a left residual 'left_resid' it will
+    // be split, to provide a standardized start of algorithms:
+    // The addend interval 'inter_val' covers the beginning of the collision sequence.
+
+    // only for the first there can be a left_resid: a part of *first_ left of inter_val
+    interval_type left_resid = right_subtract((*first_).first, inter_val);
+
+    if(!icl::is_empty(left_resid))
+    {   //            [------------ . . .
+        // [left_resid---first_ --- . . .
+        iterator prior_ = cyclic_prior(*this, first_);
+        const_cast<interval_type&>((*first_).first) 
+            = left_subtract((*first_).first, left_resid);
+        //NOTE: Only splitting
+        this->_map.insert(prior_, segment_type(left_resid, (*first_).second));
+    }
+    //POST:
+    // [----- inter_val ---- . . .
+    // ...[-- first_ --...
+}
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::add_segment(const interval_type& inter_val, const CodomainT& co_val, iterator& it_)
+{
+    interval_type lead_gap = right_subtract(inter_val, (*it_).first);
+    if(!icl::is_empty(lead_gap))
+    {
+        // [lead_gap--- . . .
+        //          [-- it_ ...
+        iterator prior_ = it_==this->_map.begin()? it_ : prior(it_); 
+        iterator inserted_ = this->template gap_insert<Combiner>(prior_, lead_gap, co_val);
+        that()->handle_inserted(prior_, inserted_);
+    }
+
+    // . . . --------- . . . addend interval
+    //      [-- it_ --)      has a common part with the first overval
+    Combiner()((*it_).second, co_val);
+    that()->template handle_left_combined<Combiner>(it_++);
+}
+
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::add_main(interval_type& inter_val, const CodomainT& co_val, 
+               iterator& it_, const iterator& last_)
+{
+    interval_type cur_interval;
+    while(it_!=last_)
+    {
+        cur_interval = (*it_).first ;
+        add_segment<Combiner>(inter_val, co_val, it_);
+        // shrink interval
+        inter_val = left_subtract(inter_val, cur_interval);
+    }
+}
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::add_rear(const interval_type& inter_val, const CodomainT& co_val, iterator& it_)
+{
+    iterator prior_ = cyclic_prior(*that(), it_);
+    interval_type cur_itv = (*it_).first ;
+
+    interval_type lead_gap = right_subtract(inter_val, cur_itv);
+    if(!icl::is_empty(lead_gap))
+    {   //         [lead_gap--- . . .
+        // [prior)          [-- it_ ...
+        iterator inserted_ = this->template gap_insert<Combiner>(prior_, lead_gap, co_val);
+        that()->handle_inserted(prior_, inserted_);
+    }
+
+    interval_type end_gap = left_subtract(inter_val, cur_itv);
+    if(!icl::is_empty(end_gap))
+    {
+        // [----------------end_gap)
+        //  . . . -- it_ --)
+        Combiner()((*it_).second, co_val);
+        that()->template gap_insert_at<Combiner>(it_, prior_, end_gap, co_val);
+    }
+    else
+    {
+        // only for the last there can be a right_resid: a part of *it_ right of x
+        interval_type right_resid = left_subtract(cur_itv, inter_val);
+
+        if(icl::is_empty(right_resid))
+        {
+            // [---------------)
+            //      [-- it_ ---)
+            Combiner()((*it_).second, co_val);
+            that()->template handle_preceeded_combined<Combiner>(prior_, it_);
+        }
+        else
+        {
+            // [--------------)
+            //      [-- it_ --right_resid)
+            const_cast<interval_type&>((*it_).first) = right_subtract((*it_).first, right_resid);
+
+            //NOTE: This is NOT an insertion that has to take care for correct application of
+            // the Combiner functor. It only reestablished that state after splitting the
+            // 'it_' interval value pair. Using _map_insert<Combiner> does not work here.
+            iterator insertion_ = this->_map.insert(it_, value_type(right_resid, (*it_).second));
+            that()->handle_reinserted(insertion_);
+
+            Combiner()((*it_).second, co_val);
+            that()->template handle_preceeded_combined<Combiner>(insertion_, it_);
+        }
+    }
+}
+
+
+//==============================================================================
+//= Addition
+//==============================================================================
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline typename interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>::iterator
+    interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::_add(const segment_type& addend)
+{
+    typedef typename on_absorbtion<type,Combiner,
+                                absorbs_identities<type>::value>::type on_absorbtion_;
+
+    const interval_type& inter_val = addend.first;
+    if(icl::is_empty(inter_val)) 
+        return this->_map.end();
+
+    const codomain_type& co_val = addend.second;
+    if(on_absorbtion_::is_absorbable(co_val))
+        return this->_map.end();
+
+    std::pair<iterator,bool> insertion 
+        = this->_map.insert(value_type(inter_val, version<Combiner>()(co_val)));
+
+    if(insertion.second)
+        return that()->handle_inserted(insertion.first);
+    else
+    {
+        // Detect the first and the end iterator of the collision sequence
+        iterator first_ = this->_map.lower_bound(inter_val),
+                 last_  = prior(this->_map.upper_bound(inter_val));
+        //assert(end_ == this->_map.upper_bound(inter_val));
+        iterator it_ = first_;
+        interval_type rest_interval = inter_val;
+
+        add_front         (rest_interval,         it_       );
+        add_main<Combiner>(rest_interval, co_val, it_, last_);
+        add_rear<Combiner>(rest_interval, co_val, it_       );
+        return it_;
+    }
+}
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline typename interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>::iterator
+    interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::_add(iterator prior_, const segment_type& addend)
+{
+    typedef typename on_absorbtion<type,Combiner,
+                                absorbs_identities<type>::value>::type on_absorbtion_;
+
+    const interval_type& inter_val = addend.first;
+    if(icl::is_empty(inter_val)) 
+        return prior_;
+
+    const codomain_type& co_val = addend.second;
+    if(on_absorbtion_::is_absorbable(co_val))
+        return prior_;
+
+    std::pair<iterator,bool> insertion 
+        = add_at<Combiner>(prior_, inter_val, co_val);
+
+    if(insertion.second)
+        return that()->handle_inserted(insertion.first);
+    else
+    {
+        // Detect the first and the end iterator of the collision sequence
+        std::pair<iterator,iterator> overlap = equal_range(inter_val);
+        iterator it_   = overlap.first,
+                 last_ = prior(overlap.second);
+        interval_type rest_interval = inter_val;
+
+        add_front         (rest_interval,         it_       );
+        add_main<Combiner>(rest_interval, co_val, it_, last_);
+        add_rear<Combiner>(rest_interval, co_val, it_       );
+        return it_;
+    }
+}
+
+//==============================================================================
+//= Subtraction detail
+//==============================================================================
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::subtract_front(const interval_type& inter_val, iterator& it_)
+{
+    interval_type left_resid = right_subtract((*it_).first, inter_val);
+
+    if(!icl::is_empty(left_resid)) //                     [--- inter_val ---)
+    {                              //[prior_) [left_resid)[--- it_ . . .
+        iterator prior_ = cyclic_prior(*this, it_); 
+        const_cast<interval_type&>((*it_).first) = left_subtract((*it_).first, left_resid);
+        this->_map.insert(prior_, value_type(left_resid, (*it_).second));
+        // The segemnt *it_ is split at inter_val.first(), so as an invariant
+        // segment *it_ is always "under" inter_val and a left_resid is empty.
+    }
+}
+
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::subtract_main(const CodomainT& co_val, iterator& it_, const iterator& last_)
+{
+    while(it_ != last_)
+    {
+        Combiner()((*it_).second, co_val);
+        that()->template handle_left_combined<Combiner>(it_++);
+    }
+}
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::subtract_rear(interval_type& inter_val, const CodomainT& co_val, iterator& it_)
+{
+    interval_type right_resid = left_subtract((*it_).first, inter_val);
+
+    if(icl::is_empty(right_resid))
+    {
+        Combiner()((*it_).second, co_val);
+        that()->template handle_combined<Combiner>(it_);
+    }
+    else
+    {
+        const_cast<interval_type&>((*it_).first) = right_subtract((*it_).first, right_resid);
+        iterator next_ = this->_map.insert(it_, value_type(right_resid, (*it_).second));
+        Combiner()((*it_).second, co_val);
+        that()->template handle_succeeded_combined<Combiner>(it_, next_);
+    }
+}
+
+//==============================================================================
+//= Subtraction
+//==============================================================================
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+    template<class Combiner>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::_subtract(const segment_type& minuend)
+{
+    interval_type inter_val = minuend.first;
+    if(icl::is_empty(inter_val)) 
+        return;
+
+    const codomain_type& co_val = minuend.second;
+    if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable(co_val)) 
+        return;
+
+    std::pair<iterator, iterator> exterior = equal_range(inter_val);
+    if(exterior.first == exterior.second)
+        return;
+
+    iterator last_  = prior(exterior.second);
+    iterator it_    = exterior.first;
+    subtract_front          (inter_val,         it_       );
+    subtract_main <Combiner>(           co_val, it_, last_);
+    subtract_rear <Combiner>(inter_val, co_val, it_       );
+}
+
+//==============================================================================
+//= Insertion
+//==============================================================================
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::insert_main(const interval_type& inter_val, const CodomainT& co_val, 
+                  iterator& it_, const iterator& last_)
+{
+    iterator end_   = boost::next(last_);
+    iterator prior_ = cyclic_prior(*this,it_), inserted_;
+    interval_type rest_interval = inter_val, left_gap, cur_itv;
+    interval_type last_interval = last_ ->first;
+
+    while(it_ != end_  )
+    {
+        cur_itv = (*it_).first ;            
+        left_gap = right_subtract(rest_interval, cur_itv);
+
+        if(!icl::is_empty(left_gap))
+        {
+            inserted_ = this->_map.insert(prior_, value_type(left_gap, co_val));
+            it_ = that()->handle_inserted(inserted_);
+        }
+
+        // shrink interval
+        rest_interval = left_subtract(rest_interval, cur_itv);
+        prior_ = it_;
+        ++it_;
+    }
+
+    //insert_rear(rest_interval, co_val, last_):
+    interval_type end_gap = left_subtract(rest_interval, last_interval);
+    if(!icl::is_empty(end_gap))
+    {
+        inserted_ = this->_map.insert(prior_, value_type(end_gap, co_val));
+        it_ = that()->handle_inserted(inserted_);
+    }
+    else
+        it_ = prior_;
+}
+
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline typename interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>::iterator
+    interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::_insert(const segment_type& addend)
+{
+    interval_type inter_val = addend.first;
+    if(icl::is_empty(inter_val)) 
+        return this->_map.end();
+
+    const codomain_type& co_val = addend.second;
+    if(on_codomain_absorbtion::is_absorbable(co_val)) 
+        return this->_map.end();
+
+    std::pair<iterator,bool> insertion = this->_map.insert(addend);
+
+    if(insertion.second)
+        return that()->handle_inserted(insertion.first);
+    else
+    {
+        // Detect the first and the end iterator of the collision sequence
+        iterator first_ = this->_map.lower_bound(inter_val),
+                 last_  = prior(this->_map.upper_bound(inter_val));
+        //assert((++last_) == this->_map.upper_bound(inter_val));
+        iterator it_ = first_;
+        insert_main(inter_val, co_val, it_, last_);
+        return it_;
+    }
+}
+
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline typename interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>::iterator
+    interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::_insert(iterator prior_, const segment_type& addend)
+{
+    interval_type inter_val = addend.first;
+    if(icl::is_empty(inter_val)) 
+        return prior_;
+
+    const codomain_type& co_val = addend.second;
+    if(on_codomain_absorbtion::is_absorbable(co_val)) 
+        return prior_;
+
+    std::pair<iterator,bool> insertion = insert_at(prior_, inter_val, co_val);
+
+    if(insertion.second)
+        return that()->handle_inserted(insertion.first);
+    {
+        // Detect the first and the end iterator of the collision sequence
+        std::pair<iterator,iterator> overlap = equal_range(inter_val);
+        iterator it_    = overlap.first,
+                 last_  = prior(overlap.second);
+        insert_main(inter_val, co_val, it_, last_);
+        return it_;
+    }
+}
+
+//==============================================================================
+//= Erasure segment_type
+//==============================================================================
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::erase_rest(interval_type& inter_val, const CodomainT& co_val, 
+                 iterator& it_, const iterator& last_)
+{
+    // For all intervals within loop: (*it_).first are contained_in inter_val
+    while(it_ != last_)
+        if((*it_).second == co_val)
+            this->_map.erase(it_++); 
+        else it_++;
+
+    //erase_rear:
+    if((*it_).second == co_val)
+    {
+        interval_type right_resid = left_subtract((*it_).first, inter_val);
+        if(icl::is_empty(right_resid))
+            this->_map.erase(it_);
+        else
+            const_cast<interval_type&>((*it_).first) = right_resid;
+    }
+}
+
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline SubType& interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::erase(const segment_type& minuend)
+{
+    interval_type inter_val = minuend.first;
+    if(icl::is_empty(inter_val)) 
+        return *that();
+
+    const codomain_type& co_val = minuend.second;
+    if(on_codomain_absorbtion::is_absorbable(co_val))
+        return *that();
+
+    std::pair<iterator,iterator> exterior = equal_range(inter_val);
+    if(exterior.first == exterior.second)
+        return *that();
+
+    iterator first_ = exterior.first, end_ = exterior.second, 
+             last_  = cyclic_prior(*this, end_);
+    iterator second_= first_; ++second_;
+
+    if(first_ == last_) 
+    {   //     [----inter_val----)
+        //   .....first_==last_.....
+        // only for the last there can be a right_resid: a part of *it_ right of minuend
+        interval_type right_resid = left_subtract((*first_).first, inter_val);
+
+        if((*first_).second == co_val)
+        {   
+            interval_type left_resid = right_subtract((*first_).first, inter_val);
+            if(!icl::is_empty(left_resid)) //            [----inter_val----)
+            {                              // [left_resid)..first_==last_......
+                const_cast<interval_type&>((*first_).first) = left_resid;
+                if(!icl::is_empty(right_resid))
+                    this->_map.insert(first_, value_type(right_resid, co_val));
+            }
+            else if(!icl::is_empty(right_resid))
+                const_cast<interval_type&>((*first_).first) = right_resid;
+            else
+                this->_map.erase(first_);
+        }
+    }
+    else
+    {
+        // first AND NOT last
+        if((*first_).second == co_val)
+        {
+            interval_type left_resid = right_subtract((*first_).first, inter_val);
+            if(icl::is_empty(left_resid))
+                this->_map.erase(first_);
+            else
+                const_cast<interval_type&>((*first_).first) = left_resid;
+        }
+
+        erase_rest(inter_val, co_val, second_, last_);
+    }
+
+     return *that();
+}
+
+//==============================================================================
+//= Erasure key_type
+//==============================================================================
+template <class SubType, class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline SubType& interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+    ::erase(const interval_type& minuend)
+{
+    if(icl::is_empty(minuend)) 
+        return *that();
+
+    std::pair<iterator, iterator> exterior = equal_range(minuend);
+    if(exterior.first == exterior.second)
+        return *that();
+
+    iterator first_ = exterior.first,
+             end_   = exterior.second,
+             last_  = prior(end_);
+
+    interval_type left_resid  = right_subtract((*first_).first, minuend);
+    interval_type right_resid =  left_subtract(last_ ->first, minuend);
+
+    if(first_ == last_ )
+        if(!icl::is_empty(left_resid))
+        {
+            const_cast<interval_type&>((*first_).first) = left_resid;
+            if(!icl::is_empty(right_resid))
+                this->_map.insert(first_, value_type(right_resid, (*first_).second));
+        }
+        else if(!icl::is_empty(right_resid))
+            const_cast<interval_type&>((*first_).first) = left_subtract((*first_).first, minuend);
+        else
+            this->_map.erase(first_);
+    else
+    {   //            [-------- minuend ---------)
+        // [left_resid   fst)   . . . .    [lst  right_resid)
+        iterator second_= first_; ++second_;
+
+        iterator start_ = icl::is_empty(left_resid)? first_: second_;
+        iterator stop_  = icl::is_empty(right_resid)? end_  : last_ ;
+        this->_map.erase(start_, stop_); //erase [start_, stop_)
+
+        if(!icl::is_empty(left_resid))
+            const_cast<interval_type&>((*first_).first) = left_resid;
+
+        if(!icl::is_empty(right_resid))
+            const_cast<interval_type&>(last_ ->first) = right_resid;
+    }
+
+    return *that();
+}
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template 
+<
+    class SubType,
+    class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc
+>
+struct is_map<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef is_map<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template 
+<
+    class SubType,
+    class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc
+>
+struct has_inverse<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef has_inverse<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (has_inverse<CodomainT>::value)); 
+};
+
+template 
+<
+    class SubType,
+    class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc
+>
+struct is_interval_container<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef is_interval_container<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template 
+<
+    class SubType,
+    class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc
+>
+struct absorbs_identities<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{
+    typedef absorbs_identities<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (Traits::absorbs_identities)); 
+};
+
+template 
+<
+    class SubType,
+    class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc
+>
+struct is_total<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{
+    typedef is_total<icl::interval_base_map<SubType,DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (Traits::is_total)); 
+};
+
+
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/interval_base_set.hpp
+++ b/inst/include/boost/icl/interval_base_set.hpp
@@ -1,0 +1,596 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2011: Joachim Faulhaber
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_BASE_SET_H_JOFA_990223
+#define BOOST_ICL_INTERVAL_BASE_SET_H_JOFA_990223
+
+#include <boost/icl/impl_config.hpp>
+
+#if defined(ICL_USE_BOOST_MOVE_IMPLEMENTATION)
+#   include <boost/container/set.hpp>
+#elif defined(ICL_USE_STD_IMPLEMENTATION)
+#   include <set>
+#else // Default for implementing containers
+#   include <set>
+#endif
+
+#include <limits>
+#include <boost/next_prior.hpp> 
+#include <boost/icl/associative_interval_container.hpp>
+#include <boost/icl/type_traits/interval_type_default.hpp>
+#include <boost/icl/interval.hpp>
+#include <boost/icl/type_traits/infinity.hpp>
+#include <boost/icl/type_traits/is_interval_joiner.hpp>
+#include <boost/icl/type_traits/is_interval_separator.hpp>
+#include <boost/icl/type_traits/is_interval_splitter.hpp>
+#include <boost/icl/detail/interval_set_algo.hpp>
+#include <boost/icl/detail/exclusive_less_than.hpp>
+
+#include <boost/icl/right_open_interval.hpp>
+#include <boost/icl/continuous_interval.hpp>
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/detail/element_iterator.hpp>
+
+namespace boost{namespace icl
+{
+
+/** \brief Implements a set as a set of intervals (base class) */
+template 
+<
+    typename             SubType,
+    typename             DomainT, 
+    ICL_COMPARE Compare  = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_INTERVAL(ICL_COMPARE) Interval = ICL_INTERVAL_INSTANCE(ICL_INTERVAL_DEFAULT, DomainT, Compare),
+    ICL_ALLOC   Alloc    = std::allocator
+> 
+class interval_base_set
+{
+public:
+    //==========================================================================
+    //= Associated types
+    //==========================================================================
+    typedef interval_base_set<SubType,DomainT,Compare,Interval,Alloc> type;
+
+    /// The designated \e derived or \e sub_type of this base class
+    typedef SubType sub_type;
+
+    /// Auxilliary type for overloadresolution
+    typedef type overloadable_type;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Data
+    //--------------------------------------------------------------------------
+    /// The domain type of the set
+    typedef DomainT   domain_type;
+    /// The codomaintype is the same as domain_type
+    typedef DomainT   codomain_type;
+
+    /// The element type of the set
+    typedef DomainT   element_type;
+
+    /// The interval type of the set
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) interval_type;
+    /// The segment type of the set
+    typedef interval_type   segment_type;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Size
+    //--------------------------------------------------------------------------
+    /// The difference type of an interval which is sometimes different form the data_type
+    typedef typename difference_type_of<domain_type>::type difference_type;
+
+    /// The size type of an interval which is mostly std::size_t
+    typedef typename size_type_of<domain_type>::type size_type;
+
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Order
+    //--------------------------------------------------------------------------
+    /// Comparison functor for domain values
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT)      domain_compare;
+    typedef ICL_COMPARE_DOMAIN(Compare,segment_type) segment_compare;
+    /// Comparison functor for intervals
+    typedef exclusive_less_than<interval_type>       interval_compare;
+
+    /// Comparison functor for keys
+    typedef exclusive_less_than<interval_type> key_compare;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Related types
+    //--------------------------------------------------------------------------
+    /// The atomized type representing the corresponding container of elements
+    typedef typename ICL_IMPL_SPACE::set<DomainT,domain_compare,Alloc<DomainT> > atomized_type;
+
+    //--------------------------------------------------------------------------
+    //- Associated types: Implementation and stl related
+    //--------------------------------------------------------------------------
+    /// The allocator type of the set
+    typedef Alloc<interval_type> allocator_type;
+
+    /// allocator type of the corresponding element set
+    typedef Alloc<DomainT> domain_allocator_type;
+
+    /// Container type for the implementation 
+    typedef typename ICL_IMPL_SPACE::set<interval_type,key_compare,allocator_type> ImplSetT;
+
+    /// key type of the implementing container
+    typedef typename ImplSetT::key_type   key_type;
+    /// data type of the implementing container
+    typedef typename ImplSetT::key_type   data_type;
+    /// value type of the implementing container
+    typedef typename ImplSetT::value_type value_type;
+
+    /// pointer type
+    typedef typename ImplSetT::pointer         pointer;
+    /// const pointer type
+    typedef typename ImplSetT::const_pointer   const_pointer;
+    /// reference type
+    typedef typename ImplSetT::reference       reference;
+    /// const reference type
+    typedef typename ImplSetT::const_reference const_reference;
+
+    /// iterator for iteration over intervals
+    typedef typename ImplSetT::iterator iterator;
+    /// const_iterator for iteration over intervals
+    typedef typename ImplSetT::const_iterator const_iterator;
+    /// iterator for reverse iteration over intervals
+    typedef typename ImplSetT::reverse_iterator reverse_iterator;
+    /// const_iterator for iteration over intervals
+    typedef typename ImplSetT::const_reverse_iterator const_reverse_iterator;
+
+    /// element iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<iterator> element_iterator; 
+    /// element const iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<const_iterator> element_const_iterator; 
+    /// element reverse iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<reverse_iterator> element_reverse_iterator; 
+    /// element const reverse iterator: Depreciated, see documentation.
+    typedef boost::icl::element_iterator<const_reverse_iterator> element_const_reverse_iterator; 
+
+    BOOST_STATIC_CONSTANT(int, fineness = 0); 
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor for the empty object */
+    interval_base_set(){}
+
+    /** Copy constructor */
+    interval_base_set(const interval_base_set& src): _set(src._set)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    /** Move constructor */
+    interval_base_set(interval_base_set&& src): _set(boost::move(src._set))
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    /** Move assignment operator */
+    interval_base_set& operator = (interval_base_set src) 
+    {                           //call by value sice 'src' is a "sink value"
+        this->_set = boost::move(src._set);
+        return *this; 
+    }
+
+    //==========================================================================
+#   else
+
+    /** Copy assignment operator */
+    interval_base_set& operator = (const interval_base_set& src) 
+    { 
+        this->_set = src._set;
+        return *this; 
+    }
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+    /** swap the content of containers */
+    void swap(interval_base_set& operand) { _set.swap(operand._set); }
+
+    //==========================================================================
+    //= Containedness
+    //==========================================================================
+    /** sets the container empty */
+    void clear() { icl::clear(*that()); }
+    /** is the container empty? */
+    bool empty()const { return icl::is_empty(*that()); }
+
+    //==========================================================================
+    //= Size
+    //==========================================================================
+    /** An interval set's size is it's cardinality */
+    size_type size()const
+    {
+        return icl::cardinality(*that());
+    }
+
+    /** Size of the iteration over this container */
+    std::size_t iterative_size()const 
+    { 
+        return _set.size(); 
+    }
+
+    //==========================================================================
+    //= Selection
+    //==========================================================================
+
+    /** Find the interval, that contains element \c key_value */
+    const_iterator find(const element_type& key_value)const
+    { 
+        return icl::find(*this, key_value);
+        //CL return this->_set.find(icl::singleton<segment_type>(key)); 
+    }
+
+    /** Find the first interval, that collides with interval \c key_interval */
+    const_iterator find(const interval_type& key_interval)const
+    { 
+        return this->_set.find(key_interval); 
+    }
+
+    //==========================================================================
+    //= Addition
+    //==========================================================================
+
+    /** Add a single element \c key to the set */
+    SubType& add(const element_type& key) 
+    {
+        return icl::add(*that(), key);
+    }
+
+    /** Add an interval of elements \c inter_val to the set */
+    SubType& add(const segment_type& inter_val) 
+    {
+        _add(inter_val);
+        return *that();
+    }
+
+    /** Add an interval of elements \c inter_val to the set. Iterator 
+        \c prior_ is a hint to the position \c inter_val can be 
+        inserted after. */
+    iterator add(iterator prior_, const segment_type& inter_val) 
+    { 
+        return _add(prior_, inter_val);
+    }
+
+    //==========================================================================
+    //= Subtraction
+    //==========================================================================
+
+    /** Subtract a single element \c key from the set */
+    SubType& subtract(const element_type& key) 
+    { 
+        return icl::subtract(*that(), key);
+    }
+
+    /** Subtract an interval of elements \c inter_val from the set */
+    SubType& subtract(const segment_type& inter_val); 
+
+    //==========================================================================
+    //= Insertion
+    //==========================================================================
+    /** Insert an element \c key into the set */
+    SubType& insert(const element_type& key) 
+    { 
+        return add(key); 
+    }
+
+    /** Insert an interval of elements \c inter_val to the set */
+    SubType& insert(const segment_type& inter_val) 
+    { 
+        return add(inter_val); 
+    }
+
+    /** Insert an interval of elements \c inter_val to the set. Iterator 
+        \c prior_ is a hint to the position \c inter_val can be 
+        inserted after. */
+    iterator insert(iterator prior_, const segment_type& inter_val) 
+    { 
+        return add(prior_, inter_val); 
+    }
+
+
+
+    //==========================================================================
+    //= Erasure
+    //==========================================================================
+    /** Erase an element \c key from the set */
+    SubType& erase(const element_type& key) 
+    { 
+        return subtract(key); 
+    }
+
+    /** Erase an interval of elements \c inter_val from the set */
+    SubType& erase(const segment_type& inter_val) 
+    { 
+        return subtract(inter_val); 
+    }
+
+    /** Erase the interval that iterator \c position points to. */
+    void erase(iterator position)
+    { 
+        _set.erase(position); 
+    }
+
+    /** Erase all intervals in the range <tt>[first,past)</tt> of iterators. */
+    void erase(iterator first, iterator past)
+    { 
+        _set.erase(first, past); 
+    }
+
+    //==========================================================================
+    //= Symmetric difference
+    //==========================================================================
+    /** If \c *this set contains \c key it is erased, otherwise it is added. */
+    SubType& flip(const element_type& key)
+    {
+        return icl::flip(*that(), key);
+    }
+
+    /** If \c *this set contains \c inter_val it is erased, otherwise it is added. */
+    SubType& flip(const segment_type& inter_val)
+    {
+        return icl::flip(*that(), inter_val);
+    }
+
+    //==========================================================================
+    //= Iterator related
+    //==========================================================================
+
+    iterator begin() { return _set.begin(); }
+    iterator end()   { return _set.end(); }
+    const_iterator begin()const { return _set.begin(); }
+    const_iterator end()const   { return _set.end(); }
+    reverse_iterator rbegin() { return _set.rbegin(); }
+    reverse_iterator rend()   { return _set.rend(); }
+    const_reverse_iterator rbegin()const { return _set.rbegin(); }
+    const_reverse_iterator rend()const   { return _set.rend(); }
+
+    iterator lower_bound(const value_type& interval)
+    { return _set.lower_bound(interval); }
+
+    iterator upper_bound(const value_type& interval)
+    { return _set.upper_bound(interval); }
+
+    const_iterator lower_bound(const value_type& interval)const
+    { return _set.lower_bound(interval); }
+
+    const_iterator upper_bound(const value_type& interval)const
+    { return _set.upper_bound(interval); }
+
+    std::pair<iterator,iterator> equal_range(const key_type& interval)
+    { 
+        return std::pair<iterator,iterator>
+            (_set.lower_bound(interval), _set.upper_bound(interval)); 
+    }
+
+    std::pair<const_iterator,const_iterator> 
+        equal_range(const key_type& interval)const
+    { 
+        return std::pair<const_iterator,const_iterator>
+            (_set.lower_bound(interval), _set.upper_bound(interval)); 
+    }
+
+private:
+    iterator _add(const segment_type& addend);
+    iterator _add(iterator prior, const segment_type& addend);
+
+protected:
+    void add_front(const interval_type& inter_val, iterator& first_);
+    void add_main(interval_type& inter_val, iterator& it_, const iterator& last_);
+    void add_segment(const interval_type& inter_val, iterator& it_);
+    void add_rear(const interval_type& inter_val, iterator& it_);
+
+protected:
+    sub_type* that() { return static_cast<sub_type*>(this); }
+    const sub_type* that()const { return static_cast<const sub_type*>(this); }
+
+protected:
+    ImplSetT _set;
+} ;
+
+
+template <class SubType, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
+    ::add_front(const interval_type& inter_val, iterator& first_)
+{
+    // If the collision sequence has a left residual 'left_resid' it will
+    // be split, to provide a standardized start of algorithms:
+    // The addend interval 'inter_val' covers the beginning of the collision sequence.
+
+    // only for the first there can be a left_resid: a part of *first_ left of inter_val
+    interval_type left_resid = right_subtract(*first_, inter_val);
+
+    if(!icl::is_empty(left_resid))
+    {   //            [------------ . . .
+        // [left_resid---first_ --- . . .
+        iterator prior_ = cyclic_prior(*this, first_);
+        const_cast<interval_type&>(*first_) = left_subtract(*first_, left_resid);
+        //NOTE: Only splitting
+        this->_set.insert(prior_, left_resid);
+    }
+
+    //POST:
+    // [----- inter_val ---- . . .
+    // ...[-- first_ --...
+}
+
+template <class SubType, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
+    ::add_segment(const interval_type& inter_val, iterator& it_)
+{
+    interval_type lead_gap = right_subtract(inter_val, *it_);
+    if(!icl::is_empty(lead_gap))
+        //           [lead_gap--- . . .
+        // [prior_)           [-- it_ ...
+        this->_set.insert(prior(it_), lead_gap);
+
+    // . . . --------- . . . addend interval
+    //      [-- it_ --)      has a common part with the first overval
+    ++it_;
+}
+
+template <class SubType, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
+    ::add_main(interval_type& rest_interval, iterator& it_, const iterator& last_)
+{
+    interval_type cur_interval;
+    while(it_ != last_)
+    {
+        cur_interval = *it_ ;
+        add_segment(rest_interval, it_);
+        // shrink interval
+        rest_interval = left_subtract(rest_interval, cur_interval);
+    }
+}
+
+template <class SubType, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline void interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
+    ::add_rear(const interval_type& inter_val, iterator& it_)
+{
+    iterator prior_ = cyclic_prior(*this, it_);
+    interval_type cur_itv = *it_;
+
+    interval_type lead_gap = right_subtract(inter_val, cur_itv);
+    if(!icl::is_empty(lead_gap))
+        //          [lead_gap--- . . .
+        // [prior_)          [-- it_ ...
+        this->_set.insert(prior_, lead_gap);
+    
+    interval_type end_gap = left_subtract(inter_val, cur_itv);
+    if(!icl::is_empty(end_gap))
+        // [---------------end_gap)
+        //      [-- it_ --)
+        it_ = this->_set.insert(it_, end_gap);
+    else
+    {
+        // only for the last there can be a right_resid: a part of *it_ right of addend
+        interval_type right_resid = left_subtract(cur_itv, inter_val);
+
+        if(!icl::is_empty(right_resid))
+        {
+            // [--------------)
+            //      [-- it_ --right_resid)
+            const_cast<interval_type&>(*it_) = right_subtract(*it_, right_resid);
+            it_ = this->_set.insert(it_, right_resid);
+        }
+    }
+}
+
+//==============================================================================
+//= Addition
+//==============================================================================
+template <class SubType, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline typename interval_base_set<SubType,DomainT,Compare,Interval,Alloc>::iterator 
+    interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
+    ::_add(const segment_type& addend)
+{
+    typedef typename interval_base_set<SubType,DomainT,Compare,Interval,Alloc>::iterator iterator;
+    if(icl::is_empty(addend)) 
+        return this->_set.end();
+
+    std::pair<iterator,bool> insertion = this->_set.insert(addend);
+
+    if(insertion.second)
+        return that()->handle_inserted(insertion.first);
+    else
+    {
+        iterator last_ = prior(this->_set.upper_bound(addend));
+        return that()->add_over(addend, last_);
+    }
+}
+
+template <class SubType, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline typename interval_base_set<SubType,DomainT,Compare,Interval,Alloc>::iterator 
+    interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
+    ::_add(iterator prior_, const segment_type& addend)
+{
+    typedef typename interval_base_set<SubType,DomainT,Compare,Interval,Alloc>::iterator iterator;
+    if(icl::is_empty(addend))
+        return prior_;
+
+    iterator insertion = this->_set.insert(prior_, addend);
+
+    if(*insertion == addend)
+        return that()->handle_inserted(insertion);
+    else
+    {
+        iterator last_ = prior(this->_set.upper_bound(addend));
+        return that()->add_over(addend, last_);
+    }
+}
+
+//==============================================================================
+//= Subtraction
+//==============================================================================
+template <class SubType, class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE) Interval, ICL_ALLOC Alloc>
+inline SubType& interval_base_set<SubType,DomainT,Compare,Interval,Alloc>
+    ::subtract(const segment_type& minuend)
+{
+    if(icl::is_empty(minuend)) 
+        return *that();
+
+    std::pair<iterator, iterator> exterior = equal_range(minuend);
+    if(exterior.first == exterior.second) 
+        return *that();
+
+    iterator first_ = exterior.first;
+    iterator end_   = exterior.second;
+    iterator last_  = prior(end_);
+
+    interval_type left_resid = right_subtract(*first_, minuend);
+    interval_type right_resid; 
+    if(first_ != end_)
+        right_resid = left_subtract(*last_ , minuend);
+
+    this->_set.erase(first_, end_);
+
+    if(!icl::is_empty(left_resid))
+        this->_set.insert(left_resid);
+
+    if(!icl::is_empty(right_resid))
+        this->_set.insert(right_resid);
+
+    return *that();
+}
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template<class SubType,
+         class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_set<icl::interval_base_set<SubType,DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_set<icl::interval_base_set<SubType,DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template<class SubType,
+         class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_container<icl::interval_base_set<SubType,DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_interval_container<icl::interval_base_set<SubType,DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/interval_bounds.hpp
+++ b/inst/include/boost/icl/interval_bounds.hpp
@@ -1,0 +1,80 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_BOUNDS_HPP_JOFA_100330
+#define BOOST_ICL_INTERVAL_BOUNDS_HPP_JOFA_100330
+
+#include <boost/utility/enable_if.hpp>
+#include <boost/icl/detail/design_config.hpp>
+
+namespace boost{namespace icl
+{
+
+typedef unsigned char bound_type;
+
+class interval_bounds
+{
+public:
+    BOOST_STATIC_CONSTANT(bound_type, static_open       = 0);
+    BOOST_STATIC_CONSTANT(bound_type, static_left_open  = 1);
+    BOOST_STATIC_CONSTANT(bound_type, static_right_open = 2);
+    BOOST_STATIC_CONSTANT(bound_type, static_closed     = 3);
+    BOOST_STATIC_CONSTANT(bound_type, dynamic           = 4);
+    BOOST_STATIC_CONSTANT(bound_type, undefined         = 5);
+
+    BOOST_STATIC_CONSTANT(bound_type, _open       = 0);
+    BOOST_STATIC_CONSTANT(bound_type, _left_open  = 1);
+    BOOST_STATIC_CONSTANT(bound_type, _right_open = 2);
+    BOOST_STATIC_CONSTANT(bound_type, _closed     = 3);
+
+    BOOST_STATIC_CONSTANT(bound_type, _right     = 1);
+    BOOST_STATIC_CONSTANT(bound_type, _left      = 2);
+    BOOST_STATIC_CONSTANT(bound_type, _all       = 3);
+
+public:
+    interval_bounds():_bits(){}
+    explicit interval_bounds(bound_type bounds): _bits(bounds){}
+    interval_bounds all  ()const { return interval_bounds(_bits & _all  ); }
+    interval_bounds left ()const { return interval_bounds(_bits & _left ); }
+    interval_bounds right()const { return interval_bounds(_bits & _right); }
+    interval_bounds reverse_left ()const { return interval_bounds((~_bits>>1) & _right); }
+    interval_bounds reverse_right()const { return interval_bounds((~_bits<<1) & _left ); }
+
+    bound_type bits()const{ return _bits; }
+
+    static interval_bounds open()      { return interval_bounds(_open);     }
+    static interval_bounds left_open() { return interval_bounds(_left_open); }
+    static interval_bounds right_open(){ return interval_bounds(_right_open);}
+    static interval_bounds closed()    { return interval_bounds(_closed);   }
+
+public:
+    bound_type _bits;
+};
+
+
+template<class DomainT>
+class bounded_value
+{
+public:
+    typedef DomainT domain_type;
+    typedef bounded_value<DomainT> type;
+public:
+    bounded_value(const domain_type& value, interval_bounds bound)
+        : _value(value), _bound(bound) {}
+
+    domain_type     value()const { return _value; }
+    interval_bounds bound()const { return _bound; }
+
+private:
+    domain_type     _value;
+    interval_bounds _bound;
+};
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/interval_combining_style.hpp
+++ b/inst/include/boost/icl/interval_combining_style.hpp
@@ -1,0 +1,28 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_COMBINING_STYLE_HPP_JOFA_100906
+#define BOOST_ICL_INTERVAL_COMBINING_STYLE_HPP_JOFA_100906
+
+namespace boost{ namespace icl
+{
+
+namespace interval_combine
+{
+    BOOST_STATIC_CONSTANT(int, unknown    = 0);
+    BOOST_STATIC_CONSTANT(int, joining    = 1);
+    BOOST_STATIC_CONSTANT(int, separating = 2);
+    BOOST_STATIC_CONSTANT(int, splitting  = 3);
+    BOOST_STATIC_CONSTANT(int, elemental  = 4);
+
+} // namespace interval_combine
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/interval_map.hpp
+++ b/inst/include/boost/icl/interval_map.hpp
@@ -1,0 +1,297 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2012: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_MAP_HPP_JOFA_080705
+#define BOOST_ICL_INTERVAL_MAP_HPP_JOFA_080705
+
+#include <boost/assert.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/interval_set.hpp>
+#include <boost/icl/interval_base_map.hpp>
+
+namespace boost{namespace icl
+{
+
+template<class DomainT, class CodomainT, class Traits, 
+         ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, 
+         ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+class split_interval_map;
+
+/** \brief implements a map as a map of intervals - on insertion 
+    overlapping intervals are split and associated values are combined.*/
+template
+<
+    typename DomainT,
+    typename CodomainT,
+    class Traits = icl::partial_absorber,
+    ICL_COMPARE Compare  = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_COMBINE Combine  = ICL_COMBINE_INSTANCE(icl::inplace_plus, CodomainT),
+    ICL_SECTION Section  = ICL_SECTION_INSTANCE(icl::inter_section, CodomainT), 
+    ICL_INTERVAL(ICL_COMPARE) Interval = ICL_INTERVAL_INSTANCE(ICL_INTERVAL_DEFAULT, DomainT, Compare),
+    ICL_ALLOC   Alloc    = std::allocator
+>
+class interval_map:
+
+    public interval_base_map<interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>, 
+                             DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+{
+public:
+    typedef Traits traits;
+    typedef       interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> type;
+    typedef split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> split_type;
+    typedef type overloadable_type;
+    typedef type joint_type;
+    typedef interval_base_map<type, 
+                              DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> base_type;
+
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) interval_type;
+    typedef typename base_type::iterator      iterator;
+    typedef typename base_type::value_type    value_type;
+    typedef typename base_type::element_type  element_type;
+    typedef typename base_type::segment_type  segment_type;
+    typedef typename base_type::domain_type   domain_type;
+    typedef typename base_type::codomain_type codomain_type;
+    typedef typename base_type::domain_mapping_type domain_mapping_type;
+    typedef typename base_type::interval_mapping_type interval_mapping_type;
+    typedef typename base_type::ImplMapT ImplMapT;
+
+    typedef typename base_type::size_type     size_type;
+    typedef typename base_type::codomain_combine codomain_combine;
+
+    typedef interval_set<DomainT,Compare,Interval,Alloc> interval_set_type;
+    typedef interval_set_type set_type;
+    typedef set_type          key_object_type;
+
+    enum { fineness = 1 };
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+
+    /// Default constructor for the empty object
+    interval_map(): base_type() {}
+
+    /// Copy constructor
+    interval_map(const interval_map& src): base_type(src) {}
+
+    /// Copy constructor for base_type
+    template<class SubType>
+    explicit interval_map
+        (const interval_base_map<SubType,DomainT,CodomainT,
+                                 Traits,Compare,Combine,Section,Interval,Alloc>& src)
+    { this->assign(src); }
+
+    explicit interval_map(const domain_mapping_type& base_pair): base_type()
+    { this->add(base_pair); }
+
+    explicit interval_map(const value_type& value_pair): base_type()
+    { this->add(value_pair); }
+
+
+    /// Assignment from a base interval_map.
+    template<class SubType>
+    void assign(const interval_base_map<SubType,DomainT,CodomainT,
+                                        Traits,Compare,Combine,Section,Interval,Alloc>& src)
+    {
+        typedef interval_base_map<SubType,DomainT,CodomainT,
+                                  Traits,Compare,Combine,Section,Interval,Alloc> base_map_type;
+        this->clear();
+        iterator prior_ = this->_map.end();
+        ICL_const_FORALL(typename base_map_type, it_, src) 
+            prior_ = this->add(prior_, *it_); 
+    }
+
+    /// Assignment operator for base type
+    template<class SubType>
+    interval_map& operator =
+        (const interval_base_map<SubType,DomainT,CodomainT,
+                                 Traits,Compare,Combine,Section,Interval,Alloc>& src)
+    { 
+        this->assign(src); 
+        return *this; 
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    /// Move constructor
+    interval_map(interval_map&& src)
+        : base_type(boost::move(src))
+    {}
+
+    /// Move assignment operator
+    interval_map& operator = (interval_map src)
+    { 
+        base_type::operator=(boost::move(src));
+        return *this;
+    }
+
+    //==========================================================================
+#   else
+
+    /// Assignment operator
+    interval_map& operator = (const interval_map& src)
+    { 
+        base_type::operator=(src);
+        return *this;
+    }
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+private:
+    // Private functions that shall be accessible by the baseclass:
+    friend class
+        interval_base_map <interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>, 
+                                        DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>;
+
+    iterator handle_inserted(iterator it_)
+    {
+        return segmental::join_neighbours(*this, it_); 
+    }
+
+    void handle_inserted(iterator prior_, iterator it_)
+    {
+        if(prior_ != this->_map.end() && segmental::joinable(*this, prior_, it_))
+            segmental::join_on_right(*this, prior_, it_);
+    }
+
+    template<class Combiner>
+    void handle_left_combined(iterator it_)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+            this->_map.erase(it_);
+        else
+            segmental::join_left(*this, it_);
+    }
+
+    template<class Combiner>
+    void handle_combined(iterator it_)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+            this->_map.erase(it_);
+        else
+            segmental::join_neighbours(*this, it_);
+    }
+
+    template<class Combiner>
+    void handle_preceeded_combined(iterator prior_, iterator& it_)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+        {
+            this->_map.erase(it_);
+            it_ = prior_;
+        }
+        else // After a new combination (e.g. combiner=max) joining neighbours may be possible
+            segmental::join_neighbours(*this, it_);
+    }
+
+    template<class Combiner>
+    void handle_succeeded_combined(iterator it_, iterator next_)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+        {
+            this->_map.erase(it_);
+            segmental::join_right(*this, next_);
+        }
+        else
+        {
+            segmental::join_left(*this, it_);
+            segmental::join_neighbours(*this, next_);
+        }
+    }
+
+
+
+    void handle_reinserted(iterator insertion_)
+    { 
+        segmental::join_right(*this, insertion_); 
+    }
+
+
+    template<class Combiner>
+    void gap_insert_at(iterator& it_, iterator prior_, 
+                       const interval_type& end_gap, const codomain_type& co_val)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+        {
+            this->_map.erase(it_);
+            it_ = this->template gap_insert<Combiner>(prior_, end_gap, co_val);
+            segmental::join_right(*this, it_);
+        }
+        else 
+        {
+            segmental::join_left(*this, it_);
+            iterator inserted_ = this->template gap_insert<Combiner>(it_, end_gap, co_val);
+            it_ = segmental::join_neighbours(*this, inserted_);
+        }
+    }
+
+} ;
+
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_map<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef is_map<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct has_inverse<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef has_inverse<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (has_inverse<CodomainT>::value)); 
+};
+
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_container<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{
+    typedef is_interval_container<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct absorbs_identities<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{
+    typedef absorbs_identities<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (Traits::absorbs_identities)); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_total<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{
+    typedef is_total<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (Traits::is_total)); 
+};
+
+
+//-----------------------------------------------------------------------------
+// type representation
+//-----------------------------------------------------------------------------
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct type_to_string<icl::interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{
+    static std::string apply()
+    { 
+        return "itv_map<"+ type_to_string<DomainT>::apply()   + ","
+                         + type_to_string<CodomainT>::apply() + ","
+                         + type_to_string<Traits>::apply()    + ">"; 
+    }
+};
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/interval_set.hpp
+++ b/inst/include/boost/icl/interval_set.hpp
@@ -1,0 +1,232 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2010: Joachim Faulhaber
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_SET_HPP_JOFA_990223
+#define BOOST_ICL_INTERVAL_SET_HPP_JOFA_990223
+
+#include <boost/assert.hpp>
+#include <boost/icl/type_traits/is_interval_joiner.hpp>
+#include <boost/icl/interval_base_set.hpp>
+
+namespace boost{namespace icl
+{
+
+/** \brief Implements a set as a set of intervals - merging adjoining intervals */
+template 
+<
+    typename    DomainT, 
+    ICL_COMPARE Compare  = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_INTERVAL(ICL_COMPARE) Interval = ICL_INTERVAL_INSTANCE(ICL_INTERVAL_DEFAULT, DomainT, Compare),
+    ICL_ALLOC   Alloc    = std::allocator
+> 
+class interval_set: 
+    public interval_base_set<interval_set<DomainT,Compare,Interval,Alloc>,
+                             DomainT,Compare,Interval,Alloc>
+{
+public:
+
+    typedef interval_set<DomainT,Compare,Interval,Alloc> type;
+
+    /// The base_type of this class
+    typedef interval_base_set<type,DomainT,Compare,Interval,Alloc> base_type;
+
+    typedef type overloadable_type;
+
+    typedef type joint_type;
+
+    typedef type key_object_type;
+
+    /// The domain type of the set
+    typedef DomainT   domain_type;
+    /// The codomaintype is the same as domain_type
+    typedef DomainT   codomain_type;
+
+    /// The element type of the set
+    typedef DomainT   element_type;
+    /// The interval type of the set
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) interval_type;
+    /// The segment type of the set
+    typedef interval_type   segment_type;
+
+    /// Comparison functor for domain values
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    /// Comparison functor for intervals
+    typedef exclusive_less_than<interval_type> interval_compare;
+
+    /// Comparison functor for keys
+    typedef exclusive_less_than<interval_type> key_compare;
+
+    /// The allocator type of the set
+    typedef Alloc<interval_type> allocator_type;
+
+    /// allocator type of the corresponding element set
+    typedef Alloc<DomainT> domain_allocator_type;
+
+    /// The corresponding atomized type representing this interval container of elements
+    typedef typename base_type::atomized_type atomized_type;
+
+    /// Container type for the implementation 
+    typedef typename base_type::ImplSetT ImplSetT;
+
+    /// key type of the implementing container
+    typedef typename ImplSetT::key_type   key_type;
+    /// data type of the implementing container
+    typedef typename ImplSetT::value_type data_type;
+    /// value type of the implementing container
+    typedef typename ImplSetT::value_type value_type;
+
+    /// iterator for iteration over intervals
+    typedef typename ImplSetT::iterator iterator;
+    /// const_iterator for iteration over intervals
+    typedef typename ImplSetT::const_iterator const_iterator;
+
+    enum { fineness = 1 };
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /// Default constructor for the empty object
+    interval_set(): base_type() {}
+
+    /// Copy constructor
+    interval_set(const interval_set& src): base_type(src) {}
+
+    /// Copy constructor for base_type
+    template<class SubType>
+    explicit interval_set
+        (const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    { 
+        this->assign(src); 
+    }
+
+    /// Constructor for a single element
+    explicit interval_set(const domain_type& value): base_type() 
+    { this->add(interval_type(value)); }
+
+    /// Constructor for a single interval
+    explicit interval_set(const interval_type& itv): base_type() 
+    { 
+        this->add(itv); 
+    }
+
+    /// Assignment from a base interval_set.
+    template<class SubType>
+    void assign(const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    {
+        typedef interval_base_set<SubType,DomainT,Compare,Interval,Alloc> base_set_type;
+        this->clear();
+        // Has to be implemented via add. there might be touching borders to be joined
+        iterator prior_ = this->_set.end();
+        ICL_const_FORALL(typename base_set_type, it_, src) 
+            prior_ = this->add(prior_, *it_);
+    }
+
+    /// Assignment operator for base type
+    template<class SubType>
+    interval_set& operator =
+        (const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    { 
+        this->assign(src); 
+        return *this; 
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    /// Move constructor
+    interval_set(interval_set&& src)
+        : base_type(boost::move(src))
+    {}
+
+    /// Move assignment operator
+    interval_set& operator = (interval_set src)
+    { 
+        base_type::operator=(boost::move(src));
+        return *this;
+    }
+
+    //==========================================================================
+#   else
+    /// Assignment operator
+    interval_set& operator = (const interval_set& src)
+    { 
+        base_type::operator=(src);
+        return *this;
+    }
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+private:
+    // Private functions that shall be accessible by the baseclass:
+    friend class
+        interval_base_set <interval_set<DomainT,Compare,Interval,Alloc>, 
+                                        DomainT,Compare,Interval,Alloc>;
+
+    iterator handle_inserted(iterator it_)
+    {
+        return segmental::join_neighbours(*this, it_); 
+    }
+
+    iterator add_over(const interval_type& addend, iterator last_)
+    {
+        iterator joined_ = segmental::join_under(*this, addend, last_);
+        return segmental::join_neighbours(*this, joined_);
+    }
+
+    iterator add_over(const interval_type& addend)
+    {
+        iterator joined_ = segmental::join_under(*this, addend);
+        return segmental::join_neighbours(*this, joined_);
+    }
+
+} ;
+
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_set<icl::interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_set<icl::interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_container<icl::interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_interval_container<icl::interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_joiner<icl::interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_interval_joiner<icl::interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+
+//-----------------------------------------------------------------------------
+// type representation
+//-----------------------------------------------------------------------------
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct type_to_string<icl::interval_set<DomainT,Compare,Interval,Alloc> >
+{
+    static std::string apply()
+    { return "itv_set<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/interval_traits.hpp
+++ b/inst/include/boost/icl/interval_traits.hpp
@@ -1,0 +1,58 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_INTERVAL_TRAITS_HPP_JOFA_100926
+#define BOOST_ICL_INTERVAL_TRAITS_HPP_JOFA_100926
+
+#include <boost/icl/type_traits/domain_type_of.hpp>
+#include <boost/icl/type_traits/difference_type_of.hpp>
+#include <boost/icl/type_traits/size_type_of.hpp>
+
+namespace boost{ namespace icl
+{
+
+template<class Type> struct interval_traits;
+
+template<class Type>
+struct domain_type_of<interval_traits<Type> >
+{
+    typedef typename interval_traits<Type>::domain_type type;
+};
+
+//------------------------------------------------------------------------------
+//- Adapter class
+//------------------------------------------------------------------------------
+template<class Type> struct interval_traits
+{
+    typedef interval_traits                     type;
+    typedef typename domain_type_of<Type>::type domain_type;
+
+    static Type construct(const domain_type& lo, const domain_type& up);
+
+    static domain_type upper(const Type& inter_val);
+    static domain_type lower(const Type& inter_val);
+};
+
+template<class Type>
+struct difference_type_of<interval_traits<Type> >
+{
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    typedef typename difference_type_of<domain_type>::type type;
+};
+
+template<class Type>
+struct size_type_of<interval_traits<Type> >
+{
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    typedef typename size_type_of<domain_type>::type type;
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/iterator.hpp
+++ b/inst/include/boost/icl/iterator.hpp
@@ -1,0 +1,103 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2009-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_ITERATOR_HPP_JOFA_091003
+#define BOOST_ICL_ITERATOR_HPP_JOFA_091003
+
+#include <iterator>
+#include <boost/config/warning_disable.hpp>
+
+namespace boost{namespace icl
+{
+
+/** \brief Performes an addition using a container's memberfunction add, when operator= is called. */
+template<class ContainerT> class add_iterator
+    : public std::iterator<std::output_iterator_tag, void, void, void, void>
+{
+public:
+    /// The container's type.
+    typedef ContainerT container_type;
+    typedef std::output_iterator_tag iterator_category; 
+
+    /** An add_iterator is constructed with a container and a position 
+        that has to be maintained. */
+    add_iterator(ContainerT& cont, typename ContainerT::iterator iter)
+    : _cont(&cont), _iter(iter) {}
+
+    /** This assignment operator adds the \c value before the current position.
+        It maintains it's position by incrementing after addition.    */
+    add_iterator& operator=(typename ContainerT::const_reference value)
+    {
+        _iter = icl::add(*_cont, _iter, value);
+        if(_iter != _cont->end())
+            ++_iter;
+        return *this;
+    }
+
+    add_iterator& operator*()    { return *this; }
+    add_iterator& operator++()   { return *this; }
+    add_iterator& operator++(int){ return *this; }
+
+private:
+    ContainerT*                   _cont;
+    typename ContainerT::iterator _iter;
+};
+
+
+/** Function adder creates and initializes an add_iterator */
+template<class ContainerT, typename IteratorT>
+inline add_iterator<ContainerT> adder(ContainerT& cont, IteratorT iter_)
+{
+    return add_iterator<ContainerT>(cont, typename ContainerT::iterator(iter_));
+}
+
+/** \brief Performes an insertion using a container's memberfunction add, when operator= is called. */
+template<class ContainerT> class insert_iterator
+    : public std::iterator<std::output_iterator_tag, void, void, void, void>
+{
+public:
+    /// The container's type.
+    typedef ContainerT container_type;
+    typedef std::output_iterator_tag iterator_category; 
+
+    /** An insert_iterator is constructed with a container and a position 
+        that has to be maintained. */
+    insert_iterator(ContainerT& cont, typename ContainerT::iterator iter)
+    : _cont(&cont), _iter(iter) {}
+
+    /** This assignment operator adds the \c value before the current position.
+        It maintains it's position by incrementing after addition.    */
+    insert_iterator& operator=(typename ContainerT::const_reference value)
+    {
+        _iter = _cont->insert(_iter, value);
+        if(_iter != _cont->end())
+            ++_iter;
+        return *this;
+    }
+
+    insert_iterator& operator*()    { return *this; }
+    insert_iterator& operator++()   { return *this; }
+    insert_iterator& operator++(int){ return *this; }
+
+private:
+    ContainerT*                   _cont;
+    typename ContainerT::iterator _iter;
+};
+
+
+/** Function inserter creates and initializes an insert_iterator */
+template<class ContainerT, typename IteratorT>
+inline insert_iterator<ContainerT> inserter(ContainerT& cont, IteratorT iter_)
+{
+    return insert_iterator<ContainerT>(cont, typename ContainerT::iterator(iter_));
+}
+
+}} // namespace icl boost
+
+#endif // BOOST_ICL_ITERATOR_HPP_JOFA_091003
+
+

--- a/inst/include/boost/icl/left_open_interval.hpp
+++ b/inst/include/boost/icl/left_open_interval.hpp
@@ -1,0 +1,119 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_LEFT_OPEN_INTERVAL_HPP_JOFA_100930
+#define BOOST_ICL_LEFT_OPEN_INTERVAL_HPP_JOFA_100930
+
+#include <functional>
+#include <boost/concept/assert.hpp>
+#include <boost/icl/concept/interval.hpp>
+#include <boost/icl/type_traits/value_size.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+
+template <class DomainT, 
+          ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)>
+class left_open_interval
+{
+public:
+    typedef left_open_interval<DomainT,Compare> type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor; yields an empty interval <tt>(0,0]</tt>. */
+    left_open_interval() 
+        : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    //NOTE: Compiler generated copy constructor is used
+
+    /** Constructor for a left-open singleton interval <tt>(val-1,val]</tt> */
+    explicit left_open_interval(const DomainT& val)
+        : _lwb(predecessor<DomainT,domain_compare>::apply(val)), _upb(val)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        // Only for discrete types this ctor creates an interval containing 
+        // a single element only.
+        BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
+        BOOST_ASSERT((numeric_minimum<DomainT, domain_compare, is_numeric<DomainT>::value >
+                                     ::is_less_than(val) )); 
+    }
+
+    /** Interval from <tt>low</tt> to <tt>up</tt> with bounds <tt>bounds</tt> */
+    left_open_interval(const DomainT& low, const DomainT& up) :
+        _lwb(low), _upb(up)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    DomainT lower()const{ return _lwb; }
+    DomainT upper()const{ return _upb; }
+
+private:
+    DomainT _lwb;
+    DomainT _upb;
+};
+
+//==============================================================================
+//=T left_open_interval -> concept intervals
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct interval_traits< icl::left_open_interval<DomainT, Compare> >
+{
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef icl::left_open_interval<DomainT, Compare> interval_type;
+
+    static interval_type construct(const domain_type& lo, const domain_type& up)
+    {
+        return interval_type(lo, up);
+    }
+
+    static domain_type lower(const interval_type& inter_val){ return inter_val.lower(); };
+    static domain_type upper(const interval_type& inter_val){ return inter_val.upper(); };
+};
+
+
+//==============================================================================
+//= Type traits
+//==============================================================================
+template <class DomainT, ICL_COMPARE Compare> 
+struct interval_bound_type< left_open_interval<DomainT,Compare> >
+{
+    typedef interval_bound_type type;
+    BOOST_STATIC_CONSTANT(bound_type, value = interval_bounds::static_left_open);
+};
+
+template <class DomainT, ICL_COMPARE Compare>
+struct type_to_string<icl::left_open_interval<DomainT,Compare> >
+{
+    static std::string apply()
+    { return "(I]<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+template<class DomainT, ICL_COMPARE Compare> 
+struct value_size<icl::left_open_interval<DomainT,Compare> >
+{
+    static std::size_t apply(const icl::left_open_interval<DomainT>&) 
+    { return 2; }
+};
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/map.hpp
+++ b/inst/include/boost/icl/map.hpp
@@ -1,0 +1,703 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2011: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_MAP_HPP_JOFA_070519
+#define BOOST_ICL_MAP_HPP_JOFA_070519
+
+#include <boost/icl/impl_config.hpp>
+
+#if defined(ICL_USE_BOOST_MOVE_IMPLEMENTATION)
+#   include <boost/container/map.hpp>
+#   include <boost/container/set.hpp>
+#elif defined(ICL_USE_STD_IMPLEMENTATION)
+#   include <map>
+#   include <set>
+#else // Default for implementing containers
+#   include <map>
+#   include <set>
+#endif
+
+#include <string>
+#include <boost/call_traits.hpp> 
+#include <boost/icl/detail/notate.hpp>
+#include <boost/icl/detail/design_config.hpp>
+#include <boost/icl/detail/concept_check.hpp>
+#include <boost/icl/detail/on_absorbtion.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/type_traits/absorbs_identities.hpp>
+#include <boost/icl/type_traits/is_total.hpp>
+#include <boost/icl/type_traits/is_element_container.hpp>
+#include <boost/icl/type_traits/has_inverse.hpp>
+#include <boost/icl/type_traits/to_string.hpp>
+
+#include <boost/icl/associative_element_container.hpp>
+#include <boost/icl/functors.hpp>
+
+namespace boost{namespace icl
+{
+
+struct partial_absorber
+{
+    enum { absorbs_identities = true };
+    enum { is_total = false };
+};
+
+template<> 
+inline std::string type_to_string<partial_absorber>::apply() { return "@0"; }
+
+struct partial_enricher
+{
+    enum { absorbs_identities = false };
+    enum { is_total = false };
+};
+
+template<> 
+inline std::string type_to_string<partial_enricher>::apply() { return "e0"; }
+
+struct total_absorber
+{
+    enum { absorbs_identities = true };
+    enum { is_total = true };
+};
+
+template<> 
+inline std::string type_to_string<total_absorber>::apply() { return "^0"; }
+
+struct total_enricher
+{
+    enum { absorbs_identities = false };
+    enum { is_total = true };
+};
+
+template<> 
+inline std::string type_to_string<total_enricher>::apply() { return "e^0"; }
+
+
+
+/** \brief Addable, subractable and intersectable maps */
+template 
+<
+    typename DomainT, 
+    typename CodomainT, 
+    class Traits = icl::partial_absorber,
+    ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_COMBINE Combine = ICL_COMBINE_INSTANCE(icl::inplace_plus, CodomainT),
+    ICL_SECTION Section = ICL_SECTION_INSTANCE(icl::inter_section, CodomainT), 
+    ICL_ALLOC   Alloc   = std::allocator 
+>
+class map: private ICL_IMPL_SPACE::map<DomainT, CodomainT, ICL_COMPARE_DOMAIN(Compare,DomainT), 
+                                       Alloc<std::pair<const DomainT, CodomainT> > >
+{
+public:
+    typedef Alloc<typename std::pair<const DomainT, CodomainT> >  allocator_type;
+
+    typedef typename icl::map<DomainT,CodomainT,Traits, Compare,Combine,Section,Alloc> type;
+    typedef typename ICL_IMPL_SPACE::map<DomainT, CodomainT, ICL_COMPARE_DOMAIN(Compare,DomainT),
+                                         allocator_type>   base_type;
+
+    typedef Traits traits;
+
+public:
+    typedef DomainT                                     domain_type;
+    typedef typename boost::call_traits<DomainT>::param_type domain_param;
+    typedef DomainT                                     key_type;
+    typedef CodomainT                                   codomain_type;
+    typedef CodomainT                                   mapped_type;
+    typedef CodomainT                                   data_type;
+    typedef std::pair<const DomainT, CodomainT>         element_type;
+    typedef std::pair<const DomainT, CodomainT>         value_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT)         domain_compare;
+    typedef ICL_COMBINE_CODOMAIN(Combine,CodomainT)     codomain_combine;
+    typedef domain_compare                              key_compare;
+    typedef ICL_COMPARE_DOMAIN(Compare,element_type)    element_compare;
+    typedef typename inverse<codomain_combine >::type   inverse_codomain_combine;
+    typedef typename mpl::if_
+        <has_set_semantics<codomain_type>
+        , ICL_SECTION_CODOMAIN(Section,CodomainT)     
+        , codomain_combine
+        >::type                                         codomain_intersect;
+    typedef typename inverse<codomain_intersect>::type  inverse_codomain_intersect;
+    typedef typename base_type::value_compare           value_compare;
+
+    typedef typename ICL_IMPL_SPACE::set<DomainT, domain_compare, Alloc<DomainT> > set_type;
+    typedef set_type                                       key_object_type;
+
+
+    BOOST_STATIC_CONSTANT(bool, _total   = (Traits::is_total));
+    BOOST_STATIC_CONSTANT(bool, _absorbs = (Traits::absorbs_identities));
+    BOOST_STATIC_CONSTANT(bool, 
+        total_invertible = (mpl::and_<is_total<type>, has_inverse<codomain_type> >::value));
+
+    typedef on_absorbtion<type,codomain_combine,Traits::absorbs_identities> 
+                                                        on_identity_absorbtion;
+
+public:
+    typedef typename base_type::pointer                 pointer;
+    typedef typename base_type::const_pointer           const_pointer;
+    typedef typename base_type::reference               reference;
+    typedef typename base_type::const_reference         const_reference;
+    typedef typename base_type::iterator                iterator;
+    typedef typename base_type::const_iterator          const_iterator;
+    typedef typename base_type::size_type               size_type;
+    typedef typename base_type::difference_type         difference_type;
+    typedef typename base_type::reverse_iterator        reverse_iterator;
+    typedef typename base_type::const_reverse_iterator  const_reverse_iterator;
+
+public:
+    BOOST_STATIC_CONSTANT(bool, 
+        is_total_invertible = (   Traits::is_total 
+                               && has_inverse<codomain_type>::value));
+
+    BOOST_STATIC_CONSTANT(int, fineness = 4); 
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    map()
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
+        BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
+    }
+
+    map(const key_compare& comp): base_type(comp){}
+
+    template <class InputIterator>
+    map(InputIterator first, InputIterator past)
+        : base_type(first,past){} 
+
+    template <class InputIterator>
+    map(InputIterator first, InputIterator past, const key_compare& comp)
+        : base_type(first,past,comp) 
+    {}
+
+    map(const map& src)
+        : base_type(src)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
+        BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
+    }
+
+    explicit map(const element_type& key_value_pair): base_type::map()
+    { 
+        insert(key_value_pair); 
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    map(map&& src)
+        : base_type(boost::move(src))
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<CodomainT>));
+        BOOST_CONCEPT_ASSERT((EqualComparableConcept<CodomainT>));
+    }
+
+    map& operator = (map src) 
+    { 
+        base_type::operator=(boost::move(src));
+        return *this; 
+    } 
+    //==========================================================================
+#   else
+
+    map& operator = (const map& src) 
+    { 
+        base_type::operator=(src);
+        return *this; 
+    } 
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+    void swap(map& src) { base_type::swap(src); }
+
+    //==========================================================================
+    using base_type::empty;
+    using base_type::clear;
+
+    using base_type::begin;
+    using base_type::end;
+    using base_type::rbegin;
+    using base_type::rend;
+
+    using base_type::size;
+    using base_type::max_size;
+
+    using base_type::key_comp;
+    using base_type::value_comp;
+
+    using base_type::erase;
+    using base_type::find;
+    using base_type::count;
+
+    using base_type::lower_bound;
+    using base_type::upper_bound;
+    using base_type::equal_range;
+
+    using base_type::operator[];
+
+public:
+    //==========================================================================
+    //= Containedness
+    //==========================================================================
+
+    template<class SubObject>
+    bool contains(const SubObject& sub)const 
+    { return icl::contains(*this, sub); }
+
+    bool within(const map& super)const 
+    { return icl::contains(super, *this); }
+
+    //==========================================================================
+    //= Size
+    //==========================================================================
+    /** \c iterative_size() yields the number of elements that is visited
+        throu complete iteration. For interval sets \c iterative_size() is
+        different from \c size(). */
+    std::size_t iterative_size()const { return base_type::size(); }
+
+    //==========================================================================
+    //= Selection
+    //==========================================================================
+
+    /** Total select function. */
+    codomain_type operator()(const domain_type& key)const
+    {
+        const_iterator it = find(key); 
+        return it==end() ? identity_element<codomain_type>::value()
+                         : it->second;
+    }
+
+    //==========================================================================
+    //= Addition
+    //==========================================================================
+    /** \c add inserts \c value_pair into the map if it's key does 
+        not exist in the map.    
+        If \c value_pairs's key value exists in the map, it's data
+        value is added to the data value already found in the map. */
+    map& add(const value_type& value_pair) 
+    { 
+        return _add<codomain_combine>(value_pair); 
+    }
+
+    /** \c add add \c value_pair into the map using \c prior as a hint to
+        insert \c value_pair after the position \c prior is pointing to. */
+    iterator add(iterator prior, const value_type& value_pair) 
+    { 
+        return _add<codomain_combine>(prior, value_pair); 
+    }
+
+    //==========================================================================
+    //= Subtraction
+    //==========================================================================
+    /** If the \c value_pair's key value is in the map, it's data value is
+        subtraced from the data value stored in the map. */
+    map& subtract(const element_type& value_pair)
+    {
+        on_invertible<type, is_total_invertible>
+            ::subtract(*this, value_pair);
+        return *this;
+    }
+
+    map& subtract(const domain_type& key)
+    {
+        icl::erase(*this, key);
+        return *this;
+    }
+
+    //==========================================================================
+    //= Insertion, erasure
+    //==========================================================================
+    std::pair<iterator,bool> insert(const value_type& value_pair)
+    {
+        if(on_identity_absorbtion::is_absorbable(value_pair.second)) 
+            return std::pair<iterator,bool>(end(),true);
+        else
+            return base_type::insert(value_pair);
+    }
+    
+    iterator insert(iterator prior, const value_type& value_pair)
+    {
+        if(on_identity_absorbtion::is_absorbable(value_pair.second)) 
+            return end();
+        else
+            return base_type::insert(prior, value_pair);
+    }
+
+    template<class Iterator>
+    iterator insert(Iterator first, Iterator last)
+    {
+        iterator prior = end(), it = first;
+        while(it != last)
+            prior = this->insert(prior, *it++);
+    }
+
+    /** With <tt>key_value_pair = (k,v)</tt> set value \c v for key \c k */
+    map& set(const element_type& key_value_pair)
+    { 
+        return icl::set_at(*this, key_value_pair);
+    }
+
+    /** erase \c key_value_pair from the map.
+        Erase only if, the exact value content \c val is stored for the given key. */
+    size_type erase(const element_type& key_value_pair)
+    {
+        return icl::erase(*this, key_value_pair); 
+    }
+
+    //==========================================================================
+    //= Intersection
+    //==========================================================================
+    /** The intersection of \c key_value_pair and \c *this map is added to \c section. */
+    void add_intersection(map& section, const element_type& key_value_pair)const
+    {
+        on_definedness<type, Traits::is_total>
+            ::add_intersection(section, *this, key_value_pair);
+    }
+
+    //==========================================================================
+    //= Symmetric difference
+    //==========================================================================
+
+    map& flip(const element_type& operand)
+    {
+        on_total_absorbable<type,_total,_absorbs>::flip(*this, operand);
+        return *this;
+    }
+
+private:
+    template<class Combiner>
+    map& _add(const element_type& value_pair);
+
+    template<class Combiner>
+    iterator _add(iterator prior, const element_type& value_pair);
+
+    template<class Combiner>
+    map& _subtract(const element_type& value_pair);
+
+    template<class FragmentT>
+    void total_add_intersection(type& section, const FragmentT& fragment)const
+    {
+        section += *this;
+        section.add(fragment);
+    }
+
+    void partial_add_intersection(type& section, const element_type& operand)const
+    {
+        const_iterator it_ = find(operand.first);
+        if(it_ != end())
+        {
+            section.template _add<codomain_combine  >(*it_);
+            section.template _add<codomain_intersect>(operand); 
+        }
+    }
+
+
+private:
+    //--------------------------------------------------------------------------
+    template<class Type, bool is_total_invertible>
+    struct on_invertible;
+
+    template<class Type>
+    struct on_invertible<Type, true>
+    {
+        typedef typename Type::element_type element_type;
+        typedef typename Type::inverse_codomain_combine inverse_codomain_combine;
+
+        static void subtract(Type& object, const element_type& operand)
+        { object.template _add<inverse_codomain_combine>(operand); }
+    };
+
+    template<class Type>
+    struct on_invertible<Type, false>
+    {
+        typedef typename Type::element_type element_type;
+        typedef typename Type::inverse_codomain_combine inverse_codomain_combine;
+
+        static void subtract(Type& object, const element_type& operand)
+        { object.template _subtract<inverse_codomain_combine>(operand); }
+    };
+
+    friend struct on_invertible<type, true>;
+    friend struct on_invertible<type, false>;
+    //--------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------
+    template<class Type, bool is_total>
+    struct on_definedness;
+
+    template<class Type>
+    struct on_definedness<Type, true>
+    {
+        static void add_intersection(Type& section, const Type& object, 
+                                     const element_type& operand)
+        { object.total_add_intersection(section, operand); }
+    };
+
+    template<class Type>
+    struct on_definedness<Type, false>
+    {
+        static void add_intersection(Type& section, const Type& object, 
+                                     const element_type& operand)
+        { object.partial_add_intersection(section, operand); }
+    };
+
+    friend struct on_definedness<type, true>;
+    friend struct on_definedness<type, false>;
+    //--------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------
+    template<class Type, bool has_set_semantics, bool absorbs_identities>
+    struct on_codomain_model;
+
+    template<class Type>
+    struct on_codomain_model<Type, false, false>
+    {                // !codomain_is_set, !absorbs_identities
+        static void subtract(Type&, typename Type::iterator it_, 
+                              const typename Type::codomain_type& )
+        { (*it_).second = identity_element<typename Type::codomain_type>::value(); }
+    };
+
+    template<class Type>
+    struct on_codomain_model<Type, false, true>
+    {                // !codomain_is_set, absorbs_identities
+        static void subtract(Type& object, typename Type::iterator       it_, 
+                                     const typename Type::codomain_type&     )
+        { object.erase(it_); }
+    };
+
+    template<class Type>
+    struct on_codomain_model<Type, true, false>
+    {               // !codomain_is_set, !absorbs_identities
+        typedef typename Type::inverse_codomain_intersect inverse_codomain_intersect;
+        static void subtract(Type&, typename Type::iterator       it_, 
+                              const typename Type::codomain_type& co_value)
+        { 
+            inverse_codomain_intersect()((*it_).second, co_value); 
+        }
+    };
+
+    template<class Type>
+    struct on_codomain_model<Type, true, true>
+    {               // !codomain_is_set, absorbs_identities
+        typedef typename Type::inverse_codomain_intersect inverse_codomain_intersect;
+        static void subtract(Type& object, typename Type::iterator       it_, 
+                                     const typename Type::codomain_type& co_value)
+        { 
+            inverse_codomain_intersect()((*it_).second, co_value); 
+            if((*it_).second == identity_element<codomain_type>::value())
+                object.erase(it_);
+        }
+    };
+    //--------------------------------------------------------------------------
+
+    //--------------------------------------------------------------------------
+    template<class Type, bool is_total, bool absorbs_identities>
+    struct on_total_absorbable;
+
+    template<class Type>
+    struct on_total_absorbable<Type, true, true>
+    {
+        typedef typename Type::element_type  element_type;
+        static void flip(Type& object, const typename Type::element_type&)
+        { icl::clear(object); }
+    };
+
+    template<class Type>
+    struct on_total_absorbable<Type, true, false>
+    {
+        typedef typename Type::element_type  element_type;
+        typedef typename Type::codomain_type codomain_type;
+
+        static void flip(Type& object, const element_type& operand)
+        { 
+            object.add(operand);
+            ICL_FORALL(typename Type, it_, object)
+                (*it_).second = identity_element<codomain_type>::value();
+        }
+    };
+
+    template<class Type>
+    struct on_total_absorbable<Type, false, true>
+    {                         // !is_total, absorbs_identities
+        typedef typename Type::element_type   element_type;
+        typedef typename Type::codomain_type  codomain_type;
+        typedef typename Type::iterator       iterator;
+        typedef typename Type::inverse_codomain_intersect inverse_codomain_intersect;
+
+        static void flip(Type& object, const element_type& operand)
+        {
+            std::pair<iterator,bool> insertion = object.insert(operand);
+            if(!insertion.second)
+                on_codomain_model<Type, has_set_semantics<codomain_type>::value, true>
+                ::subtract(object, insertion.first, operand.second);
+        }
+    };
+
+    template<class Type>
+    struct on_total_absorbable<Type, false, false>
+    {                         // !is_total  !absorbs_identities
+        typedef typename Type::element_type   element_type;
+        typedef typename Type::codomain_type  codomain_type;
+        typedef typename Type::iterator       iterator;
+        typedef typename Type::inverse_codomain_intersect inverse_codomain_intersect;
+
+        static void flip(Type& object, const element_type& operand)
+        {
+            std::pair<iterator,bool> insertion = object.insert(operand);
+            if(!insertion.second)
+                on_codomain_model<Type, has_set_semantics<codomain_type>::value, false>
+                ::subtract(object, insertion.first, operand.second);
+        }
+    };
+
+    friend struct on_total_absorbable<type, true,  true >;
+    friend struct on_total_absorbable<type, false, true >;
+    friend struct on_total_absorbable<type, true,  false>;
+    friend struct on_total_absorbable<type, false, false>;
+    //--------------------------------------------------------------------------
+};
+
+
+
+//==============================================================================
+//= Addition<ElementMap>
+//==============================================================================
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+    template <class Combiner>
+map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc>&
+    map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc>
+    ::_add(const element_type& addend)
+{
+    typedef typename on_absorbtion
+        <type,Combiner,absorbs_identities<type>::value>::type on_absorbtion_;
+
+    const codomain_type& co_val    = addend.second;
+    if(on_absorbtion_::is_absorbable(co_val))
+        return *this;
+
+    std::pair<iterator,bool> insertion 
+        = base_type::insert(value_type(addend.first, version<Combiner>()(co_val)));
+
+    if(!insertion.second)
+    {
+        iterator it = insertion.first;
+        Combiner()((*it).second, co_val);
+
+        if(on_absorbtion_::is_absorbable((*it).second))
+            erase(it);
+    }
+    return *this;
+}
+
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+    template <class Combiner>
+typename map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc>::iterator
+    map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc>
+    ::_add(iterator prior_, const value_type& addend)
+{
+    typedef typename on_absorbtion
+        <type,Combiner,absorbs_identities<type>::value>::type on_absorbtion_;
+
+    const codomain_type& co_val    = addend.second;
+    if(on_absorbtion_::is_absorbable(co_val))
+        return end();
+
+    iterator inserted_ 
+        = base_type::insert(prior_, 
+                            value_type(addend.first, Combiner::identity_element()));
+    Combiner()((*inserted_).second, addend.second);
+
+    if(on_absorbtion_::is_absorbable((*inserted_).second))
+    {
+        erase(inserted_);
+        return end();
+    }
+    else
+        return inserted_;
+}
+
+
+//==============================================================================
+//= Subtraction<ElementMap>
+//==============================================================================
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+    template <class Combiner>
+map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc>&
+    map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc>::_subtract(const value_type& minuend)
+{
+    typedef typename on_absorbtion
+        <type,Combiner,absorbs_identities<type>::value>::type on_absorbtion_;
+
+    iterator it_ = find(minuend.first);
+    if(it_ != end())
+    {
+        Combiner()((*it_).second, minuend.second);
+        if(on_absorbtion_::is_absorbable((*it_).second))
+            erase(it_);
+    }
+    return *this;
+}
+
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+struct is_map<icl::map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc> >
+{ 
+    typedef is_map<icl::map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+struct has_inverse<icl::map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc> >
+{ 
+    typedef has_inverse<icl::map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (has_inverse<CodomainT>::value)); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+struct absorbs_identities<icl::map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc> >
+{ 
+    typedef absorbs_identities type;
+    BOOST_STATIC_CONSTANT(int, value = Traits::absorbs_identities); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+struct is_total<icl::map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc> >
+{ 
+    typedef is_total type;
+    BOOST_STATIC_CONSTANT(int, value = Traits::is_total); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_ALLOC Alloc>
+struct type_to_string<icl::map<DomainT,CodomainT,Traits,Compare,Combine,Section,Alloc> >
+{
+    static std::string apply()
+    {
+        return "map<"+ type_to_string<DomainT>::apply()  + ","
+                     + type_to_string<CodomainT>::apply() + ","
+                     + type_to_string<Traits>::apply() +">"; 
+    }
+};
+
+
+
+}} // namespace icl boost
+
+#endif // BOOST_ICL_MAP_HPP_JOFA_070519
+

--- a/inst/include/boost/icl/open_interval.hpp
+++ b/inst/include/boost/icl/open_interval.hpp
@@ -1,0 +1,120 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_OPEN_INTERVAL_HPP_JOFA_100930
+#define BOOST_ICL_OPEN_INTERVAL_HPP_JOFA_100930
+
+#include <functional>
+#include <boost/concept/assert.hpp>
+#include <boost/icl/detail/concept_check.hpp>
+#include <boost/icl/concept/interval.hpp>
+#include <boost/icl/type_traits/value_size.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+
+template <class DomainT, 
+          ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)>
+class open_interval
+{
+public:
+    typedef open_interval<DomainT,Compare> type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor; yields an empty interval <tt>(0,0)</tt>. */
+    open_interval() 
+        : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    //NOTE: Compiler generated copy constructor is used
+
+    /** Constructor for an open singleton interval <tt>(val-1,val+1)</tt> */
+    explicit open_interval(const DomainT& val)
+        : _lwb(pred(val)), _upb(succ(val))
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        // Only for discrete types this ctor creates an interval containing 
+        // a single element only.
+        BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
+        BOOST_ASSERT((numeric_minimum<DomainT, domain_compare, is_numeric<DomainT>::value >
+                                     ::is_less_than(val) )); 
+    }
+
+    /** Interval from <tt>low</tt> to <tt>up</tt> with bounds <tt>bounds</tt> */
+    open_interval(const DomainT& low, const DomainT& up) :
+        _lwb(low), _upb(up)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    DomainT lower()const{ return _lwb; }
+    DomainT upper()const{ return _upb; }
+
+private:
+    DomainT _lwb;
+    DomainT _upb;
+};
+
+//==============================================================================
+//=T open_interval -> concept intervals
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct interval_traits< icl::open_interval<DomainT, Compare> >
+{
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef icl::open_interval<DomainT, Compare> interval_type;
+
+    static interval_type construct(const domain_type& lo, const domain_type& up)
+    {
+        return interval_type(lo, up);
+    }
+
+    static domain_type lower(const interval_type& inter_val){ return inter_val.lower(); };
+    static domain_type upper(const interval_type& inter_val){ return inter_val.upper(); };
+};
+
+
+//==============================================================================
+//= Type traits
+//==============================================================================
+template <class DomainT, ICL_COMPARE Compare> 
+struct interval_bound_type< open_interval<DomainT,Compare> >
+{
+    typedef interval_bound_type type;
+    BOOST_STATIC_CONSTANT(bound_type, value = interval_bounds::static_open);
+};
+
+template <class DomainT, ICL_COMPARE Compare>
+struct type_to_string<icl::open_interval<DomainT,Compare> >
+{
+    static std::string apply()
+    { return "(I)<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+template<class DomainT, ICL_COMPARE Compare> 
+struct value_size<icl::open_interval<DomainT,Compare> >
+{
+    static std::size_t apply(const icl::open_interval<DomainT>&) 
+    { return 2; }
+};
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/predicates/distinct_equal.hpp
+++ b/inst/include/boost/icl/predicates/distinct_equal.hpp
@@ -1,0 +1,32 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_PREDICATES_DISTINCT_EQUAL_HPP_JOFA_101102
+#define BOOST_ICL_PREDICATES_DISTINCT_EQUAL_HPP_JOFA_101102
+
+#include <boost/icl/type_traits/predicate.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+    template <class Type> 
+    struct distinct_equal : public relation<Type,Type>
+    {
+        bool operator()(const Type& lhs, const Type& rhs)const
+        {
+            return is_distinct_equal(lhs, rhs);
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<icl::distinct_equal>::apply()  
+    { return "==/0"; }
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/predicates/element_equal.hpp
+++ b/inst/include/boost/icl/predicates/element_equal.hpp
@@ -1,0 +1,32 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_PREDICATES_ELEMENT_EQUAL_HPP_JOFA_101102
+#define BOOST_ICL_PREDICATES_ELEMENT_EQUAL_HPP_JOFA_101102
+
+#include <boost/icl/type_traits/predicate.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+    template <class Type> 
+    struct element_equal : public relation<Type,Type>
+    {
+        bool operator()(const Type& lhs, const Type& rhs)const
+        {
+            return is_element_equal(lhs, rhs);
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<icl::element_equal>::apply()  
+    { return "="; }
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/predicates/std_equal.hpp
+++ b/inst/include/boost/icl/predicates/std_equal.hpp
@@ -1,0 +1,33 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_PREDICATES_STD_EQUAL_HPP_JOFA_101102
+#define BOOST_ICL_PREDICATES_STD_EQUAL_HPP_JOFA_101102
+
+#include <boost/icl/type_traits/predicate.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+    template <class Type> struct std_equal : public relation<Type,Type>
+    {
+        bool operator()(const Type& lhs, const Type& rhs)const
+        {
+            return lhs == rhs;
+        }
+    };
+
+    //-----------------------------------------------------------------------------
+
+    template<>         
+    inline std::string unary_template_to_string<icl::std_equal>::apply()
+    { return "=="; }
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/predicates/sub_super_set.hpp
+++ b/inst/include/boost/icl/predicates/sub_super_set.hpp
@@ -1,0 +1,54 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_PREDICATES_SUB_SUPER_SET_HPP_JOFA_101102
+#define BOOST_ICL_PREDICATES_SUB_SUPER_SET_HPP_JOFA_101102
+
+#include <boost/icl/type_traits/predicate.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+
+    /// Functor class template contained_in implements the subset relation.
+    template<class Type> 
+    struct sub_super_set : public relation<Type,Type>
+    {
+        /// Apply the subset relation.
+        /** <tt>contained_in(sub, super)</tt> is true if <tt>sub</tt> 
+            is contained in <tt>super</tt> */
+        bool operator()(const Type& sub, const Type& super)const
+        {
+            return contains(super, sub);
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<icl::sub_super_set>::apply()  
+    { return "C="; }
+
+    /// Functor class template <b>contains</b> implements the superset relation. 
+    template<class Type> 
+    struct super_sub_set : public relation<Type,Type>
+    {
+        /// Apply the superset relation.
+        /** <tt>contains(super, sub)</tt> is true if <tt>super</tt> containes 
+            <tt>sub</tt> */
+        bool operator()(const Type& super, const Type& sub)const
+        {
+            return contains(super, sub);
+        }
+    };
+
+    template<>
+    inline std::string unary_template_to_string<icl::super_sub_set>::apply()  
+    { return "D="; }
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/ptime.hpp
+++ b/inst/include/boost/icl/ptime.hpp
@@ -1,0 +1,122 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+
+/*------------------------------------------------------------------------------
+itl_ptime provides adapter code for boost::posix_time::ptime.
+It implements incrementation (++) decrementation (--) and a neutral element
+w.r.t. addition (identity_element()).
+------------------------------------------------------------------------------*/
+
+#ifndef BOOST_ICL_PTIME_HPP_JOFA_080416
+#define BOOST_ICL_PTIME_HPP_JOFA_080416
+
+#include <boost/icl/detail/boost_config.hpp>
+#include <boost/detail/workaround.hpp>
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4100) // boost/date_time/time.hpp(80) : warning C4100: 'as_offset' : unreferenced formal parameter
+#pragma warning(disable:4127) // conditional expression is constant
+#pragma warning(disable:4244) // 'argument' : conversion from 'int' to 'unsigned short', possible loss of data
+#pragma warning(disable:4702) // boost\lexical_cast.hpp(1159) : warning C4702: unreachable code
+#pragma warning(disable:4996) // Function call with parameters that may be unsafe - this call relies on the caller to check that the passed values are correct. To disable this warning, use -D_SCL_SECURE_NO_WARNINGS. See documentation on how to use Visual C++ 'Checked Iterators'
+#endif                        
+
+#include <stdio.h>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/difference_type_of.hpp>
+#include <boost/icl/type_traits/size_type_of.hpp>
+#include <boost/icl/type_traits/is_discrete.hpp>
+
+namespace boost{namespace icl
+{
+    template<> struct is_discrete<boost::posix_time::ptime>
+    {
+        typedef is_discrete type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    template<> 
+    inline boost::posix_time::ptime identity_element<boost::posix_time::ptime>::value()
+    { 
+        return boost::posix_time::ptime(boost::posix_time::min_date_time); 
+    }
+
+    template<> 
+    struct has_difference<boost::posix_time::ptime> 
+    { 
+        typedef has_difference type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };  
+
+    template<> 
+    struct difference_type_of<boost::posix_time::ptime> 
+    { 
+        typedef boost::posix_time::time_duration type; 
+    };  
+
+    template<> 
+    struct size_type_of<boost::posix_time::ptime> 
+    { 
+        typedef boost::posix_time::time_duration type; 
+    };  
+
+    // ------------------------------------------------------------------------
+    inline boost::posix_time::ptime operator ++(boost::posix_time::ptime& x)
+    {
+        return x += boost::posix_time::ptime::time_duration_type::unit();
+    }
+
+    inline boost::posix_time::ptime operator --(boost::posix_time::ptime& x)
+    {
+        return x -= boost::posix_time::ptime::time_duration_type::unit();
+    }
+
+    // ------------------------------------------------------------------------
+    template<> struct is_discrete<boost::posix_time::time_duration>
+    {
+        typedef is_discrete type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    template<> 
+    struct has_difference<boost::posix_time::time_duration> 
+    { 
+        typedef has_difference type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };  
+
+    template<> 
+    struct size_type_of<boost::posix_time::time_duration> 
+    { 
+        typedef boost::posix_time::time_duration type; 
+    };  
+
+    inline boost::posix_time::time_duration operator ++(boost::posix_time::time_duration& x)
+    {
+        return x += boost::posix_time::ptime::time_duration_type::unit();
+    }
+
+    inline boost::posix_time::time_duration operator --(boost::posix_time::time_duration& x)
+    {
+        return x -= boost::posix_time::ptime::time_duration_type::unit();
+    }
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/rational.hpp
+++ b/inst/include/boost/icl/rational.hpp
@@ -1,0 +1,70 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+
+/*------------------------------------------------------------------------------
+itl_rational provides adapter code for boost::rational.
+------------------------------------------------------------------------------*/
+
+#ifndef BOOST_ICL_RATIONAL_HPP_JOFA_080913
+#define BOOST_ICL_RATIONAL_HPP_JOFA_080913
+
+#include <boost/config.hpp> // For BOOST_MSVC and more
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4127) // conditional expression is constant
+#pragma warning(disable:4512) // 'boost::detail::resetter' : assignment operator could not be generated
+#pragma warning(disable:4800) // 'unsigned int' : forcing value to bool 'true' or 'false' (performance warning)
+#endif                        
+
+#include <boost/rational.hpp>
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+#include <boost/icl/type_traits/is_continuous.hpp>
+#include <boost/icl/type_traits/has_inverse.hpp>
+#include <boost/icl/type_traits/is_numeric.hpp>
+
+namespace boost{namespace icl
+{
+    template<class Integral> 
+    struct is_numeric<boost::rational<Integral> >
+    {
+        typedef is_numeric type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    template<class Integral> 
+    struct is_continuous<boost::rational<Integral> >
+    {
+        typedef is_continuous type;
+        BOOST_STATIC_CONSTANT(bool, value = true);
+    };
+
+    template<class Integral> 
+    struct is_discrete<boost::rational<Integral> >
+    {
+        typedef is_discrete type;
+        BOOST_STATIC_CONSTANT(bool, value = false);
+    };
+
+    template<class Integral> 
+    struct has_inverse<boost::rational<Integral> >
+    {
+        typedef has_inverse type;
+        BOOST_STATIC_CONSTANT(bool, value = (boost::is_signed<Integral>::value));
+    };
+
+}} // namespace icl boost
+
+
+#endif
+
+

--- a/inst/include/boost/icl/right_open_interval.hpp
+++ b/inst/include/boost/icl/right_open_interval.hpp
@@ -1,0 +1,118 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_RIGHT_OPEN_INTERVAL_HPP_JOFA_100323
+#define BOOST_ICL_RIGHT_OPEN_INTERVAL_HPP_JOFA_100323
+
+#include <functional>
+#include <boost/concept/assert.hpp>
+#include <boost/icl/concept/interval.hpp>
+#include <boost/icl/type_traits/succ_pred.hpp>
+#include <boost/icl/type_traits/value_size.hpp>
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{namespace icl
+{
+
+template <class DomainT, 
+          ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)>
+class right_open_interval
+{
+public:
+    typedef right_open_interval<DomainT,Compare> type;
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /** Default constructor; yields an empty interval <tt>[0,0)</tt>. */
+    right_open_interval() 
+        : _lwb(identity_element<DomainT>::value()), _upb(identity_element<DomainT>::value()) 
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    //NOTE: Compiler generated copy constructor is used
+
+    /** Constructor for a singleton interval <tt>[val,val+1)</tt> */
+    explicit right_open_interval(const DomainT& val)
+        : _lwb(val), _upb(icl::successor<DomainT,domain_compare>::apply(val))
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+        // Only for discrete types this ctor creates an interval containing 
+        // a single element only.
+        BOOST_STATIC_ASSERT((icl::is_discrete<DomainT>::value));
+    }
+
+    /** Interval from <tt>low</tt> to <tt>up</tt> with bounds <tt>bounds</tt> */
+    right_open_interval(const DomainT& low, const DomainT& up) :
+        _lwb(low), _upb(up)
+    {
+        BOOST_CONCEPT_ASSERT((DefaultConstructibleConcept<DomainT>));
+        BOOST_CONCEPT_ASSERT((LessThanComparableConcept<DomainT>));
+    }
+
+    domain_type lower()const{ return _lwb; }
+    domain_type upper()const{ return _upb; }
+
+private:
+    domain_type _lwb;
+    domain_type _upb;
+};
+
+//==============================================================================
+//=T right_open_interval -> concept intervals
+//==============================================================================
+template<class DomainT, ICL_COMPARE Compare>
+struct interval_traits< icl::right_open_interval<DomainT, Compare> >
+{
+    typedef DomainT domain_type;
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    typedef icl::right_open_interval<DomainT, Compare> interval_type;
+
+    static interval_type construct(const domain_type& lo, const domain_type& up)
+    {
+        return interval_type(lo, up);
+    }
+
+    static domain_type lower(const interval_type& inter_val){ return inter_val.lower(); };
+    static domain_type upper(const interval_type& inter_val){ return inter_val.upper(); };
+};
+
+
+//==============================================================================
+//= Type traits
+//==============================================================================
+template <class DomainT, ICL_COMPARE Compare> 
+struct interval_bound_type< right_open_interval<DomainT,Compare> >
+{
+    typedef interval_bound_type type;
+    BOOST_STATIC_CONSTANT(bound_type, value = interval_bounds::static_right_open);
+};
+
+template <class DomainT, ICL_COMPARE Compare>
+struct type_to_string<icl::right_open_interval<DomainT,Compare> >
+{
+    static std::string apply()
+    { return "[I)<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+template<class DomainT, ICL_COMPARE Compare> 
+struct value_size<icl::right_open_interval<DomainT,Compare> >
+{
+    static std::size_t apply(const icl::right_open_interval<DomainT>&) 
+    { return 2; }
+};
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/separate_interval_set.hpp
+++ b/inst/include/boost/icl/separate_interval_set.hpp
@@ -1,0 +1,217 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_SEPARATE_INTERVAL_SET_HPP_JOFA_080608
+#define BOOST_ICL_SEPARATE_INTERVAL_SET_HPP_JOFA_080608
+
+#include <boost/assert.hpp>
+#include <boost/icl/type_traits/is_interval_separator.hpp>
+#include <boost/icl/interval_base_set.hpp>
+#include <boost/icl/interval_set.hpp>
+
+namespace boost{namespace icl
+{
+
+/** \brief Implements a set as a set of intervals - leaving adjoining intervals separate */
+template 
+<
+    typename                         DomainT, 
+    ICL_COMPARE                      Compare  = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_INTERVAL(ICL_COMPARE) Interval = ICL_INTERVAL_INSTANCE(ICL_INTERVAL_DEFAULT, DomainT, Compare),
+    ICL_ALLOC                        Alloc    = std::allocator
+> 
+class separate_interval_set: 
+    public interval_base_set<separate_interval_set<DomainT,Compare,Interval,Alloc>,
+                             DomainT,Compare,Interval,Alloc>
+{
+public:
+    typedef separate_interval_set<DomainT,Compare,Interval,Alloc> type;
+
+    typedef interval_base_set<type,DomainT,Compare,Interval,Alloc> base_type;
+
+    typedef type overloadable_type;
+    typedef type key_object_type;
+
+    typedef interval_set<DomainT,Compare,Interval,Alloc> joint_type;
+
+    /// The domain type of the set
+    typedef DomainT   domain_type;
+    /// The codomaintype is the same as domain_type
+    typedef DomainT   codomain_type;
+
+    /// The element type of the set
+    typedef DomainT   element_type;
+    /// The interval type of the set
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) interval_type;
+    /// The segment type of the set
+    typedef interval_type   segment_type;
+
+    /// Comparison functor for domain values
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    /// Comparison functor for intervals
+    typedef exclusive_less_than<interval_type> interval_compare;
+
+    /// Comparison functor for keys
+    typedef exclusive_less_than<interval_type> key_compare;
+
+    /// The allocator type of the set
+    typedef Alloc<interval_type> allocator_type;
+
+    /// allocator type of the corresponding element set
+    typedef Alloc<DomainT> domain_allocator_type;
+
+    /// The corresponding atomized type representing this interval container of elements
+    typedef typename base_type::atomized_type atomized_type;
+
+    /// Container type for the implementation 
+    typedef typename base_type::ImplSetT ImplSetT;
+
+    /// key type of the implementing container
+    typedef typename ImplSetT::key_type   key_type;
+    /// data type of the implementing container
+    typedef typename ImplSetT::value_type data_type;
+    /// value type of the implementing container
+    typedef typename ImplSetT::value_type value_type;
+
+    /// iterator for iteration over intervals
+    typedef typename ImplSetT::iterator iterator;
+    /// const_iterator for iteration over intervals
+    typedef typename ImplSetT::const_iterator const_iterator;
+
+    enum { fineness = 2 };
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /// Default constructor for the empty object
+    separate_interval_set(): base_type() {}
+    /// Copy constructor
+    separate_interval_set(const separate_interval_set& src): base_type(src) {}
+
+    /// Copy constructor for base_type
+    template<class SubType>
+    separate_interval_set
+        (const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    { 
+        this->assign(src); 
+    }
+
+    /// Constructor for a single element
+    explicit separate_interval_set(const domain_type& elem): base_type() { this->add(elem); }
+    /// Constructor for a single interval
+    explicit separate_interval_set(const interval_type& itv): base_type() { this->add(itv); }
+
+    /// Assignment from a base interval_set.
+    template<class SubType>
+    void assign(const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    {
+        this->clear();
+        this->_set.insert(src.begin(), src.end());
+    }
+
+    /// Assignment operator for base type
+    template<class SubType>
+    separate_interval_set& operator =
+        (const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    { 
+        this->assign(src); 
+        return *this; 
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    /// Move constructor
+    separate_interval_set(separate_interval_set&& src)
+        : base_type(boost::move(src))
+    {}
+
+    /// Move assignment operator
+    separate_interval_set& operator = (separate_interval_set src)
+    { 
+        base_type::operator=(boost::move(src));
+        return *this;
+    }
+    //==========================================================================
+#   else
+
+    /// Assignment operator
+    separate_interval_set& operator = (const separate_interval_set& src)
+    { 
+        base_type::operator=(src);
+        return *this;
+    }
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+private:
+    // Private functions that shall be accessible by the baseclass:
+    friend class
+        interval_base_set<separate_interval_set<DomainT,Compare,Interval,Alloc>, 
+                                                DomainT,Compare,Interval,Alloc>;
+
+    iterator handle_inserted(iterator inserted_)
+    { 
+        return inserted_; 
+    }
+
+    iterator add_over(const interval_type& addend, iterator last_)
+    {
+        return segmental::join_under(*this, addend, last_);
+    }
+
+    iterator add_over(const interval_type& addend)
+    {
+        return segmental::join_under(*this, addend);
+    }
+
+} ;
+
+
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_set<icl::separate_interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_set<icl::separate_interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_container<icl::separate_interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_interval_container<icl::separate_interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_separator<icl::separate_interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_interval_separator<icl::separate_interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+//-----------------------------------------------------------------------------
+// type representation
+//-----------------------------------------------------------------------------
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct type_to_string<icl::separate_interval_set<DomainT,Compare,Interval,Alloc> >
+{
+    static std::string apply()
+    { return "se_itv_set<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/set.hpp
+++ b/inst/include/boost/icl/set.hpp
@@ -1,0 +1,25 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2011: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_SET_HPP_JOFA_070519
+#define BOOST_ICL_SET_HPP_JOFA_070519
+
+#include <boost/icl/impl_config.hpp>
+
+#if defined(ICL_USE_BOOST_MOVE_IMPLEMENTATION)
+#   include <boost/container/set.hpp>
+#elif defined(ICL_USE_STD_IMPLEMENTATION)
+#   include <set>
+#else 
+#   include <set>
+#endif
+
+#include <boost/icl/associative_element_container.hpp>
+#include <boost/icl/functors.hpp>
+
+#endif // BOOST_ICL_SET_HPP_JOFA_070519
+

--- a/inst/include/boost/icl/split_interval_map.hpp
+++ b/inst/include/boost/icl/split_interval_map.hpp
@@ -1,0 +1,246 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2012: Joachim Faulhaber
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_SPLIT_INTERVAL_MAP_HPP_JOFA_000706
+#define BOOST_ICL_SPLIT_INTERVAL_MAP_HPP_JOFA_000706
+
+#include <boost/icl/interval_set.hpp>
+#include <boost/icl/interval_map.hpp>
+#include <boost/icl/interval_base_map.hpp>
+#include <boost/icl/split_interval_set.hpp>
+
+namespace boost{namespace icl
+{
+
+/** \brief implements a map as a map of intervals - on insertion 
+    overlapping intervals are split and associated values are combined. */
+template
+<
+    typename DomainT,
+    typename CodomainT,
+    class Traits = icl::partial_absorber,
+    ICL_COMPARE Compare  = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_COMBINE Combine  = ICL_COMBINE_INSTANCE(icl::inplace_plus, CodomainT),
+    ICL_SECTION Section  = ICL_SECTION_INSTANCE(icl::inter_section, CodomainT), 
+    ICL_INTERVAL(ICL_COMPARE) Interval = ICL_INTERVAL_INSTANCE(ICL_INTERVAL_DEFAULT, DomainT, Compare),
+    ICL_ALLOC   Alloc    = std::allocator
+>
+class split_interval_map:
+    public interval_base_map<split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>, 
+                             DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>
+{
+public:
+    typedef Traits traits;
+    typedef split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> type;
+    typedef       interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> joint_type;
+    typedef type overloadable_type;
+
+    typedef interval_base_map <type, 
+                               DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> base_type;
+
+    typedef DomainT domain_type;
+    typedef CodomainT codomain_type;
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) interval_type;
+    typedef typename base_type::iterator iterator;
+    typedef typename base_type::value_type value_type;
+    typedef typename base_type::element_type element_type;
+    typedef typename base_type::segment_type segment_type;
+    typedef typename base_type::domain_mapping_type    domain_mapping_type;
+    typedef typename base_type::interval_mapping_type  interval_mapping_type;
+    typedef typename base_type::ImplMapT ImplMapT;
+
+    typedef typename base_type::codomain_combine codomain_combine;
+
+    typedef interval_set<DomainT,Compare,Interval,Alloc> interval_set_type;
+    typedef interval_set_type set_type;
+    typedef set_type          key_object_type;
+
+    enum { fineness = 3 };
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /// Default constructor for the empty object
+    split_interval_map(): base_type() {}
+
+    /// Copy constructor
+    split_interval_map(const split_interval_map& src): base_type(src) {}
+
+    explicit split_interval_map(const domain_mapping_type& base_pair): base_type()
+    { this->add(base_pair); }
+
+    explicit split_interval_map(const value_type& value_pair): base_type()
+    { this->add(value_pair); }
+
+    /// Assignment from a base interval_map.
+    template<class SubType>
+    void assign(const interval_base_map<SubType,DomainT,CodomainT,
+                                        Traits,Compare,Combine,Section,Interval,Alloc>& src)
+    {
+        this->clear();
+        this->_map.insert(src.begin(), src.end());
+    }
+
+    /// Assignment operator for base type
+    template<class SubType>
+    split_interval_map& operator =
+        (const interval_base_map<SubType,DomainT,CodomainT,
+                                 Traits,Compare,Combine,Section,Interval,Alloc>& src)
+    { 
+        this->assign(src); 
+        return *this; 
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    /// Move constructor
+    split_interval_map(split_interval_map&& src)
+        : base_type(boost::move(src))
+    {}
+
+    /// Move assignment operator
+    split_interval_map& operator = (split_interval_map src)
+    { 
+        base_type::operator=(boost::move(src));
+        return *this;
+    }
+
+    //==========================================================================
+#   else
+
+    /// Assignment operator
+    split_interval_map& operator = (const split_interval_map& src)
+    { 
+        base_type::operator=(src);
+        return *this;
+    }
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+
+private:
+    // Private functions that shall be accessible by the baseclass:
+    friend class
+        interval_base_map <split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>, 
+                                              DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc>;
+
+    iterator handle_inserted(iterator it_)const { return it_; }
+    void handle_inserted(iterator, iterator)const{ }
+
+    template<class Combiner>
+    void handle_left_combined(iterator it_)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+            this->_map.erase(it_);
+    }
+
+    template<class Combiner>
+    void handle_combined(iterator it_)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+            this->_map.erase(it_);
+    }
+
+    template<class Combiner>
+    void handle_preceeded_combined(iterator prior_, iterator& it_)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+        {
+            this->_map.erase(it_);
+            it_ = prior_;
+        }
+    }
+
+    template<class Combiner>
+    void handle_succeeded_combined(iterator it_, iterator)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+            this->_map.erase(it_);
+    }
+
+    void handle_reinserted(iterator){}
+
+    template<class Combiner>
+    void gap_insert_at(iterator& it_, iterator prior_, 
+                       const interval_type& end_gap, const codomain_type& co_val)
+    {
+        if(on_absorbtion<type,Combiner,Traits::absorbs_identities>::is_absorbable((*it_).second))
+        {
+            this->_map.erase(it_);
+            it_ = this->template gap_insert<Combiner>(prior_, end_gap, co_val);
+        }
+        else
+            it_ = this->template gap_insert<Combiner>(it_, end_gap, co_val);
+    }
+} ;
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_map<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef is_map<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct has_inverse<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef has_inverse<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (has_inverse<CodomainT>::value)); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_container<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef is_interval_container<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_splitter<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef is_interval_splitter<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct absorbs_identities<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef absorbs_identities<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (Traits::absorbs_identities)); 
+};
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_total<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{ 
+    typedef is_total<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = (Traits::is_total)); 
+};
+
+
+template <class DomainT, class CodomainT, class Traits, ICL_COMPARE Compare, ICL_COMBINE Combine, ICL_SECTION Section, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct type_to_string<icl::split_interval_map<DomainT,CodomainT,Traits,Compare,Combine,Section,Interval,Alloc> >
+{
+    static std::string apply()
+    { 
+        return "sp_itv_map<"+ type_to_string<DomainT>::apply()   + ","
+                            + type_to_string<CodomainT>::apply() + ","
+                            + type_to_string<Traits>::apply()    +">"; 
+    }
+};
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/split_interval_set.hpp
+++ b/inst/include/boost/icl/split_interval_set.hpp
@@ -1,0 +1,237 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2009: Joachim Faulhaber
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_SPLIT_INTERVAL_SET_HPP_JOFA_990223
+#define BOOST_ICL_SPLIT_INTERVAL_SET_HPP_JOFA_990223
+
+#include <boost/icl/type_traits/is_interval_splitter.hpp>
+#include <boost/icl/interval_base_set.hpp>
+#include <boost/icl/interval_set.hpp>
+
+namespace boost{namespace icl
+{
+
+/** \brief implements a set as a set of intervals - on insertion 
+    overlapping intervals are split */
+template 
+<
+    typename                  DomainT, 
+    ICL_COMPARE               Compare  = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT),
+    ICL_INTERVAL(ICL_COMPARE) Interval = ICL_INTERVAL_INSTANCE(ICL_INTERVAL_DEFAULT, DomainT, Compare),
+    ICL_ALLOC                 Alloc    = std::allocator
+> 
+class split_interval_set: 
+    public interval_base_set<split_interval_set<DomainT,Compare,Interval,Alloc>, 
+                             DomainT,Compare,Interval,Alloc>
+{
+public:
+    typedef split_interval_set<DomainT,Compare,Interval,Alloc> type;
+    typedef interval_base_set<type,DomainT,Compare,Interval,Alloc> base_type;
+
+    typedef interval_set<DomainT,Compare,Interval,Alloc> joint_type;
+    typedef type overloadable_type;
+    typedef type key_object_type;
+
+    /// The domain type of the set
+    typedef DomainT   domain_type;
+    /// The codomaintype is the same as domain_type
+    typedef DomainT   codomain_type;
+
+    /// The element type of the set
+    typedef DomainT   element_type;
+    /// The interval type of the set
+    typedef ICL_INTERVAL_TYPE(Interval,DomainT,Compare) interval_type;
+    /// The segment type of the set
+    typedef interval_type   segment_type;
+
+    /// Comparison functor for domain values
+    typedef ICL_COMPARE_DOMAIN(Compare,DomainT) domain_compare;
+    /// Comparison functor for intervals
+    typedef exclusive_less_than<interval_type> interval_compare;
+
+    /// Comparison functor for keys
+    typedef exclusive_less_than<interval_type> key_compare;
+
+    /// The allocator type of the set
+    typedef Alloc<interval_type> allocator_type;
+
+    /// allocator type of the corresponding element set
+    typedef Alloc<DomainT> domain_allocator_type;
+
+    /// The corresponding atomized type representing this interval container of elements
+    typedef typename base_type::atomized_type atomized_type;
+
+    /// Container type for the implementation 
+    typedef typename base_type::ImplSetT ImplSetT;
+
+    /// key type of the implementing container
+    typedef typename ImplSetT::key_type   key_type;
+    /// data type of the implementing container
+    typedef typename ImplSetT::value_type data_type;
+    /// value type of the implementing container
+    typedef typename ImplSetT::value_type value_type;
+
+    /// iterator for iteration over intervals
+    typedef typename ImplSetT::iterator iterator;
+    /// const_iterator for iteration over intervals
+    typedef typename ImplSetT::const_iterator const_iterator;
+
+    enum { fineness = 3 };
+
+public:
+    //==========================================================================
+    //= Construct, copy, destruct
+    //==========================================================================
+    /// Default constructor for the empty object
+    split_interval_set(): base_type() {}
+
+    /// Copy constructor
+    split_interval_set(const split_interval_set& src): base_type(src) {}
+
+    /// Copy constructor for base_type
+    template<class SubType>
+    split_interval_set
+        (const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    { this->assign(src); }
+
+    /// Constructor for a single element
+    explicit split_interval_set(const interval_type& elem): base_type() { this->add(elem); }
+    /// Constructor for a single interval
+    explicit split_interval_set(const domain_type& itv): base_type() { this->add(itv); }
+
+    /// Assignment from a base interval_set.
+    template<class SubType>
+    void assign(const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    {
+        this->clear();
+        this->_set.insert(src.begin(), src.end());
+    }
+
+    /// Assignment operator for base type
+    template<class SubType>
+    split_interval_set& operator =
+        (const interval_base_set<SubType,DomainT,Compare,Interval,Alloc>& src)
+    { 
+        this->assign(src); 
+        return *this; 
+    }
+
+#   ifndef BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    //==========================================================================
+    //= Move semantics
+    //==========================================================================
+
+    /// Move constructor
+    split_interval_set(split_interval_set&& src)
+        : base_type(boost::move(src))
+    {}
+
+    /// Move assignment operator
+    split_interval_set& operator = (split_interval_set src)
+    { 
+        base_type::operator=(boost::move(src));
+        return *this;
+    }
+    //==========================================================================
+#   else
+
+    /// Assignment operator
+    split_interval_set& operator = (const split_interval_set& src)
+    { 
+        base_type::operator=(src);
+        return *this;
+    }
+
+#   endif // BOOST_ICL_NO_CXX11_RVALUE_REFERENCES
+    
+private:
+    // Private functions that shall be accessible by the baseclass:
+    friend class
+        interval_base_set<split_interval_set<DomainT,Compare,Interval,Alloc>, 
+                                             DomainT,Compare,Interval,Alloc>;
+
+    iterator handle_inserted(iterator inserted_)
+    { 
+        return inserted_; 
+    }
+
+    iterator add_over(const interval_type& addend, iterator last_)
+    {
+        iterator first_ = this->_set.lower_bound(addend);
+        //BOOST_ASSERT(next(last_) == this->_set.upper_bound(inter_val));
+
+        iterator it_ = first_;
+        interval_type rest_interval = addend;
+
+        this->add_front(rest_interval, it_);
+        this->add_main (rest_interval, it_, last_);
+        this->add_rear (rest_interval, it_);
+        return it_;
+    }
+
+    iterator add_over(const interval_type& addend)
+    {
+        std::pair<iterator,iterator> overlap = this->equal_range(addend);
+        iterator first_ = overlap.first,
+                 end_   = overlap.second,
+                 last_  = end_; --last_;
+
+        iterator it_ = first_;
+        interval_type rest_interval = addend;
+
+        this->add_front(rest_interval, it_);
+        this->add_main (rest_interval, it_, last_);
+        this->add_rear (rest_interval, it_);
+
+        return it_;
+    }
+
+} ;
+
+
+//-----------------------------------------------------------------------------
+// type traits
+//-----------------------------------------------------------------------------
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_set<icl::split_interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_set<icl::split_interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_container<icl::split_interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_interval_container<icl::split_interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true); 
+};
+
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct is_interval_splitter<icl::split_interval_set<DomainT,Compare,Interval,Alloc> >
+{ 
+    typedef is_interval_splitter<icl::split_interval_set<DomainT,Compare,Interval,Alloc> > type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+//-----------------------------------------------------------------------------
+// type representation
+//-----------------------------------------------------------------------------
+template <class DomainT, ICL_COMPARE Compare, ICL_INTERVAL(ICL_COMPARE)  Interval, ICL_ALLOC Alloc>
+struct type_to_string<icl::split_interval_set<DomainT,Compare,Interval,Alloc> >
+{
+    static std::string apply()
+    { return "sp_itv_set<"+ type_to_string<DomainT>::apply() +">"; }
+};
+
+
+}} // namespace icl boost
+
+#endif // BOOST_ICL_SPLIT_INTERVAL_SET_HPP_JOFA_990223
+
+
+

--- a/inst/include/boost/icl/type_traits/absorbs_identities.hpp
+++ b/inst/include/boost/icl/type_traits/absorbs_identities.hpp
@@ -1,0 +1,23 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_ABSORBS_IDENTITIES_HPP_JOFA_081004
+#define BOOST_ICL_TYPE_TRAITS_ABSORBS_IDENTITIES_HPP_JOFA_081004
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct absorbs_identities
+    {
+        typedef absorbs_identities<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = false); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/adds_inversely.hpp
+++ b/inst/include/boost/icl/type_traits/adds_inversely.hpp
@@ -1,0 +1,29 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_ADDS_INVERSELY_HPP_JOFA_100829
+#define BOOST_ICL_TYPE_TRAITS_ADDS_INVERSELY_HPP_JOFA_100829
+
+#include <boost/icl/type_traits/has_inverse.hpp>
+#include <boost/icl/functors.hpp>
+
+namespace boost{ namespace icl
+{
+
+template<class Type, class Combiner>
+struct adds_inversely
+{
+    typedef adds_inversely type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (mpl::and_<has_inverse<Type>, is_negative<Combiner> >::value)); 
+};
+
+}} // namespace boost icl
+
+#endif // BOOST_ICL_TYPE_TRAITS_ADDS_INVERSELY_HPP_JOFA_100829
+
+

--- a/inst/include/boost/icl/type_traits/codomain_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/codomain_type_of.hpp
@@ -1,0 +1,64 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_CODOMAIN_TYPE_OF_HPP_JOFA_100829
+#define BOOST_ICL_TYPE_TRAITS_CODOMAIN_TYPE_OF_HPP_JOFA_100829
+
+#include <set>
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/icl/type_traits/no_type.hpp>
+#include <boost/icl/type_traits/is_container.hpp>
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(codomain_type)
+    }
+
+    template <class Type>
+    struct has_codomain_type 
+      : mpl::bool_<detail::has_codomain_type<Type>::value>
+    {};
+
+    template <class Type, bool has_codomain_type, bool is_std_set> 
+    struct get_codomain_type;
+
+    template <class Type>
+    struct get_codomain_type<Type, false, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type, bool is_std_set>
+    struct get_codomain_type<Type, true, is_std_set>
+    {
+        typedef typename Type::codomain_type type;
+    };
+
+    template <class Type>
+    struct get_codomain_type<Type, false, true>
+    {
+        typedef typename Type::value_type type;
+    };
+
+    template <class Type>
+    struct codomain_type_of
+    {
+        typedef typename 
+            get_codomain_type< Type
+                             , has_codomain_type<Type>::value
+                             , is_std_set<Type>::value
+                             >::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/difference.hpp
+++ b/inst/include/boost/icl/type_traits/difference.hpp
@@ -1,0 +1,19 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_DIFFERENCE_HPP_JOFA_080911
+#define BOOST_ICL_TYPE_TRAITS_DIFFERENCE_HPP_JOFA_080911
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct difference{ typedef Type type; };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/difference_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/difference_type_of.hpp
@@ -1,0 +1,103 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_DIFFERENCE_TYPE_OF_HPP_JOFA_080911
+#define BOOST_ICL_TYPE_TRAITS_DIFFERENCE_TYPE_OF_HPP_JOFA_080911
+
+#include <boost/config.hpp> // For macro BOOST_STATIC_CONSTANT
+#include <boost/type_traits/is_pointer.hpp>
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/icl/type_traits/no_type.hpp>
+#include <boost/icl/type_traits/is_numeric.hpp>
+#include <boost/icl/type_traits/rep_type_of.hpp>
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(difference_type)
+    }
+
+    //--------------------------------------------------------------------------
+    template <class Type>
+    struct has_difference_type 
+      : mpl::bool_<detail::has_difference_type<Type>::value>
+    {};
+
+    //--------------------------------------------------------------------------
+    template<class Type> // type_of(T-T)==T
+    struct is_subtraction_closed
+    {
+        typedef is_subtraction_closed type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = (mpl::or_< is_numeric<Type>
+                             , mpl::and_< has_rep_type<Type>
+                                        , mpl::not_<has_difference_type<Type> > 
+                                        >
+                             >::value)
+            );
+    };
+
+    //--------------------------------------------------------------------------
+    template<class Type>
+    struct has_difference
+    {
+        typedef has_difference type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = (mpl::or_< is_subtraction_closed<Type>
+                             , is_pointer<Type> 
+                             , has_difference_type<Type> >::value) 
+            );
+    };
+
+    //--------------------------------------------------------------------------
+    template <class Type, bool has_difference, bool has_diff_type> 
+    struct get_difference_type;
+
+    template <class Type>
+    struct get_difference_type<Type, false, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_difference_type<Type*, true, false>
+    {
+        typedef std::ptrdiff_t type;
+    };
+
+    template <class Type>
+    struct get_difference_type<Type, true, false>
+    {
+        typedef Type type;
+    };
+
+    template <class Type>
+    struct get_difference_type<Type, true, true>
+    {
+        typedef typename Type::difference_type type;
+    };
+
+    //--------------------------------------------------------------------------
+    template<class Type> 
+    struct difference_type_of
+    { 
+        typedef typename 
+            get_difference_type< Type 
+                               , has_difference<Type>::value
+                               , has_difference_type<Type>::value
+                               >::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/domain_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/domain_type_of.hpp
@@ -1,0 +1,54 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_DOMAIN_TYPE_OF_HPP_JOFA_100902
+#define BOOST_ICL_TYPE_TRAITS_DOMAIN_TYPE_OF_HPP_JOFA_100902
+
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/icl/type_traits/no_type.hpp>
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(domain_type)
+    }
+
+    template <class Type>
+    struct has_domain_type 
+      : mpl::bool_<detail::has_domain_type<Type>::value>
+    {};
+
+
+    template <class Type, bool has_domain_type> 
+    struct get_domain_type;
+
+    template <class Type>
+    struct get_domain_type<Type, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_domain_type<Type, true>
+    {
+        typedef typename Type::domain_type type;
+    };
+
+    template <class Type>
+    struct domain_type_of
+    {
+        typedef typename 
+            get_domain_type<Type, has_domain_type<Type>::value>::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/element_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/element_type_of.hpp
@@ -1,0 +1,112 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_ELEMENT_TYPE_OF_HPP_JOFA_100902
+#define BOOST_ICL_TYPE_TRAITS_ELEMENT_TYPE_OF_HPP_JOFA_100902
+
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/icl/type_traits/no_type.hpp>
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(element_type)
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(value_type)
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(key_type)
+    }
+
+    //--------------------------------------------------------------------------
+    template <class Type>
+    struct has_element_type 
+      : mpl::bool_<detail::has_element_type<Type>::value>
+    {};
+
+    template <class Type, bool has_element_type> 
+    struct get_element_type;
+
+    template <class Type>
+    struct get_element_type<Type, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_element_type<Type, true>
+    {
+        typedef typename Type::element_type type;
+    };
+
+    template <class Type>
+    struct element_type_of
+    {
+        typedef typename 
+            get_element_type<Type, has_element_type<Type>::value>::type type;
+    };
+
+    //--------------------------------------------------------------------------
+    template <class Type>
+    struct has_value_type 
+      : mpl::bool_<detail::has_value_type<Type>::value>
+    {};
+
+    template <class Type, bool has_value_type> 
+    struct get_value_type;
+
+    template <class Type>
+    struct get_value_type<Type, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_value_type<Type, true>
+    {
+        typedef typename Type::value_type type;
+    };
+
+    template <class Type>
+    struct value_type_of
+    {
+        typedef typename 
+            get_value_type<Type, has_value_type<Type>::value>::type type;
+    };
+
+    //--------------------------------------------------------------------------
+    template <class Type>
+    struct has_key_type 
+      : mpl::bool_<detail::has_key_type<Type>::value>
+    {};
+
+    template <class Type, bool has_key_type> 
+    struct get_key_type;
+
+    template <class Type>
+    struct get_key_type<Type, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_key_type<Type, true>
+    {
+        typedef typename Type::key_type type;
+    };
+
+    template <class Type>
+    struct key_type_of
+    {
+        typedef typename 
+            get_key_type<Type, has_key_type<Type>::value>::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/has_inverse.hpp
+++ b/inst/include/boost/icl/type_traits/has_inverse.hpp
@@ -1,0 +1,29 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_HAS_INVERSE_HPP_JOFA_090205
+#define BOOST_ICL_TYPE_TRAITS_HAS_INVERSE_HPP_JOFA_090205
+
+#include <boost/type_traits/is_signed.hpp>
+#include <boost/type_traits/is_floating_point.hpp>
+
+namespace boost{ namespace icl
+{
+
+    template <class Type> struct has_inverse
+    { 
+        typedef has_inverse<Type> type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = (   boost::is_signed<Type>::value 
+                     || is_floating_point<Type>::value ) ); 
+    };
+
+}} // namespace boost icl
+
+#endif // BOOST_ICL_TYPE_TRAITS_HAS_INVERSE_HPP_JOFA_090205
+
+

--- a/inst/include/boost/icl/type_traits/has_set_semantics.hpp
+++ b/inst/include/boost/icl/type_traits/has_set_semantics.hpp
@@ -1,0 +1,35 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_HAS_SET_SEMANTICS_HPP_JOFA_100829
+#define BOOST_ICL_TYPE_TRAITS_HAS_SET_SEMANTICS_HPP_JOFA_100829
+
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/icl/type_traits/is_set.hpp>
+#include <boost/icl/type_traits/is_map.hpp>
+#include <boost/icl/type_traits/codomain_type_of.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct has_set_semantics
+    { 
+        typedef has_set_semantics<Type> type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = (mpl::or_< is_set<Type>
+                             , mpl::and_< is_map<Type>
+                                        , has_set_semantics
+                                          <typename codomain_type_of<Type>::type > 
+                                        > 
+                             >::value)); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/identity_element.hpp
+++ b/inst/include/boost/icl/type_traits/identity_element.hpp
@@ -1,0 +1,35 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IDENTITY_ELEMENT_HPP_JOFA_080912
+#define BOOST_ICL_TYPE_TRAITS_IDENTITY_ELEMENT_HPP_JOFA_080912
+
+#include <boost/icl/type_traits/type_to_string.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct identity_element
+    { 
+        static Type value(); 
+        Type operator()()const { return value(); }
+    };
+
+    template <class Type>
+    inline Type identity_element<Type>::value()
+    {
+        static Type _value;
+        return _value;
+    }
+
+    template<>
+    inline std::string unary_template_to_string<identity_element>::apply() { return "0"; }
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/infinity.hpp
+++ b/inst/include/boost/icl/type_traits/infinity.hpp
@@ -1,0 +1,181 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2011: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_INFINITY_HPP_JOFA_100322
+#define BOOST_ICL_TYPE_TRAITS_INFINITY_HPP_JOFA_100322
+
+#include <string>
+#include <boost/static_assert.hpp>
+#include <boost/icl/type_traits/is_numeric.hpp>
+#include <boost/icl/type_traits/rep_type_of.hpp>
+#include <boost/icl/type_traits/size_type_of.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost{ namespace icl
+{
+
+template<class Type> struct has_std_infinity
+{
+    typedef has_std_infinity type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (     is_numeric<Type>::value
+                   && std::numeric_limits<Type>::has_infinity
+                )
+       );
+};
+
+template<class Type> struct has_max_infinity
+{
+    typedef has_max_infinity type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (     is_numeric<Type>::value
+                   && ! std::numeric_limits<Type>::has_infinity
+                )
+       );
+};
+
+//------------------------------------------------------------------------------
+template <class Type, bool has_std_inf=false, bool has_std_max=false> 
+struct get_numeric_infinity;
+
+template <class Type, bool has_std_max> 
+struct get_numeric_infinity<Type, true, has_std_max>
+{
+    typedef get_numeric_infinity type;
+    static Type value()
+    {
+        return (std::numeric_limits<Type>::infinity)();
+    }
+};
+
+template <class Type> 
+struct get_numeric_infinity<Type, false, true>
+{
+    typedef get_numeric_infinity type;
+    static Type value()
+    {
+        return (std::numeric_limits<Type>::max)();
+    }
+};
+
+template <class Type> 
+struct get_numeric_infinity<Type, false, false>
+{
+    typedef get_numeric_infinity type;
+    static Type value()
+    {
+        return Type();
+    }
+};
+
+template <class Type> 
+struct numeric_infinity
+{
+    typedef numeric_infinity type;
+    static Type value()
+    {
+        return get_numeric_infinity< Type
+                                   , has_std_infinity<Type>::value
+                                   , has_max_infinity<Type>::value >::value();
+    }
+};
+
+
+//------------------------------------------------------------------------------
+template<class Type, bool has_numeric_inf, bool has_repr_inf, bool has_size, bool has_diff>
+struct get_infinity;
+
+template<class Type, bool has_repr_inf, bool has_size, bool has_diff>
+struct get_infinity<Type, true, has_repr_inf, has_size, has_diff>
+{
+    typedef get_infinity type;
+
+    static Type value()
+    {
+        return  numeric_infinity<Type>::value();
+    }
+};
+
+template<class Type, bool has_size, bool has_diff>
+struct get_infinity<Type, false, true, has_size, has_diff>
+{
+    typedef get_infinity type;
+
+    static Type value()
+    {
+        return Type(numeric_infinity<typename Type::rep>::value());
+    }
+};
+
+template<class Type, bool has_diff>
+struct get_infinity<Type, false, false, true, has_diff>
+{
+    typedef get_infinity type;
+    typedef typename Type::size_type size_type;
+
+    static Type value()
+    {
+        return Type(numeric_infinity<size_type>::value());
+    }
+};
+
+template<class Type>
+struct get_infinity<Type, false, false, false, true>
+{
+    typedef get_infinity type;
+    typedef typename Type::difference_type difference_type;
+
+    static Type value()
+    {
+        return identity_element<difference_type>::value();
+    }
+};
+
+template<class Type>
+struct get_infinity<Type, false, false, false, false>
+{
+    typedef get_infinity type;
+
+    static Type value()
+    {
+        return identity_element<Type>::value();
+    }
+};
+
+template <class Type> struct infinity
+{
+    typedef infinity type;
+
+    static Type value()
+    {
+        return
+            get_infinity< Type
+                        , is_numeric<Type>::value
+                        , has_rep_type<Type>::value
+                        , has_size_type<Type>::value
+                        , has_difference_type<Type>::value
+                        >::value();
+    }
+};
+
+template <> 
+struct infinity<std::string>
+{
+    typedef infinity type;
+
+    static std::string value()
+    {
+        return std::string();
+    }
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/interval_type_default.hpp
+++ b/inst/include/boost/icl/type_traits/interval_type_default.hpp
@@ -1,0 +1,55 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_INTERVAL_TYPE_DEFAULT_HPP_JOFA_100403
+#define BOOST_ICL_TYPE_TRAITS_INTERVAL_TYPE_DEFAULT_HPP_JOFA_100403
+
+#include <boost/mpl/if.hpp>
+#include <boost/icl/detail/design_config.hpp>
+#include <boost/icl/continuous_interval.hpp>
+#include <boost/icl/discrete_interval.hpp>
+#include <boost/icl/right_open_interval.hpp>
+#include <boost/icl/left_open_interval.hpp>
+#include <boost/icl/closed_interval.hpp>
+#include <boost/icl/open_interval.hpp>
+#include <boost/icl/type_traits/is_continuous.hpp>
+#include <boost/icl/type_traits/is_discrete.hpp>
+
+namespace boost{ namespace icl
+{
+
+    template <class DomainT, ICL_COMPARE Compare = ICL_COMPARE_INSTANCE(ICL_COMPARE_DEFAULT, DomainT)> 
+    struct interval_type_default
+    {
+#ifdef BOOST_ICL_USE_STATIC_BOUNDED_INTERVALS
+        typedef
+            typename mpl::if_< is_discrete<DomainT>
+#  ifdef BOOST_ICL_DISCRETE_STATIC_INTERVAL_DEFAULT 
+                             , BOOST_ICL_DISCRETE_STATIC_INTERVAL_DEFAULT<DomainT,Compare>
+#  else
+                             , right_open_interval<DomainT,Compare>
+#  endif
+
+#  ifdef BOOST_ICL_CONTINUOUS_STATIC_INTERVAL_DEFAULT 
+                             , BOOST_ICL_CONTINUOUS_STATIC_INTERVAL_DEFAULT<DomainT,Compare> 
+#  else
+                             , right_open_interval<DomainT,Compare>
+#  endif
+                             >::type type;
+#else
+        typedef
+            typename mpl::if_< is_discrete<DomainT>
+                             ,   discrete_interval<DomainT,Compare>
+                             , continuous_interval<DomainT,Compare> >::type type;
+#endif
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/interval_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/interval_type_of.hpp
@@ -1,0 +1,53 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_INTERVAL_TYPE_OF_HPP_JOFA_100910
+#define BOOST_ICL_TYPE_TRAITS_INTERVAL_TYPE_OF_HPP_JOFA_100910
+
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/icl/type_traits/no_type.hpp>
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(interval_type)
+    }
+
+    template <class Type>
+    struct has_interval_type 
+      : mpl::bool_<detail::has_interval_type<Type>::value>
+    {};
+
+    template <class Type, bool has_interval_type> 
+    struct get_interval_type;
+
+    template <class Type>
+    struct get_interval_type<Type, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_interval_type<Type, true>
+    {
+        typedef typename Type::interval_type type;
+    };
+
+    template <class Type>
+    struct interval_type_of
+    {
+        typedef typename 
+            get_interval_type<Type, has_interval_type<Type>::value>::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_associative_element_container.hpp
+++ b/inst/include/boost/icl/type_traits/is_associative_element_container.hpp
@@ -1,0 +1,32 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_ASSOCIATIVE_ELEMENT_CONTAINER_HPP_JOFA_100831
+#define BOOST_ICL_TYPE_TRAITS_IS_ASSOCIATIVE_ELEMENT_CONTAINER_HPP_JOFA_100831
+
+#include <boost/mpl/and.hpp> 
+#include <boost/mpl/or.hpp> 
+#include <boost/mpl/not.hpp> 
+#include <boost/icl/type_traits/is_element_container.hpp> 
+#include <boost/icl/type_traits/is_set.hpp> 
+
+namespace boost{ namespace icl
+{
+    template <class Type> 
+    struct is_associative_element_container
+    { 
+        typedef is_associative_element_container type;
+        BOOST_STATIC_CONSTANT(bool, value = 
+            (mpl::or_<is_element_set<Type>, is_element_map<Type> >::value));
+    };
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_asymmetric_interval.hpp
+++ b/inst/include/boost/icl/type_traits/is_asymmetric_interval.hpp
@@ -1,0 +1,54 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_ASYMMETRIC_INTERVAL_HPP_JOFA_100327
+#define BOOST_ICL_TYPE_TRAITS_IS_ASYMMETRIC_INTERVAL_HPP_JOFA_100327
+
+#include <boost/icl/type_traits/is_interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+template <class Type> struct is_asymmetric_interval
+{ 
+    typedef is_asymmetric_interval<Type> type;
+    BOOST_STATIC_CONSTANT(bool,
+            value = (mpl::and_<
+                        is_interval<Type>
+                    ,   has_static_bounds<Type>
+                    ,   has_asymmetric_bounds<Type>
+                    >::value)
+                );
+};
+
+template <class Type> struct is_continuous_asymmetric
+{ 
+    typedef is_continuous_asymmetric<Type> type;
+    BOOST_STATIC_CONSTANT(bool,
+            value = (mpl::and_<
+                        is_asymmetric_interval<Type>
+                    ,   is_continuous<typename domain_type_of<interval_traits<Type> >::type>
+                    >::value)
+                );
+};
+
+template <class Type> struct is_discrete_asymmetric
+{ 
+    typedef is_discrete_asymmetric<Type> type;
+    BOOST_STATIC_CONSTANT(bool,
+            value = (mpl::and_<
+                        is_asymmetric_interval<Type>
+                    ,   mpl::not_<is_continuous<typename domain_type_of<interval_traits<Type> >::type> >
+                    >::value)
+                );
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_combinable.hpp
+++ b/inst/include/boost/icl/type_traits/is_combinable.hpp
@@ -1,0 +1,568 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_IS_COMBINABLE_HPP_JOFA_090115
+#define BOOST_ICL_IS_COMBINABLE_HPP_JOFA_090115
+
+#include <boost/mpl/bool.hpp> 
+#include <boost/mpl/if.hpp> 
+#include <boost/mpl/and.hpp> 
+#include <boost/mpl/or.hpp> 
+#include <boost/mpl/not.hpp> 
+#include <boost/type_traits/is_same.hpp>
+#include <boost/icl/type_traits/is_concept_equivalent.hpp>
+#include <boost/icl/type_traits/is_interval_container.hpp>
+
+namespace boost{namespace icl
+{
+
+template<class Type>
+struct is_overloadable
+{
+    typedef is_overloadable<Type> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (boost::is_same<Type, typename Type::overloadable_type>::value)
+        );
+};
+
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+struct is_codomain_equal
+{
+    typedef is_codomain_equal<LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (boost::is_same<typename LeftT::codomain_type, 
+                        typename RightT::codomain_type>::value)
+        );
+};
+
+//NOTE: Equality of compare order implies the equality of the domain_types
+template<class LeftT, class RightT>
+struct is_key_compare_equal
+{
+    typedef is_key_compare_equal<LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (boost::is_same<typename LeftT::key_compare, 
+                        typename RightT::key_compare>::value)
+        );
+};
+
+template<class LeftT, class RightT>
+struct is_codomain_type_equal
+{
+    typedef is_codomain_type_equal<LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::and_<is_key_compare_equal<LeftT, RightT>, 
+                   is_codomain_equal<LeftT, RightT> >::value)
+        );
+};
+
+
+// For equal containers concepts, domain order and codomain type must match.
+template<template<class>class IsConcept, class LeftT, class RightT>
+struct is_concept_compatible
+{
+    typedef is_concept_compatible<IsConcept, LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::and_<
+            IsConcept<LeftT>
+          , IsConcept<RightT>
+          , is_codomain_type_equal<LeftT, RightT>
+        >::value)
+        );
+};
+
+template<template<class>class LeftConcept, 
+         template<class>class RightConcept,         
+         class LeftT, class RightT>
+struct is_concept_combinable
+{
+    typedef is_concept_combinable<LeftConcept, RightConcept, LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::and_<
+            LeftConcept<LeftT>
+          , RightConcept<RightT>
+          , is_key_compare_equal<LeftT, RightT>
+        >::value)
+        );
+};
+
+template<class LeftT, class RightT>
+struct is_intra_combinable
+{
+    typedef is_intra_combinable<LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::or_<
+            is_concept_compatible<is_interval_set, LeftT, RightT>
+          , is_concept_compatible<is_interval_map, LeftT, RightT>
+        >::value)
+        );
+};
+
+//------------------------------------------------------------------------------
+
+
+//------------------------------------------------------------------------------
+template<class LeftT, class RightT>
+struct is_cross_combinable
+{
+    typedef is_cross_combinable<LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::or_<
+            is_concept_combinable<is_interval_set, is_interval_map, LeftT, RightT>
+          , is_concept_combinable<is_interval_map, is_interval_set, LeftT, RightT>
+        >::value)
+        );
+};
+
+template<class LeftT, class RightT>
+struct is_inter_combinable
+{
+    typedef is_inter_combinable<LeftT, RightT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::or_<is_intra_combinable<LeftT,RightT>, 
+                  is_cross_combinable<LeftT,RightT> >::value)
+        );
+};
+
+//------------------------------------------------------------------------------
+// is_fragment_of
+//------------------------------------------------------------------------------
+template<class FragmentT, class Type>
+struct is_fragment_of
+{
+    typedef is_fragment_of type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+template<class Type>
+struct is_fragment_of<typename Type::element_type, Type>
+{
+    typedef is_fragment_of type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+template<class Type>
+struct is_fragment_of<typename Type::segment_type, Type>
+{
+    typedef is_fragment_of type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+//------------------------------------------------------------------------------
+// is_key_of
+//------------------------------------------------------------------------------
+template<class KeyT, class Type>
+struct is_key_of
+{
+    typedef is_key_of type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+template<class Type>
+struct is_key_of<typename Type::domain_type, Type>
+{
+    typedef is_key_of type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+template<class Type>
+struct is_key_of<typename Type::interval_type, Type>
+{
+    typedef is_key_of type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+//------------------------------------------------------------------------------
+// is_interval_set_derivative
+//------------------------------------------------------------------------------
+template<class Type, class AssociateT>
+struct is_interval_set_derivative;
+
+template<class Type>
+struct is_interval_set_derivative<Type, typename Type::domain_type>
+{ 
+    typedef is_interval_set_derivative type;
+    BOOST_STATIC_CONSTANT(bool, value = (is_interval_container<Type>::value)); 
+};
+
+template<class Type>
+struct is_interval_set_derivative<Type, typename Type::interval_type>
+{ 
+    typedef is_interval_set_derivative type;
+    BOOST_STATIC_CONSTANT(bool, value = (is_interval_container<Type>::value)); 
+};
+
+template<class Type, class AssociateT>
+struct is_interval_set_derivative
+{
+    typedef is_interval_set_derivative<Type, AssociateT> type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+//------------------------------------------------------------------------------
+// is_interval_map_derivative
+//------------------------------------------------------------------------------
+template<class Type, class AssociateT>
+struct is_interval_map_derivative;
+
+template<class Type>
+struct is_interval_map_derivative<Type, typename Type::domain_mapping_type>
+{
+    typedef is_interval_map_derivative type;
+    BOOST_STATIC_CONSTANT(bool, value = (is_interval_container<Type>::value));
+};
+
+template<class Type>
+struct is_interval_map_derivative<Type, typename Type::interval_mapping_type>
+{
+    typedef is_interval_map_derivative type;
+    BOOST_STATIC_CONSTANT(bool, value = (is_interval_container<Type>::value));
+};
+
+template<class Type>
+struct is_interval_map_derivative<Type, typename Type::value_type>
+{
+    typedef is_interval_map_derivative type;
+    BOOST_STATIC_CONSTANT(bool, value = (is_interval_container<Type>::value));
+};
+
+template<class Type, class AssociateT>
+struct is_interval_map_derivative
+{
+    typedef is_interval_map_derivative<Type, AssociateT> type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+//------------------------------------------------------------------------------
+// is_intra_derivative
+//------------------------------------------------------------------------------
+template<class Type, class AssociateT>
+struct is_intra_derivative
+{
+    typedef is_intra_derivative<Type, AssociateT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::or_
+        <     
+            mpl::and_<is_interval_set<Type>, 
+                      is_interval_set_derivative<Type, AssociateT> >
+          , mpl::and_<is_interval_map<Type>, 
+                      is_interval_map_derivative<Type, AssociateT> >
+        >::value)
+        );
+};
+
+template<class Type, class AssociateT>
+struct is_cross_derivative
+{
+    typedef is_cross_derivative<Type, AssociateT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::and_<
+            is_interval_map<Type>
+          , is_interval_set_derivative<Type, AssociateT>
+        >::value)
+        );
+};
+
+template<class Type, class AssociateT>
+struct is_inter_derivative
+{
+    typedef is_inter_derivative<Type, AssociateT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_<
+            is_intra_derivative<Type, AssociateT> 
+          , is_cross_derivative<Type, AssociateT>
+        >::value)
+        );
+};
+
+//------------------------------------------------------------------------------
+//- right combinable
+//------------------------------------------------------------------------------
+
+template<class GuideT, class CompanionT>
+struct is_interval_set_right_combinable
+{
+    typedef is_interval_set_right_combinable<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::and_
+        <
+            is_interval_set<GuideT>
+          , mpl::or_
+            <
+                is_interval_set_derivative<GuideT, CompanionT> 
+              , is_concept_compatible<is_interval_set, GuideT, CompanionT>
+            >
+        >::value)
+        );
+};
+
+template<class GuideT, class CompanionT>
+struct is_interval_map_right_intra_combinable //NOTE equivalent to is_fragment_type_of
+{
+    typedef is_interval_map_right_intra_combinable<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::and_
+        <
+            is_interval_map<GuideT>
+          , mpl::or_
+            <
+                is_interval_map_derivative<GuideT, CompanionT> 
+              , is_concept_compatible<is_interval_map, GuideT, CompanionT>
+            >
+        >::value)
+        );
+};
+
+template<class GuideT, class CompanionT>
+struct is_interval_map_right_cross_combinable //NOTE equivalent to key_type_of<Comp, Guide>
+{
+    typedef is_interval_map_right_cross_combinable<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::and_
+        <
+            is_interval_map<GuideT>
+          , mpl::or_
+            <
+                is_cross_derivative<GuideT, CompanionT> 
+              , is_concept_combinable<is_interval_map, is_interval_set, GuideT, CompanionT>
+            >
+        >::value)
+        );
+};
+
+template<class GuideT, class CompanionT>
+struct is_interval_map_right_inter_combinable
+{
+    typedef is_interval_map_right_inter_combinable<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_<
+            is_interval_map_right_intra_combinable<GuideT, CompanionT> 
+          , is_interval_map_right_cross_combinable<GuideT, CompanionT> 
+        >::value)
+        );
+};
+
+
+template<class GuideT, class CompanionT>
+struct is_right_intra_combinable
+{
+    typedef is_right_intra_combinable<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_
+        <
+            is_interval_set_right_combinable<GuideT, CompanionT> 
+          , is_interval_map_right_intra_combinable<GuideT, CompanionT> 
+        >::value)
+        );
+};
+
+template<class GuideT, class CompanionT>
+struct is_right_inter_combinable
+{
+    typedef is_right_inter_combinable<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_
+        <
+            is_interval_set_right_combinable<GuideT, CompanionT> 
+          , is_interval_map_right_inter_combinable<GuideT, CompanionT> 
+        >::value)
+        );
+};
+
+template<class GuideT, class IntervalSetT>
+struct combines_right_to_interval_set
+{
+    typedef combines_right_to_interval_set<GuideT, IntervalSetT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (is_concept_combinable<is_interval_container, is_interval_set, 
+                               GuideT, IntervalSetT>::value)
+        );
+};
+
+template<class GuideT, class IntervalMapT>
+struct combines_right_to_interval_map
+{
+    typedef combines_right_to_interval_map<GuideT, IntervalMapT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (is_concept_compatible<is_interval_map, GuideT, IntervalMapT>::value) );
+};
+
+template<class GuideT, class IntervalContainerT>
+struct combines_right_to_interval_container
+{
+    typedef combines_right_to_interval_container<GuideT, IntervalContainerT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_<combines_right_to_interval_set<GuideT, IntervalContainerT>,
+                  combines_right_to_interval_map<GuideT, IntervalContainerT> >::value)
+        );
+};
+
+
+
+//------------------------------------------------------------------------------
+//- segmentational_fineness
+//------------------------------------------------------------------------------
+template<class Type> struct unknown_fineness
+{
+    typedef unknown_fineness<Type> type;
+    static const int value = 0;
+};
+
+template<class Type> struct known_fineness
+{
+    typedef known_fineness<Type> type;
+    static const int value = Type::fineness;
+};
+
+template<class Type>struct segmentational_fineness
+{
+    typedef segmentational_fineness<Type> type;
+    static const int value = 
+        mpl::if_<is_interval_container<Type>, 
+                        known_fineness<Type>,
+                      unknown_fineness<Type>
+                >::type::value;
+};
+
+
+//------------------------------------------------------------------------------
+// is_interval_set_companion
+//------------------------------------------------------------------------------
+
+// CompanionT is either an interval_set or a derivative of set level: 
+// element_type=domain_type, segment_type=interval_type
+template<class GuideT, class CompanionT> struct is_interval_set_companion
+{ 
+    typedef is_interval_set_companion<GuideT,CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_
+        <
+            combines_right_to_interval_set<GuideT,CompanionT>
+          , is_interval_set_derivative<GuideT,CompanionT>
+        >::value)
+        );
+};
+
+
+//------------------------------------------------------------------------------
+// is_interval_map_companion
+//------------------------------------------------------------------------------
+
+template<class GuideT, class CompanionT> struct is_interval_map_companion
+{ 
+    typedef is_interval_map_companion<GuideT,CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_
+        <
+            combines_right_to_interval_map<GuideT,CompanionT>
+          , is_interval_map_derivative<GuideT,CompanionT>
+        >::value)
+        );
+};
+
+
+//------------------------------------------------------------------------------
+//- is_coarser_interval_{set,map}_companion
+//------------------------------------------------------------------------------
+template<class GuideT, class CompanionT> 
+struct is_coarser_interval_set_companion
+{
+    typedef is_coarser_interval_set_companion<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::and_
+        <
+           is_interval_set_companion<GuideT, CompanionT>
+         , mpl::bool_<(  segmentational_fineness<GuideT>::value 
+                       > segmentational_fineness<CompanionT>::value)>
+        >::value)
+        );
+};
+
+template<class GuideT, class CompanionT> 
+struct is_coarser_interval_map_companion
+{
+    typedef is_coarser_interval_map_companion<GuideT, CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::and_
+        <
+           is_interval_map_companion<GuideT, CompanionT>
+         , mpl::bool_<(  segmentational_fineness<GuideT>::value 
+                       > segmentational_fineness<CompanionT>::value)>
+        >::value)
+        );
+};
+
+//------------------------------------------------------------------------------
+// is_binary_interval_{set,map}_combinable
+//------------------------------------------------------------------------------
+template<class GuideT, class CompanionT>
+struct is_binary_interval_set_combinable
+{ 
+    typedef is_binary_interval_set_combinable<GuideT,CompanionT> type;
+    static const int value =
+        mpl::and_<  is_interval_set<GuideT>
+                  , is_coarser_interval_set_companion<GuideT, CompanionT> 
+                 >::value;
+};
+
+template<class GuideT, class CompanionT>
+struct is_binary_interval_map_combinable
+{ 
+    typedef is_binary_interval_map_combinable<GuideT,CompanionT> type;
+    static const int value =
+        mpl::and_<  is_interval_map<GuideT>
+                  , is_coarser_interval_map_companion<GuideT, CompanionT> 
+                 >::value;
+};
+
+template<class GuideT, class CompanionT>
+struct is_binary_intra_combinable
+{ 
+    typedef is_binary_intra_combinable<GuideT,CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::or_<is_binary_interval_set_combinable<GuideT, CompanionT>,
+                 is_binary_interval_map_combinable<GuideT, CompanionT> 
+                >::value)
+        );
+};
+
+template<class GuideT, class CompanionT>
+struct is_binary_cross_combinable
+{ 
+    typedef is_binary_cross_combinable<GuideT,CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::and_
+        <     is_interval_map<GuideT>
+            , mpl::or_<  is_coarser_interval_map_companion<GuideT, CompanionT>
+                       ,         is_interval_set_companion<GuideT, CompanionT> > 
+        >::value)
+        );
+};
+
+template<class GuideT, class CompanionT>
+struct is_binary_inter_combinable
+{ 
+    typedef is_binary_inter_combinable<GuideT,CompanionT> type;
+    BOOST_STATIC_CONSTANT(bool, value =
+        (mpl::or_
+        <     
+            mpl::and_<is_interval_map<GuideT>, 
+                      is_binary_cross_combinable<GuideT, CompanionT> >
+          , mpl::and_<is_interval_set<GuideT>, 
+                      is_binary_intra_combinable<GuideT, CompanionT> >
+        >::value)
+        );
+};
+
+
+}} // namespace icl boost
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_concept_equivalent.hpp
+++ b/inst/include/boost/icl/type_traits/is_concept_equivalent.hpp
@@ -1,0 +1,38 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_CONCEPT_EQUIVALENT_HPP_JOFA_090830
+#define BOOST_ICL_TYPE_TRAITS_IS_CONCEPT_EQUIVALENT_HPP_JOFA_090830
+
+#include <boost/mpl/and.hpp> 
+
+namespace boost{ namespace icl
+{
+
+    template<template<class>class IsConcept, class LeftT, class RightT>
+    struct is_concept_equivalent
+    {
+        typedef is_concept_equivalent<IsConcept, LeftT, RightT> type;
+        BOOST_STATIC_CONSTANT(bool, value =
+            (mpl::and_<IsConcept<LeftT>, IsConcept<RightT> >::value)
+            );
+    };
+
+    template<template<class>class IsConcept, class LeftT, class RightT>
+    struct has_same_concept
+    {
+        typedef has_same_concept<IsConcept, LeftT, RightT> type;
+        BOOST_STATIC_CONSTANT(bool, value =
+            (mpl::and_<IsConcept<LeftT>, is_concept_equivalent<IsConcept, LeftT, RightT> >::value)
+            );
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_container.hpp
+++ b/inst/include/boost/icl/type_traits/is_container.hpp
@@ -1,0 +1,56 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_CONTAINER_HPP_JOFA_100828
+#define BOOST_ICL_TYPE_TRAITS_IS_CONTAINER_HPP_JOFA_100828
+
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/mpl/and.hpp> 
+#include <boost/mpl/not.hpp> 
+#include <boost/type_traits/is_same.hpp>
+#include <boost/icl/type_traits/element_type_of.hpp> 
+#include <boost/icl/type_traits/segment_type_of.hpp> 
+#include <boost/icl/type_traits/size_type_of.hpp> 
+#include <boost/icl/type_traits/is_map.hpp> 
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(iterator)
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(reference)
+    }
+
+    template <class Type>
+    struct is_container 
+      : mpl::bool_<
+            detail::has_value_type<Type>::value &&
+            detail::has_iterator<Type>::value &&
+            detail::has_size_type<Type>::value &&
+            detail::has_reference<Type>::value>
+    {};
+
+    template <class Type>
+    struct is_std_set
+    {
+        typedef is_std_set type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = (mpl::and_< is_container<Type> 
+                              , detail::has_key_type<Type>
+                              , boost::is_same< typename key_type_of<Type>::type
+                                              , typename value_type_of<Type>::type >
+                              , mpl::not_<detail::has_segment_type<Type> >
+                              >::value )
+        ); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_continuous.hpp
+++ b/inst/include/boost/icl/type_traits/is_continuous.hpp
@@ -1,0 +1,28 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_CONTINUOUS_HPP_JOFA_080910
+#define BOOST_ICL_TYPE_TRAITS_IS_CONTINUOUS_HPP_JOFA_080910
+
+#include <string>
+#include <boost/mpl/not.hpp>
+#include <boost/icl/type_traits/is_discrete.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_continuous
+    {
+        typedef is_continuous type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = mpl::not_<is_discrete<Type> >::value);
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_continuous_interval.hpp
+++ b/inst/include/boost/icl/type_traits/is_continuous_interval.hpp
@@ -1,0 +1,26 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_CONTINUOUS_INTERVAL_HPP_JOFA_100331
+#define BOOST_ICL_TYPE_TRAITS_IS_CONTINUOUS_INTERVAL_HPP_JOFA_100331
+
+#include <boost/icl/type_traits/is_interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+template <class Type> struct is_continuous_interval
+{ 
+    typedef is_continuous_interval<Type> type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_discrete.hpp
+++ b/inst/include/boost/icl/type_traits/is_discrete.hpp
@@ -1,0 +1,64 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_DISCRETE_HPP_JOFA_100410
+#define BOOST_ICL_TYPE_TRAITS_IS_DISCRETE_HPP_JOFA_100410
+
+#include <string>
+#include <boost/config.hpp> // For macro BOOST_STATIC_CONSTANT
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/not.hpp>
+
+#ifdef BOOST_MSVC 
+#pragma warning(push)
+#pragma warning(disable:4913) // user defined binary operator ',' exists but no overload could convert all operands, default built-in binary operator ',' used
+#endif                        
+
+#include <boost/detail/is_incrementable.hpp>
+
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/is_floating_point.hpp>
+#include <boost/icl/type_traits/rep_type_of.hpp>
+#include <boost/icl/type_traits/is_numeric.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_discrete
+    {
+        typedef is_discrete type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = 
+                (mpl::and_
+                 < 
+                     boost::detail::is_incrementable<Type>
+                   , mpl::or_
+                     < 
+                         mpl::and_
+                         <
+                             mpl::not_<has_rep_type<Type> >
+                           , is_non_floating_point<Type>
+                         >
+                       , mpl::and_
+                         <
+                             has_rep_type<Type>
+                           , is_discrete<typename rep_type_of<Type>::type>
+                         >
+                     >
+                 >::value
+                )
+            );
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_discrete_interval.hpp
+++ b/inst/include/boost/icl/type_traits/is_discrete_interval.hpp
@@ -1,0 +1,26 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_DISCRETE_INTERVAL_HPP_JOFA_100327
+#define BOOST_ICL_TYPE_TRAITS_IS_DISCRETE_INTERVAL_HPP_JOFA_100327
+
+#include <boost/icl/type_traits/is_interval.hpp>
+
+namespace boost{ namespace icl
+{
+
+template <class Type> struct is_discrete_interval
+{ 
+    typedef is_discrete_interval<Type> type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_element_container.hpp
+++ b/inst/include/boost/icl/type_traits/is_element_container.hpp
@@ -1,0 +1,53 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_ELEMENT_CONTAINER_HPP_JOFA_090830
+#define BOOST_ICL_TYPE_TRAITS_IS_ELEMENT_CONTAINER_HPP_JOFA_090830
+
+#include <boost/mpl/and.hpp> 
+#include <boost/mpl/or.hpp> 
+#include <boost/mpl/not.hpp> 
+#include <boost/icl/type_traits/is_container.hpp> 
+#include <boost/icl/type_traits/is_interval_container.hpp> 
+#include <boost/icl/type_traits/is_set.hpp> 
+
+namespace boost{ namespace icl
+{
+    template<class Type> 
+    struct is_element_map
+    {
+        typedef is_element_map<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = 
+            (mpl::and_<is_map<Type>, mpl::not_<is_interval_container<Type> > >::value)
+            );
+    };
+
+    template<class Type> 
+    struct is_element_set
+    {
+        typedef is_element_set<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = 
+            (mpl::or_< mpl::and_< is_set<Type>
+                                , mpl::not_<is_interval_container<Type> > > 
+                     , is_std_set<Type>
+                     >::value)
+            );
+    };
+
+    template <class Type> 
+    struct is_element_container
+    { 
+        typedef is_element_container<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = 
+            (mpl::or_<is_element_set<Type>, is_element_map<Type> >::value) 
+            );
+    };
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_icl_container.hpp
+++ b/inst/include/boost/icl/type_traits/is_icl_container.hpp
@@ -1,0 +1,33 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_ICL_CONTAINER_HPP_JOFA_100831
+#define BOOST_ICL_TYPE_TRAITS_IS_ICL_CONTAINER_HPP_JOFA_100831
+
+#include <boost/mpl/and.hpp> 
+#include <boost/mpl/or.hpp> 
+#include <boost/mpl/not.hpp> 
+#include <boost/icl/type_traits/is_element_container.hpp> 
+#include <boost/icl/type_traits/is_interval_container.hpp> 
+#include <boost/icl/type_traits/is_set.hpp> 
+
+namespace boost{ namespace icl
+{
+    template <class Type> 
+    struct is_icl_container
+    { 
+        typedef is_icl_container<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = 
+            (mpl::or_<  is_element_container<Type>
+                     , is_interval_container<Type> >::value));
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_increasing.hpp
+++ b/inst/include/boost/icl/type_traits/is_increasing.hpp
@@ -1,0 +1,34 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2011-2011: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_INCREASING_HPP_JOFA_110416
+#define BOOST_ICL_TYPE_TRAITS_IS_INCREASING_HPP_JOFA_110416
+
+#include <functional>
+
+namespace boost{ namespace icl
+{
+
+template <class DomainT, class Compare>
+struct is_increasing
+{
+    typedef is_increasing type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+template <class DomainT>
+struct is_increasing<DomainT, std::greater<DomainT> >
+{
+    typedef is_increasing type;
+    BOOST_STATIC_CONSTANT(bool, value = false);
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_interval.hpp
+++ b/inst/include/boost/icl/type_traits/is_interval.hpp
@@ -1,0 +1,171 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_HPP_JOFA_100327
+#define BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_HPP_JOFA_100327
+
+#include <boost/mpl/or.hpp>
+#include <boost/icl/interval_bounds.hpp>
+#include <boost/icl/interval_traits.hpp>
+
+namespace boost{ namespace icl
+{
+
+template <class Type>
+struct interval_bound_type
+{
+    typedef interval_bound_type type;
+    BOOST_STATIC_CONSTANT(bound_type, value = (interval_bounds::undefined)); 
+};
+
+template <class Type> struct is_interval
+{ 
+    typedef is_interval<Type> type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = ((interval_bound_type<Type>::value) < interval_bounds::undefined)); 
+};
+
+
+template <class Type> struct has_static_bounds
+{ 
+    typedef has_static_bounds<Type> type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = ((interval_bound_type<Type>::value) < interval_bounds::dynamic)); 
+};
+
+template <class Type> struct has_dynamic_bounds
+{ 
+    typedef has_dynamic_bounds<Type> type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (interval_bound_type<Type>::value == interval_bounds::dynamic));
+};
+
+template <class Type> struct has_asymmetric_bounds
+{ 
+    typedef has_asymmetric_bounds<Type> type;
+    BOOST_STATIC_CONSTANT(bound_type, bounds = (interval_bound_type<Type>::value)); 
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (   bounds == interval_bounds::static_left_open 
+                 || bounds == interval_bounds::static_right_open)); 
+};
+
+template <class Type> struct has_symmetric_bounds
+{ 
+    typedef has_symmetric_bounds<Type> type;
+    BOOST_STATIC_CONSTANT(bound_type, bounds = (interval_bound_type<Type>::value)); 
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (   bounds == interval_bounds::static_closed 
+                 || bounds == interval_bounds::static_open)); 
+};
+
+//------------------------------------------------------------------------------
+template <class Type> struct is_discrete_static
+{ 
+    typedef is_discrete_static type;
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (mpl::and_< has_static_bounds<Type>
+                          , is_discrete<domain_type> >::value) ); 
+};
+
+//------------------------------------------------------------------------------
+template <class Type> struct is_continuous_static
+{ 
+    typedef is_continuous_static type;
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (mpl::and_< has_static_bounds<Type>
+                          , is_continuous<domain_type>
+                          , has_asymmetric_bounds<Type> >::value) ); 
+};
+
+//------------------------------------------------------------------------------
+template <class Type> struct is_static_right_open
+{ 
+    typedef is_static_right_open<Type> type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (interval_bound_type<Type>::value == interval_bounds::static_right_open)); 
+};
+
+template <class Type> struct is_static_left_open
+{ 
+    typedef is_static_left_open<Type> type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (interval_bound_type<Type>::value == interval_bounds::static_left_open)); 
+};
+
+template <class Type> struct is_static_open
+{ 
+    typedef is_static_open<Type> type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (interval_bound_type<Type>::value == interval_bounds::static_open)); 
+};
+
+template <class Type> struct is_static_closed
+{ 
+    typedef is_static_closed<Type> type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (interval_bound_type<Type>::value == interval_bounds::static_closed)); 
+};
+
+template <class Type> struct is_discrete_static_closed
+{ 
+    typedef is_static_closed<Type> type;
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    
+    BOOST_STATIC_CONSTANT( bool, 
+        value = (mpl::and_< is_static_closed<Type>
+                          , is_discrete<domain_type> >::value) ); 
+};
+
+template <class Type> struct is_discrete_static_open
+{ 
+    typedef is_static_closed<Type> type;
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    
+    BOOST_STATIC_CONSTANT( bool, 
+        value = (mpl::and_< is_static_open<Type>
+                          , is_discrete<domain_type> >::value) ); 
+};
+
+//------------------------------------------------------------------------------
+template <class Type> struct is_continuous_right_open
+{ 
+    typedef is_continuous_right_open<Type> type;
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (mpl::and_<is_static_right_open<Type>, is_continuous<domain_type> >::value)); 
+};
+
+template <class Type> struct is_continuous_left_open
+{ 
+    typedef is_continuous_left_open<Type> type;
+    typedef typename interval_traits<Type>::domain_type domain_type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (mpl::and_<is_static_left_open<Type>, is_continuous<domain_type> >::value)); 
+};
+
+//------------------------------------------------------------------------------
+
+template <class Type> struct is_singelizable
+{
+    typedef is_singelizable type;
+    typedef typename interval_traits<Type>::domain_type domain_type;
+
+    BOOST_STATIC_CONSTANT(bool, 
+        value =
+            (mpl::or_< has_dynamic_bounds<Type>
+                     , is_discrete<domain_type> 
+                     >::value)
+    );
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_interval_container.hpp
+++ b/inst/include/boost/icl/type_traits/is_interval_container.hpp
@@ -1,0 +1,47 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_CONTAINER_HPP_JOFA_081004
+#define BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_CONTAINER_HPP_JOFA_081004
+
+#include <boost/mpl/and.hpp> 
+#include <boost/mpl/not.hpp> 
+#include <boost/icl/type_traits/is_map.hpp> 
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_interval_container
+    { 
+        typedef is_interval_container<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = false); 
+    };
+
+    template<class Type>
+    struct is_interval_map
+    {
+        typedef is_interval_map<Type> type; 
+        BOOST_STATIC_CONSTANT(bool, value =
+            (mpl::and_<is_interval_container<Type>, is_map<Type> >::value)
+            ); 
+    };
+
+    template<class Type>
+    struct is_interval_set
+    { 
+        typedef is_interval_set<Type> type; 
+        BOOST_STATIC_CONSTANT(bool, value =
+            (mpl::and_<          is_interval_container<Type>,
+                       mpl::not_<is_interval_map<Type> > >::value)
+            ); 
+    };
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_interval_joiner.hpp
+++ b/inst/include/boost/icl/type_traits/is_interval_joiner.hpp
@@ -1,0 +1,25 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_JOINER_HPP_JOFA_100901
+#define BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_JOINER_HPP_JOFA_100901
+
+#include <boost/config.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_interval_joiner
+    { 
+        typedef is_interval_joiner<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = false); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_interval_separator.hpp
+++ b/inst/include/boost/icl/type_traits/is_interval_separator.hpp
@@ -1,0 +1,25 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_SEPARATOR_HPP_JOFA_081004
+#define BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_SEPARATOR_HPP_JOFA_081004
+
+#include <boost/config.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_interval_separator
+    { 
+        typedef is_interval_separator<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = false); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_interval_splitter.hpp
+++ b/inst/include/boost/icl/type_traits/is_interval_splitter.hpp
@@ -1,0 +1,25 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_SPLITTER_HPP_JOFA_081004
+#define BOOST_ICL_TYPE_TRAITS_IS_INTERVAL_SPLITTER_HPP_JOFA_081004
+
+#include <boost/config.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_interval_splitter
+    { 
+        typedef is_interval_splitter<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = false); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_key_container_of.hpp
+++ b/inst/include/boost/icl/type_traits/is_key_container_of.hpp
@@ -1,0 +1,89 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_KEY_CONTAINER_OF_HPP_JOFA_100829
+#define BOOST_ICL_TYPE_TRAITS_IS_KEY_CONTAINER_OF_HPP_JOFA_100829
+
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/icl/type_traits/is_combinable.hpp>
+#include <boost/icl/type_traits/is_container.hpp>
+
+namespace boost{ namespace icl
+{
+    //--------------------------------------------------------------------------
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(key_object_type)
+    }
+
+    //--------------------------------------------------------------------------
+    template <class Type>
+    struct has_key_object_type 
+      : mpl::bool_<detail::has_key_object_type<Type>::value>
+    {};
+
+    template <class Type, bool HasKeyContainerType, bool IsSet> 
+    struct get_key_object_type;
+
+    template <class Type>
+    struct get_key_object_type<Type, false, false>
+    {
+        typedef Type no_type;
+    };
+
+    template <class Type>
+    struct get_key_object_type<Type, false, true>
+    {
+        typedef Type type;
+    };
+
+    template <class Type, bool IsSet>
+    struct get_key_object_type<Type, true, IsSet>
+    {
+        typedef typename Type::key_object_type type;
+    };
+
+    template <class Type>
+    struct key_container_type_of
+    {
+        typedef typename 
+            get_key_object_type
+            < Type
+            , has_key_object_type<Type>::value
+            , mpl::or_<is_set<Type>, is_map<Type> >::value
+            >::type type;
+    };
+
+    //--------------------------------------------------------------------------
+    template<class KeyT, class ObjectT>
+    struct is_strict_key_container_of // set is_strict_key_container_of map
+    {
+        typedef is_strict_key_container_of<KeyT, ObjectT> type;
+        BOOST_STATIC_CONSTANT(bool, value =
+            (mpl::and_< is_map<ObjectT>
+                      , boost::is_same<KeyT, typename key_container_type_of<ObjectT>::type> >::value)
+            );
+    };
+
+    template<class KeyT, class ObjectT>
+    struct is_key_container_of // set is_key_container_of (set or map)
+    {
+        typedef is_key_container_of<KeyT, ObjectT> type;
+        BOOST_STATIC_CONSTANT(bool, value =
+            (mpl::or_< is_strict_key_container_of<KeyT, ObjectT> 
+                     , mpl::and_< mpl::or_<is_set<ObjectT>, is_map<ObjectT> >
+                                , boost::is_same<ObjectT, KeyT> > >::value)
+            );
+    };
+
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_map.hpp
+++ b/inst/include/boost/icl/type_traits/is_map.hpp
@@ -1,0 +1,25 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_MAP_HPP_JOFA_081107
+#define BOOST_ICL_TYPE_TRAITS_IS_MAP_HPP_JOFA_081107
+
+#include <boost/config.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_map
+    {
+        typedef is_map<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = false); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_numeric.hpp
+++ b/inst/include/boost/icl/type_traits/is_numeric.hpp
@@ -1,0 +1,97 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_NUMERIC_HPP_JOFA_100322
+#define BOOST_ICL_TYPE_TRAITS_IS_NUMERIC_HPP_JOFA_100322
+
+#include <limits>
+#include <complex>
+#include <functional>
+#include <boost/type_traits/is_floating_point.hpp>
+#include <boost/type_traits/is_integral.hpp>
+
+namespace boost{ namespace icl
+{
+
+template <class Type> struct is_fixed_numeric
+{
+    typedef is_fixed_numeric type;
+    BOOST_STATIC_CONSTANT(bool, value = (0 < std::numeric_limits<Type>::digits));
+};
+
+template <class Type> struct is_std_numeric
+{
+    typedef is_std_numeric type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (std::numeric_limits<Type>::is_specialized));
+};
+
+template <class Type> struct is_std_integral
+{
+    typedef is_std_integral type;
+    BOOST_STATIC_CONSTANT(bool, 
+        value = (std::numeric_limits<Type>::is_integer));
+};
+
+template <class Type> struct is_numeric
+{
+    typedef is_numeric type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::or_< is_std_numeric<Type>
+                 , boost::is_integral<Type> 
+                 , is_std_integral<Type> >::value) );
+};
+
+template <class Type> 
+struct is_numeric<std::complex<Type> >
+{
+    typedef is_numeric type;
+    BOOST_STATIC_CONSTANT(bool, value = true);
+};
+
+//--------------------------------------------------------------------------
+template<class Type, class Compare, bool Enable = false>
+struct numeric_minimum
+{
+    static bool is_less_than(Type){ return true; }
+    static bool is_less_than_or(Type, bool){ return true; }
+};
+
+template<class Type> 
+struct numeric_minimum<Type, std::less<Type>, true>
+{
+    static bool is_less_than(Type value)
+    { return std::less<Type>()((std::numeric_limits<Type>::min)(), value); }
+
+    static bool is_less_than_or(Type value, bool cond)
+    { return cond || is_less_than(value); }
+};
+
+template<class Type> 
+struct numeric_minimum<Type, std::greater<Type>, true>
+{
+    static bool is_less_than(Type value)
+    { return std::greater<Type>()((std::numeric_limits<Type>::max)(), value); }
+
+    static bool is_less_than_or(Type value, bool cond)
+    { return cond || is_less_than(value); }
+};
+
+//--------------------------------------------------------------------------
+template<class Type> 
+struct is_non_floating_point
+{
+    typedef is_non_floating_point type;
+    BOOST_STATIC_CONSTANT(bool, value = 
+        (mpl::not_< is_floating_point<Type> >::value));
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_set.hpp
+++ b/inst/include/boost/icl/type_traits/is_set.hpp
@@ -1,0 +1,26 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_SET_HPP_JOFA_081004
+#define BOOST_ICL_TYPE_TRAITS_IS_SET_HPP_JOFA_081004
+
+#include <boost/config.hpp>
+#include <boost/icl/type_traits/is_container.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_set
+    { 
+        typedef is_set<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = is_std_set<Type>::value); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/is_total.hpp
+++ b/inst/include/boost/icl/type_traits/is_total.hpp
@@ -1,0 +1,23 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_IS_TOTAL_HPP_JOFA_081004
+#define BOOST_ICL_TYPE_TRAITS_IS_TOTAL_HPP_JOFA_081004
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct is_total
+    { 
+        typedef is_total<Type> type;
+        BOOST_STATIC_CONSTANT(bool, value = false); 
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/no_type.hpp
+++ b/inst/include/boost/icl/type_traits/no_type.hpp
@@ -1,0 +1,19 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_NO_TYPE_HPP_JOFA_100902
+#define BOOST_ICL_TYPE_TRAITS_NO_TYPE_HPP_JOFA_100902
+
+namespace boost{ namespace icl
+{
+    struct no_type{};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/predicate.hpp
+++ b/inst/include/boost/icl/type_traits/predicate.hpp
@@ -1,0 +1,44 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2010-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_PREDICATE_HPP_JOFA_101102
+#define BOOST_ICL_TYPE_TRAITS_PREDICATE_HPP_JOFA_101102
+
+#include <functional>
+
+namespace boost{namespace icl
+{
+    // naming convention
+    // predicate: n-ary predicate
+    // property:  unary predicate
+    // relation:  binary predicate
+
+    // Unary predicates
+
+    template <class Type>
+    class property : public std::unary_function<Type,bool>{};
+
+    template <class Type>
+    class member_property : public property<Type>
+    {
+    public:
+        member_property( bool(Type::* pred)()const ): property<Type>(), m_pred(pred){}
+        bool operator()(const Type& x)const { return (x.*m_pred)(); }
+    private:
+        bool(Type::* m_pred)()const;
+    } ;
+
+    // Binary predicates: relations
+
+    template <class LeftT, class RightT>
+    class relation : public std::binary_function<LeftT,RightT,bool>{};
+
+
+}} // namespace icl boost
+
+#endif
+

--- a/inst/include/boost/icl/type_traits/rep_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/rep_type_of.hpp
@@ -1,0 +1,70 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_REP_TYPE_OF_HPP_JOFA_110329
+#define BOOST_ICL_TYPE_TRAITS_REP_TYPE_OF_HPP_JOFA_110329
+
+#include <boost/config.hpp> // For macro BOOST_STATIC_CONSTANT
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/or.hpp>
+#include <boost/mpl/and.hpp>
+#include <boost/mpl/not.hpp>
+#include <boost/icl/type_traits/no_type.hpp>
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(rep)
+    }
+
+    //--------------------------------------------------------------------------
+    template <class Type>
+    struct has_rep_type 
+      : mpl::bool_<detail::has_rep<Type>::value>
+    {};
+
+    template <class Rep, class Type>
+    struct represents // Rep represents Type;  Type is_wrapper_of Rep
+      : mpl::bool_<detail::has_rep<Type>::value>
+    {
+        typedef represents type;
+        BOOST_STATIC_CONSTANT(bool, 
+            value = (mpl::and_< has_rep_type<Type>
+                              , is_same<typename Type::rep, Rep> >::value)
+            );
+    };
+
+    //--------------------------------------------------------------------------
+    template <class Type, bool has_rep> 
+    struct get_rep_type;
+
+    template <class Type>
+    struct get_rep_type<Type, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_rep_type<Type, true>
+    {
+        typedef typename Type::rep type;
+    };
+
+    //--------------------------------------------------------------------------
+    template<class Type> 
+    struct rep_type_of
+    { 
+        typedef typename 
+            get_rep_type<Type, has_rep_type<Type>::value>::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/segment_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/segment_type_of.hpp
@@ -1,0 +1,53 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_SEGMENT_TYPE_OF_HPP_JOFA_100902
+#define BOOST_ICL_TYPE_TRAITS_SEGMENT_TYPE_OF_HPP_JOFA_100902
+
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/mpl/bool.hpp>
+#include <boost/icl/type_traits/no_type.hpp>
+
+namespace boost{ namespace icl
+{
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(segment_type)
+    }
+
+    template <class Type>
+    struct has_segment_type 
+      : mpl::bool_<detail::has_segment_type<Type>::value>
+    {};
+
+    template <class Type, bool has_segment_type> 
+    struct get_segment_type;
+
+    template <class Type>
+    struct get_segment_type<Type, false>
+    {
+        typedef no_type type;
+    };
+
+    template <class Type>
+    struct get_segment_type<Type, true>
+    {
+        typedef typename Type::segment_type type;
+    };
+
+    template <class Type>
+    struct segment_type_of
+    {
+        typedef typename 
+            get_segment_type<Type, has_segment_type<Type>::value>::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/size.hpp
+++ b/inst/include/boost/icl/type_traits/size.hpp
@@ -1,0 +1,18 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_SIZE_HPP_JOFA_080911
+#define BOOST_ICL_TYPE_TRAITS_SIZE_HPP_JOFA_080911
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct size{ typedef std::size_t type; };
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/size_type_of.hpp
+++ b/inst/include/boost/icl/type_traits/size_type_of.hpp
@@ -1,0 +1,72 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_SIZE_TYPE_OF_HPP_JOFA_080911
+#define BOOST_ICL_TYPE_TRAITS_SIZE_TYPE_OF_HPP_JOFA_080911
+
+#include <boost/mpl/has_xxx.hpp>
+#include <boost/icl/type_traits/difference_type_of.hpp>
+
+namespace boost{ namespace icl
+{
+
+    namespace detail
+    {
+        BOOST_MPL_HAS_XXX_TRAIT_DEF(size_type)
+    }
+
+    //--------------------------------------------------------------------------
+    template <class Type>
+    struct has_size_type 
+      : mpl::bool_<detail::has_size_type<Type>::value>
+    {};
+
+    //--------------------------------------------------------------------------
+    template <class Type, bool has_size, bool has_diff, bool has_rep> 
+    struct get_size_type;
+
+    template <class Type> 
+    struct get_size_type<Type, false, false, false>
+    { 
+        typedef std::size_t type; 
+    };
+
+    template <class Type, bool has_diff, bool has_rep> 
+    struct get_size_type<Type, true, has_diff, has_rep>
+    { 
+        typedef typename Type::size_type type; 
+    };
+
+    template <class Type, bool has_rep> 
+    struct get_size_type<Type, false, true, has_rep>
+    { 
+        typedef typename Type::difference_type type; 
+    };
+
+    template <class Type> 
+    struct get_size_type<Type, false, false, true>
+    { 
+        typedef Type type; 
+    };
+
+    //--------------------------------------------------------------------------
+    template<class Type> 
+    struct size_type_of
+    { 
+        typedef typename 
+            get_size_type< Type
+                         , has_size_type<Type>::value
+                         , has_difference_type<Type>::value
+                         , has_rep_type<Type>::value  
+                         >::type type;
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/succ_pred.hpp
+++ b/inst/include/boost/icl/type_traits/succ_pred.hpp
@@ -1,0 +1,83 @@
+/*-----------------------------------------------------------------------------+    
+Copyright (c) 2008-2011: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_SUCC_PRED_HPP_JOFA_080913
+#define BOOST_ICL_TYPE_TRAITS_SUCC_PRED_HPP_JOFA_080913
+
+#include <boost/icl/type_traits/is_increasing.hpp>
+
+namespace boost{ namespace icl
+{
+template <class IncrementableT>
+inline static IncrementableT succ(IncrementableT x) { return ++x; }
+
+template <class DecrementableT>
+inline static DecrementableT pred(DecrementableT x) { return --x; }
+
+namespace detail
+{
+    template <class DomainT, bool increasing = true>
+    struct successor;
+
+    template <class DomainT>
+    struct successor<DomainT, true>
+    {
+        typedef successor type;
+        inline static DomainT apply(DomainT value){ return ++value; }
+    };
+
+    template <class DomainT>
+    struct successor<DomainT, false>
+    {
+        typedef successor type;
+        inline static DomainT apply(DomainT value){ return --value; }
+    };
+
+    template <class DomainT, bool increasing = true>
+    struct predecessor;
+
+    template <class DomainT>
+    struct predecessor<DomainT, true>
+    {
+        typedef predecessor type;
+        inline static DomainT apply(DomainT value){ return --value; }
+    };
+
+    template <class DomainT>
+    struct predecessor<DomainT, false>
+    {
+        typedef predecessor type;
+        inline static DomainT apply(DomainT value){ return ++value; }
+    };
+} // namespace detail
+
+//------------------------------------------------------------------------------
+template <class DomainT, class Compare>
+struct successor
+{
+    inline static DomainT apply(DomainT value)
+    {
+        return detail::successor
+            <DomainT, is_increasing<DomainT,Compare>::value>::apply(value);
+    }
+};
+
+template <class DomainT, class Compare>
+struct predecessor
+{
+    inline static DomainT apply(DomainT value)
+    {
+        return detail::predecessor
+            <DomainT, is_increasing<DomainT,Compare>::value>::apply(value);
+    }
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/to_string.hpp
+++ b/inst/include/boost/icl/type_traits/to_string.hpp
@@ -1,0 +1,43 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+
+/*-----------------------------------------------------------------------------
+Function-templates for discrete Datatypes like int, unsigned or
+    any class that provides a ++ operator c.f. iterators
+-----------------------------------------------------------------------------*/
+
+#ifndef BOOST_ICL_TO_STRING_HPP_JOFA_000712
+#define BOOST_ICL_TO_STRING_HPP_JOFA_000712
+
+#include <stdio.h>
+#include <string>
+#include <sstream>
+
+namespace boost{ namespace icl
+{    
+
+/// Static class template for the string representation of values
+template <class Type>
+struct to_string
+{
+    /** Converts all values of types to std::string that implement an operator << */
+    static std::string apply(const Type& value)
+    {
+        std::stringstream repr;
+        repr << value;
+        return repr.str();
+    }
+};
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/type_to_string.hpp
+++ b/inst/include/boost/icl/type_traits/type_to_string.hpp
@@ -1,0 +1,85 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2007-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TO_STRING_HPP_JOFA_080416
+#define BOOST_ICL_TYPE_TO_STRING_HPP_JOFA_080416
+
+#include <stdio.h>
+#include <string>
+#include <sstream>
+
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/is_float.hpp>
+#include <boost/mpl/if.hpp>
+
+namespace boost{ namespace icl
+{
+    //--------------------------------------------------------------------------
+    template<class Type>
+    struct type_to_string
+    {
+        /** Convert the type to it's typestring */
+        static std::string apply();
+    };
+
+
+    //--------------------------------------------------------------------------
+    template<>inline std::string type_to_string<bool>::apply() { return "bool"; }
+    template<>inline std::string type_to_string<char>::apply() { return "char"; }
+    template<>inline std::string type_to_string<short>::apply(){ return "short"; }
+    template<>inline std::string type_to_string<int>::apply()  { return "int"; }
+    template<>inline std::string type_to_string<long>::apply() { return "long"; }
+    template<>inline std::string type_to_string<long long>::apply(){ return "Long"; }
+
+    template<>inline std::string type_to_string<unsigned char>::apply(){ return "char+"; }
+    template<>inline std::string type_to_string<unsigned short>::apply(){ return "short+"; }
+    template<>inline std::string type_to_string<unsigned int>::apply()  { return "int+"; }
+    template<>inline std::string type_to_string<unsigned long>::apply() { return "long+"; }
+    template<>inline std::string type_to_string<unsigned long long>::apply(){ return "Long+"; }
+
+    template<>inline std::string type_to_string<float>::apply() { return "flt"; }
+    template<>inline std::string type_to_string<double>::apply() { return "dbl"; }
+    template<>inline std::string type_to_string<std::string>::apply() { return "string"; }
+
+    //-------------------------------------------------------------------------
+    template<template<class> class Templ>
+    struct unary_template_to_string
+    {
+        static std::string apply();
+    };
+
+    template <template<class>class Unary, class Type>
+    struct type_to_string<Unary<Type> >
+    {
+        static std::string to_string()
+        { 
+            return unary_template_to_string<Unary>::apply()+"<"+type_to_string<Type>::apply()+">"; 
+        }
+    };
+
+    // ---------------------------------------------------------------------------
+    template<template<class,class>class Templ>
+    struct binary_template_to_string
+    {
+        static std::string apply();
+    };
+
+    template <template<class Type1, class Type2>class Binary, class Type1, class Type2>
+    struct type_to_string<Binary<Type1, Type2> >
+    {
+        static std::string apply()
+        { 
+            return binary_template_to_string<Binary>::apply()+
+                "<"+type_to_string<Type1>::apply()+","+type_to_string<Type2>::apply()+">"; 
+        }
+    };
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/unit_element.hpp
+++ b/inst/include/boost/icl/type_traits/unit_element.hpp
@@ -1,0 +1,38 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2010: Joachim Faulhaber
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_TYPE_TRAITS_UNIT_ELEMENT_HPP_JOFA_080912
+#define BOOST_ICL_TYPE_TRAITS_UNIT_ELEMENT_HPP_JOFA_080912
+
+#include <string>
+#include <boost/icl/type_traits/identity_element.hpp>
+#include <boost/icl/type_traits/succ_pred.hpp>
+
+namespace boost{ namespace icl
+{
+    template <class Type> struct unit_element{ static Type value(); };
+
+    template<> inline bool   unit_element<bool>::value()   { return true;}
+    template<> inline float  unit_element<float>::value()  { return 1.0; }
+    template<> inline double unit_element<double>::value() { return 1.0; }
+    template<> inline long double unit_element<long double>::value() 
+                                                           { return 1.0; }
+    
+    // Smallest 'visible' string that is greater than the empty string.
+    template <>    
+    inline std::string unit_element<std::string>::value()
+    { return std::string(" "); }
+
+    template <class Type> 
+    inline Type unit_element<Type>::value()
+    { return icl::succ(identity_element<Type>::value()); }
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/icl/type_traits/value_size.hpp
+++ b/inst/include/boost/icl/type_traits/value_size.hpp
@@ -1,0 +1,52 @@
+/*-----------------------------------------------------------------------------+
+Copyright (c) 2008-2009: Joachim Faulhaber
++------------------------------------------------------------------------------+
+Copyright (c) 1999-2006: Cortex Software GmbH, Kantstrasse 57, Berlin
++------------------------------------------------------------------------------+
+   Distributed under the Boost Software License, Version 1.0.
+      (See accompanying file LICENCE.txt or copy at
+           http://www.boost.org/LICENSE_1_0.txt)
++-----------------------------------------------------------------------------*/
+#ifndef BOOST_ICL_VALUE_SIZE_HPP_JOFA_081004
+#define BOOST_ICL_VALUE_SIZE_HPP_JOFA_081004
+
+namespace boost{ namespace icl
+{    
+
+template <typename Type>
+Type abs(Type val) { return val < 0 ? -val : val; }
+
+/// static class template for the size of a type's value
+/** This function is needed to be able to order values according
+    to their size. This is used to e.g. prefer simple test
+    instances and to express this simplicity independent of the
+    type of the test case.
+
+    @author  Joachim Faulhaber
+*/
+template <class Type>
+struct value_size
+{
+    /** The size of a value is used to be able to order values according to
+        their simplicity */
+    static std::size_t apply(const Type& val);
+};
+
+
+template<> inline std::size_t value_size<int>::apply(const int& value) 
+{ return abs(value); }
+
+template<> inline std::size_t value_size<double>::apply(const double& value) 
+{ return static_cast<int>(abs(value)); }
+
+template <typename Type> 
+inline std::size_t value_size<Type>::apply(const Type& value)
+{ return icl::iterative_size(value); }
+
+
+
+}} // namespace boost icl
+
+#endif
+
+

--- a/inst/include/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp
+++ b/inst/include/boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp
@@ -1,0 +1,48 @@
+/*
+ [auto_generated]
+ boost/numeric/odeint/stepper/generation/generation_runge_kutta_cash_karp54_classic.hpp
+
+ [begin_description]
+ Enable the factory functions for the controller and the dense output of the
+ Runge-Kutta-Cash-Karp 54 method with the classical implementation.
+ [end_description]
+
+ Copyright 2011 Karsten Ahnert
+ Copyright 2011 Mario Mulansky
+
+ Distributed under the Boost Software License, Version 1.0.
+ (See accompanying file LICENSE_1_0.txt or
+ copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+
+#ifndef BOOST_NUMERIC_ODEINT_STEPPER_GENERATION_GENERATION_RUNGE_KUTTA_CASH_KARP54_CLASSIC_HPP_INCLUDED
+#define BOOST_NUMERIC_ODEINT_STEPPER_GENERATION_GENERATION_RUNGE_KUTTA_CASH_KARP54_CLASSIC_HPP_INCLUDED
+
+#include <boost/numeric/odeint/stepper/controlled_runge_kutta.hpp>
+#include <boost/numeric/odeint/stepper/runge_kutta_cash_karp54_classic.hpp>
+#include <boost/numeric/odeint/stepper/generation/make_controlled.hpp>
+
+
+namespace boost {
+namespace numeric {
+namespace odeint {
+
+
+// Specializations for runge_kutta_cash_karp54
+template< class State , class Value , class Deriv , class Time , class Algebra , class Operations , class Resize >
+struct get_controller< runge_kutta_cash_karp54_classic< State , Value , Deriv , Time , Algebra , Operations , Resize > >
+{
+    typedef runge_kutta_cash_karp54_classic< State , Value , Deriv , Time , Algebra , Operations , Resize > stepper_type;
+    typedef controlled_runge_kutta< stepper_type > type;
+};
+
+
+
+
+} // odeint
+} // numeric
+} // boost
+
+
+#endif // BOOST_NUMERIC_ODEINT_STEPPER_GENERATION_GENERATION_RUNGE_KUTTA_CASH_KARP54_CLASSIC_HPP_INCLUDED

--- a/local/scripts/CreateBoost.sh
+++ b/local/scripts/CreateBoost.sh
@@ -13,7 +13,7 @@ pkgdir="${HOME}/git/bh"
 boosttargz="boost_1_60_0.tar.gz"
 ## -- current package version and date (and other metadata as needed)
 version="1.60.0-0"
-date="2016-2-20"
+date="2016-5-4"
 
 
 
@@ -121,7 +121,7 @@ bcp --boost=${boostroot}  ${boostlibs}  ${pkgincl}   > /dev/null  2>&1
 # Plus phoenix (cf [github] issue ticket #19)
 boostextras="filesystem spirit foreach algorithm iostreams \
             dynamic_bitset heap any circular_buffer geometry fusion graph \
-            multiprcecision phoenix bimap"
+            multiprcecision phoenix bimap icl"
 
 bcp --boost=${boostroot}  ${boostextras}   ${pkgincl}   > /dev/null   2>&1
 


### PR DESCRIPTION
This PR incorporates boost headers for the ICL (Interval Container Library).

I used the `CreateBoost.sh` script to incorporate the new headers, and below is a diff of that script.

```diff
index cd682d0..f4f2252 100755
--- a/local/scripts/CreateBoost.sh
+++ b/local/scripts/CreateBoost.sh
@@ -13,7 +13,7 @@ pkgdir="${HOME}/git/bh"
 boosttargz="boost_1_60_0.tar.gz"
 ## -- current package version and date (and other metadata as needed)
 version="1.60.0-0"
-date="2016-2-20"
+date="2016-5-4"
 
 
 
@@ -121,7 +121,7 @@ bcp --boost=${boostroot}  ${boostlibs}  ${pkgincl}   > /dev/null  2>&1
 # Plus phoenix (cf [github] issue ticket #19)
 boostextras="filesystem spirit foreach algorithm iostreams \
             dynamic_bitset heap any circular_buffer geometry fusion graph \
-            multiprcecision phoenix bimap"
+            multiprcecision phoenix bimap icl"
 
 bcp --boost=${boostroot}  ${boostextras}   ${pkgincl}   > /dev/null   2>&1
```

For reference, this is a "middleweight" addition to the package:

```bash
$ du -h /usr/local/include/boost/icl/
232K	/usr/local/include/boost/icl/concept
144K	/usr/local/include/boost/icl/detail
16K	/usr/local/include/boost/icl/predicates
208K	/usr/local/include/boost/icl/type_traits
892K	/usr/local/include/boost/icl/
```