### PR TITLE
travis: verify travis-tool.sh before executing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - _R_CHECK_FORCE_SUGGESTS_=FALSE
 
 before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
+  - curl -OL https://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
   - chmod 755 ./travis-tool.sh
   - ./travis-tool.sh bootstrap
 


### PR DESCRIPTION
Currently, grabbing the travis-tool.sh via http could be subject
to http man-in-the-middle attacks.

Switch to grabbing travis-tool.sh via git over https.

Signed-off-by: William Roberts <william.c.roberts@intel.com>