### PR TITLE
spinlock_gcc_atomic.hpp: fix for macOS ppc32 (backport from upstream)

### DIFF
--- a/inst/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp
+++ b/inst/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp
@@ -30,7 +30,16 @@ class spinlock
 {
 public:
 
-    unsigned char v_;
+    // `bool` alignment is required for Apple PPC32
+    // https://github.com/boostorg/smart_ptr/issues/105
+    // https://github.com/PurpleI2P/i2pd/issues/1726
+    // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107590
+
+    union
+    {
+        unsigned char v_;
+        bool align_;
+    };
 
 public:
 
@@ -80,6 +89,6 @@ public:
 } // namespace detail
 } // namespace boost
 
-#define BOOST_DETAIL_SPINLOCK_INIT {0}
+#define BOOST_DETAIL_SPINLOCK_INIT {{0}}
 
 #endif // #ifndef BOOST_SMART_PTR_DETAIL_SPINLOCK_GCC_ATOMIC_HPP_INCLUDED


### PR DESCRIPTION
This is a backport of the fix from Boost upstream: https://github.com/boostorg/smart_ptr/commit/97c9204a952f60d13def0e321c0a92ec6dec148b
See also: https://github.com/boostorg/smart_ptr/issues/105