### PR TITLE
fix typo in cardinal_cubic_b_spline

### DIFF
--- a/inst/include/boost/math/interpolators/cardinal_cubic_b_spline.hpp
+++ b/inst/include/boost/math/interpolators/cardinal_cubic_b_spline.hpp
@@ -20,7 +20,7 @@
 // - All cubic polynomials interpolated exactly
 
 #ifndef BOOST_MATH_INTERPOLATORS_CARDINAL_CUBIC_B_SPLINE_HPP
-#define BOOST_MATH_INTERPOLATORS_CARINDAL_CUBIC_B_SPLINE_HPP
+#define BOOST_MATH_INTERPOLATORS_CARDINAL_CUBIC_B_SPLINE_HPP
 
 #include <boost/math/interpolators/detail/cardinal_cubic_b_spline_detail.hpp>
 


### PR DESCRIPTION
As per [this commit](https://github.com/boostorg/math/commit/5393a606f352b2d047a1561667dd8d9296c95f01) in boost / math, there was a typo in the Cardinal Cubic B Spline header guard.
